### PR TITLE
chore: clean up old flake update branches

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -48,7 +48,7 @@ jobs:
   close-old-prs:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
### Motivation
- Superseded automated flake-update PRs were being closed but their remote branches remained, leaving stale branches that should be removed by the cleanup step.

### Description
- Updated `.github/workflows/nix-flake-update.yml` so `gh pr list` returns both the PR number and `headRefName`, then the workflow closes each matching PR and deletes the remote branch using `gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" || true`.

### Testing
- No automated tests were run for this change because it only modifies the GitHub Actions workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970270a0c78832fafae5c333db1711e)