### PR TITLE
Fix: Resolve YAML syntax error in nix-flake-update.yml

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -170,9 +170,11 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git checkout -b "$BRANCH_NAME"
         git add flake.lock
-        git commit -m "chore: update flake inputs
+        git commit -F - <<EOF
+chore: update flake inputs
 
-Automated flake update by GitHub Actions"
+Automated flake update by GitHub Actions
+EOF
         
         # Push and verify success
         if ! git push origin "$BRANCH_NAME"; then


### PR DESCRIPTION
The YAML syntax error on line 175 was caused by a multi-line string within double quotes in the git commit message. This has been resolved by using a heredoc for the commit message, which is more robust for multi-line strings in YAML run blocks.