### PR TITLE
feat: add PR build matrix to test workflow

### DIFF
--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -124,20 +124,28 @@ jobs:
           }' || echo "Reaction failed, continuing..."
 
   # Test all NixOS configurations
-  test-configurations:
+  prepare-hosts:
     runs-on: ubuntu-latest
     needs: check-flake-syntax
+    outputs:
+      hosts: ${{ steps.set-hosts.outputs.hosts }}
+
+    steps:
+    - name: Define test hosts
+      id: set-hosts
+      run: |
+        # Define all available NixOS hosts
+        ALL_HOSTS='["david", "pits"]'  # tristons-desk excluded from testing
+        echo "hosts=$ALL_HOSTS" >> $GITHUB_OUTPUT
+
+  test-configurations:
+    runs-on: ubuntu-latest
+    needs: [check-flake-syntax, prepare-hosts]
     outputs:
       parent_event_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
     strategy:
       matrix:
-        host: 
-          - name: david
-            hostname: david
-          - name: pits
-            hostname: pits
-          # - name: tristons-desk
-            # hostname: tristons-desk
+        host: ${{ fromJson(needs.prepare-hosts.outputs.hosts) }}
       fail-fast: false  # Continue testing other hosts even if one fails
     
     steps:
@@ -151,7 +159,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          🔵 Testing ${{ matrix.host.name }}
+          🔵 Testing ${{ matrix.host }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -167,11 +175,11 @@ jobs:
     - name: Wait for Tailscale connection
       run: sleep 10
       
-    - name: Test ${{ matrix.host.name }} Configuration
+    - name: Test ${{ matrix.host }} Configuration
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host.hostname }}"
-        echo "Testing configuration for ${{ matrix.host.name }} on $SERVER_HOSTNAME"
+        SERVER_HOSTNAME="${{ matrix.host }}"
+        echo "Testing configuration for ${{ matrix.host }} on $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification
         mkdir -p ~/.ssh
@@ -190,34 +198,34 @@ jobs:
           --exclude='.github' \
           --exclude='*.save' \
           --exclude='nextcloud/admin-pass' \
-          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-test-${{ matrix.host.name }}/
+          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-test-${{ matrix.host }}/
         
         # Test configuration on server
         ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME << EOF
           set -e
           
           # Navigate to test directory
-          cd /tmp/nixos-config-test-${{ matrix.host.name }}
+          cd /tmp/nixos-config-test-${{ matrix.host }}
           
           # Test the NixOS configuration using flake
-          echo "Testing NixOS configuration for ${{ matrix.host.name }}..."
-          if sudo nixos-rebuild dry-run --flake .#${{ matrix.host.name }}; then
-            echo "✅ Configuration test passed for ${{ matrix.host.name }}!"
-            echo "SUCCESS" > /tmp/nixos-test-result-${{ matrix.host.name }}.txt
+          echo "Testing NixOS configuration for ${{ matrix.host }}..."
+          if sudo nixos-rebuild dry-run --flake .#${{ matrix.host }}; then
+            echo "✅ Configuration test passed for ${{ matrix.host }}!"
+            echo "SUCCESS" > /tmp/nixos-test-result-${{ matrix.host }}.txt
           else
-            echo "❌ Configuration test failed for ${{ matrix.host.name }}!"
-            echo "FAILED" > /tmp/nixos-test-result-${{ matrix.host.name }}.txt
+            echo "❌ Configuration test failed for ${{ matrix.host }}!"
+            echo "FAILED" > /tmp/nixos-test-result-${{ matrix.host }}.txt
             exit 1
           fi
         EOF
         
         # Get test result
-        TEST_RESULT=$(ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME "cat /tmp/nixos-test-result-${{ matrix.host.name }}.txt")
+        TEST_RESULT=$(ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME "cat /tmp/nixos-test-result-${{ matrix.host }}.txt")
         
         if [ "$TEST_RESULT" = "SUCCESS" ]; then
-          echo "✅ NixOS configuration test passed for ${{ matrix.host.name }}!"
+          echo "✅ NixOS configuration test passed for ${{ matrix.host }}!"
         else
-          echo "❌ NixOS configuration test failed for ${{ matrix.host.name }}!"
+          echo "❌ NixOS configuration test failed for ${{ matrix.host }}!"
           exit 1
         fi
         
@@ -225,9 +233,9 @@ jobs:
       if: always()
       run: |
         if [ "${{ job.status }}" = "success" ]; then
-          echo "✅ ${{ matrix.host.name }} configuration test passed"
+          echo "✅ ${{ matrix.host }} configuration test passed"
         else
-          echo "❌ ${{ matrix.host.name }} configuration test failed"
+          echo "❌ ${{ matrix.host }} configuration test failed"
         fi
     
     - name: Notify success
@@ -236,7 +244,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ✅ ${{ matrix.host.name }} passed
+          ✅ ${{ matrix.host }} passed
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -249,7 +257,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ❌ ${{ matrix.host.name }} failed
+          ❌ ${{ matrix.host }} failed
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
@@ -257,6 +265,148 @@ jobs:
         thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
         # redact_event_id: ${{ steps.notify-start-test.outputs['event_id'] }}
     
+    - name: React to parent with failure emoji
+      if: failure()
+      run: |
+        PARENT_EVENT_ID="${{ needs.check-flake-syntax.outputs.parent_event_id }}"
+        ROOM_ID_ENCODED=$(echo -n "${{ secrets.MATRIX_ROOM_ID }}" | jq -sRr @uri)
+        
+        curl -X PUT "${{ secrets.MATRIX_HOMESERVER_URL }}/_matrix/client/r0/rooms/$ROOM_ID_ENCODED/send/m.reaction/$(openssl rand -hex 16)" \
+          -H "Authorization: Bearer ${{ secrets.MATRIX_ACCESS_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "m.relates_to": {
+              "rel_type": "m.annotation",
+              "event_id": "'"$PARENT_EVENT_ID"'",
+              "key": "❌"
+            }
+          }' || echo "Reaction failed, continuing..."
+
+  # Build all NixOS configurations for pull requests
+  build-configurations:
+    runs-on: ubuntu-latest
+    needs: [check-flake-syntax, prepare-hosts]
+    if: github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        host: ${{ fromJson(needs.prepare-hosts.outputs.hosts) }}
+      fail-fast: false  # Continue building other hosts even if one fails
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Notify start
+      id: notify-start-build
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          🔵 Building ${{ matrix.host }}
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
+
+    - name: Setup Tailscale
+      uses: tailscale/github-action@v2
+      with:
+        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        tags: tag:github-actions
+
+    - name: Wait for Tailscale connection
+      run: sleep 10
+
+    - name: Build ${{ matrix.host }} Configuration
+      run: |
+        # Connect to server via Tailscale
+        SERVER_HOSTNAME="${{ matrix.host }}"
+        echo "Building configuration for ${{ matrix.host }} on $SERVER_HOSTNAME"
+        
+        # Configure SSH to bypass host key verification
+        mkdir -p ~/.ssh
+        echo "Host *" >> ~/.ssh/config
+        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+        
+        # Setup SSH key
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        
+        # Copy configuration to server
+        rsync -avz --delete \
+          --exclude='.git' \
+          --exclude='.github' \
+          --exclude='*.save' \
+          --exclude='nextcloud/admin-pass' \
+          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-build-${{ matrix.host }}/
+        
+        # Build configuration on server
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME << EOF
+          set -e
+          
+          # Navigate to build directory
+          cd /tmp/nixos-config-build-${{ matrix.host }}
+          
+          # Build the NixOS configuration using flake
+          echo "Building NixOS configuration for ${{ matrix.host }}..."
+          if sudo nixos-rebuild build --flake .#${{ matrix.host }}; then
+            echo "✅ Configuration build passed for ${{ matrix.host }}!"
+            echo "SUCCESS" > /tmp/nixos-build-result-${{ matrix.host }}.txt
+          else
+            echo "❌ Configuration build failed for ${{ matrix.host }}!"
+            echo "FAILED" > /tmp/nixos-build-result-${{ matrix.host }}.txt
+            exit 1
+          fi
+        EOF
+        
+        # Get build result
+        BUILD_RESULT=$(ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME "cat /tmp/nixos-build-result-${{ matrix.host }}.txt")
+        
+        if [ "$BUILD_RESULT" = "SUCCESS" ]; then
+          echo "✅ NixOS configuration build passed for ${{ matrix.host }}!"
+        else
+          echo "❌ NixOS configuration build failed for ${{ matrix.host }}!"
+          exit 1
+        fi
+
+    - name: Set GitHub status
+      if: always()
+      run: |
+        if [ "${{ job.status }}" = "success" ]; then
+          echo "✅ ${{ matrix.host }} configuration build passed"
+        else
+          echo "❌ ${{ matrix.host }} configuration build failed"
+        fi
+
+    - name: Notify success
+      if: success()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ✅ ${{ matrix.host }} build passed
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
+
+    - name: Notify failure
+      if: failure()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ❌ ${{ matrix.host }} build failed
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
+
     - name: React to parent with failure emoji
       if: failure()
       run: |


### PR DESCRIPTION
### Motivation
- Run an actual Nix build as part of pull request validation to catch errors like hash mismatches earlier in the pipeline.
- Consolidate host selection into a single matrix source so test and build jobs share the same target set.

### Description
- Add a new `prepare-hosts` job that emits a `hosts` JSON output used as a shared matrix for downstream jobs.
- Update `test-configurations` to consume the shared matrix and normalize matrix variable usage so SSH/rsync paths and result files use `matrix.host` consistently.
- Add a pull-request-only `build-configurations` job that runs `sudo nixos-rebuild build --flake .#<host>` per host using the same matrix and existing notification/Tailscale steps.
- Keep notification, status, and failure reaction steps consistent with existing workflow behavior and reuse the `matrix-notification` action.

### Testing
- No automated workflow runs were executed for this change because it only modifies GitHub Actions YAML; the change has not been validated by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703234f3dc832face613a1c310ebd4)