### PR TITLE
Add `codex` to common system packages

### DIFF
--- a/common/system.nix
+++ b/common/system.nix
@@ -66,6 +66,7 @@
     # AI tools
     gemini-cli
     claude-code
+    codex
 
     # Note: Linux-only utilities (pciutils, usbutils) are in profiles/server.nix
   ];
@@ -82,4 +83,3 @@
   # Note: programs.git is NixOS-only and is configured in common/linux.nix
   # Note: security.sudo is NixOS-only and is configured in common/linux.nix
 }
-


### PR DESCRIPTION
### Motivation
- Make the `codex` package available on all machines using the shared configuration by adding it to the global `environment.systemPackages`.

### Description
- Added `codex` to the `environment.systemPackages` list in `common/system.nix`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970277e60b4832fba002ae4038d65b6)