### PR TITLE
Fix boot loader conflict causing redis-immich failures

### DIFF
--- a/modules/hardware/boot.nix
+++ b/modules/hardware/boot.nix
@@ -6,29 +6,16 @@ let
 in
 {
   options.modules.hardware.boot = {
-    enable = mkEnableOption "Bootloader configuration (systemd-boot with GRUB theming)";
+    enable = mkEnableOption "Bootloader configuration (systemd-boot)";
     
     configurationLimit = mkOption {
       type = types.int;
       default = 50;
       description = "Number of boot generations to keep";
     };
-    
-    enableGrubTheme = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable GRUB theme (Breeze)";
-    };
-    
-    backgroundColor = mkOption {
-      type = types.str;
-      default = "#8275b4";
-      description = "GRUB background color";
-    };
   };
 
   config = mkIf cfg.enable {
-    # Bootloader configuration
     boot.loader = {
       systemd-boot = {
         enable = true;
@@ -36,14 +23,6 @@ in
       };
       
       efi.canTouchEfiVariables = true;
-      
-      grub = {
-        efiSupport = true;
-        splashMode = "normal";
-        backgroundColor = cfg.backgroundColor;
-        theme = mkIf cfg.enableGrubTheme "${pkgs.libsForQt5.breeze-grub}/grub/themes/breeze";
-        extraEntriesBeforeNixOS = true;
-      };
     };
   };
 }


### PR DESCRIPTION
## Summary
Fixes #2 

Removes conflicting GRUB configuration from the boot module that was preventing systemd-boot from properly managing boot entries.

## Problem
The system was booting from an old EFI partition (nvme0n1p1, generation 144) instead of the current one (nvme1n1p2, generations 244+). This caused `redis-immich.service` to fail consistently after reboots due to version mismatches between the booted system and the rebuilt configuration.

The root cause was that `modules/hardware/boot.nix` had both systemd-boot AND GRUB configurations enabled simultaneously, which is not supported in NixOS.

## Solution
- Removed all GRUB-related configuration options and settings
- Kept only systemd-boot configuration for UEFI systems
- Reinstalled systemd-boot to the correct EFI partition
- Updated EFI boot entries to point to the current partition

## Changes
- Updated `modules/hardware/boot.nix`:
  - Removed `enableGrubTheme` option
  - Removed `backgroundColor` option  
  - Removed entire `boot.loader.grub` configuration block
  - Simplified to systemd-boot only

## Testing
- ✅ Successfully rebuilt system (generation 295)
- ✅ 50 boot entries properly created on correct partition
- ✅ System rebooted and booted from correct partition
- ✅ redis-immich.service running without errors
- ✅ No more UUID mismatch warnings from bootctl