### PR TITLE
Fix CI failure when commit messages contain quotes

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -34,7 +34,24 @@ jobs:
       id: get-commit
       if: always()
       run: |
-        COMMIT_MSG="${{ github.event.head_commit.message || github.event.commits[0].message || 'Manual trigger' }}"
+        # Get commit message from GitHub event JSON to safely handle quotes and special characters
+        # Read from GITHUB_EVENT_PATH to avoid shell interpolation issues with quotes
+        # For workflow_run events, try to get commit from workflow_run.head_commit
+        if [ "${{ github.event_name }}" = "workflow_run" ]; then
+          # Try to get commit message from workflow_run event structure
+          COMMIT_MSG=$(jq -r '.workflow_run.head_commit.message // "Deployment triggered by workflow run" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Deployment triggered by workflow run")
+        else
+          # For push and other events, get from standard location
+          COMMIT_MSG=$(jq -r '.head_commit.message // .commits[0].message // "Manual trigger" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Manual trigger")
+        fi
+        # If message is empty or null, use fallback
+        if [ -z "$COMMIT_MSG" ] || [ "$COMMIT_MSG" = "null" ]; then
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            COMMIT_MSG="Deployment triggered by workflow run"
+          else
+            COMMIT_MSG="Manual trigger"
+          fi
+        fi
         TRUNCATED_MSG=$(echo "$COMMIT_MSG" | head -n 2 | tr '\n' ' ')
         echo "commit_message<<EOF" >> $GITHUB_OUTPUT
         echo "$TRUNCATED_MSG" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -26,7 +26,13 @@ jobs:
       id: notify-start
       if: always()
       run: |
-        COMMIT_MSG="${{ github.event.head_commit.message || github.event.commits[0].message || 'Manual trigger' }}"
+        # Get commit message from GitHub event JSON to safely handle quotes and special characters
+        # Read from GITHUB_EVENT_PATH to avoid shell interpolation issues with quotes
+        COMMIT_MSG=$(jq -r '.head_commit.message // .commits[0].message // "Manual trigger" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Manual trigger")
+        # If message is empty or null, use fallback
+        if [ -z "$COMMIT_MSG" ] || [ "$COMMIT_MSG" = "null" ]; then
+          COMMIT_MSG="Manual trigger"
+        fi
         TRUNCATED_MSG=$(echo "$COMMIT_MSG" | head -n 2 | tr '\n' ' ')
         echo "commit_message<<EOF" >> $GITHUB_OUTPUT
         echo "$TRUNCATED_MSG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes issue #17 by properly handling commit messages that contain quotes and other special characters.

## Changes
- Use `GITHUB_EVENT_PATH` and `jq` to safely read commit messages from the GitHub event JSON
- Avoids shell interpolation issues that caused CI failures when commit messages contained quotes
- Handles different event types (push, workflow_run) appropriately
- Includes proper fallbacks for missing or null commit messages

## Testing
This fix ensures that commit messages with quotes, newlines, and other special characters are properly handled without breaking the CI pipeline.

Fixes #17