### PR TITLE
Gate dns02.theyoder.family Caddy vhost on pits when Technitium enabled

### DIFF
--- a/hosts/pits/configuration.nix
+++ b/hosts/pits/configuration.nix
@@ -62,46 +62,50 @@
     
   # Example: Enable Syncthing for edge data sync
   # modules.services.storage.syncthing.enable = true;
+
+  # Ensure Technitium DNS is enabled on pits (edge DNS host)
+  modules.services.infrastructure.technitium.enable = true;
   
   # =============================================================================
   # CADDY CONFIGURATION FOR TECHNITIUM DNS
   # =============================================================================
   
   # Technitium DNS Web UI and DoH - dns02.theyoder.family
-  services.caddy.virtualHosts."dns02.theyoder.family" = {
-    extraConfig = ''
-      # Define matchers for allowed IP ranges (internal networks + Tailscale)
-      @internal {
-        remote_ip 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 100.64.0.0/10
-      }
-      
-      # Handle requests from allowed internal IPs
-      handle @internal {
-        # DNS over HTTPS endpoint - Technitium runs DoH on port 5353
-        handle /dns-query* {
-          reverse_proxy http://localhost:5353 {
-            header_up Host {upstream_hostport}
-            header_up X-Real-IP {remote_host}
+  services.caddy.virtualHosts."dns02.theyoder.family" =
+    lib.mkIf config.modules.services.infrastructure.technitium.enable {
+      extraConfig = ''
+        # Define matchers for allowed IP ranges (internal networks + Tailscale)
+        @internal {
+          remote_ip 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 100.64.0.0/10
+        }
+        
+        # Handle requests from allowed internal IPs
+        handle @internal {
+          # DNS over HTTPS endpoint - Technitium runs DoH on port 5353
+          handle /dns-query* {
+            reverse_proxy http://localhost:5353 {
+              header_up Host {upstream_hostport}
+              header_up X-Real-IP {remote_host}
+            }
+          }
+          
+          # Web UI for all other paths
+          handle {
+            reverse_proxy http://localhost:5380 {
+              header_up Host {upstream_hostport}
+              header_up X-Real-IP {remote_host}
+            }
           }
         }
         
-        # Web UI for all other paths
+        # Handle requests from disallowed IPs (external access)
         handle {
-          reverse_proxy http://localhost:5380 {
-            header_up Host {upstream_hostport}
-            header_up X-Real-IP {remote_host}
-          }
+          respond "Access Forbidden - Internal Network Only" 403
         }
-      }
-      
-      # Handle requests from disallowed IPs (external access)
-      handle {
-        respond "Access Forbidden - Internal Network Only" 403
-      }
-      
-      import cloudflare_tls
-    '';
-  };
+        
+        import cloudflare_tls
+      '';
+    };
 
   # =============================================================================
   # CADDY CONFIGURATION
@@ -265,4 +269,3 @@
   # Consider adding monitoring for a public-facing server
   # Example: Prometheus node exporter, Grafana agent, etc.
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the pits edge host runs Technitium DNS and expose its Web UI and DoH endpoints via Caddy at `dns02.theyoder.family`.
- Only configure the Caddy vhost when the Technitium service is enabled to avoid stale or broken vhosts when the module is disabled.

### Description
- Ensure `modules.services.infrastructure.technitium.enable = true` is set in `hosts/pits/configuration.nix` to enable Technitium on pits.
- Add a gated Caddy virtual host `services.caddy.virtualHosts."dns02.theyoder.family" = lib.mkIf config.modules.services.infrastructure.technitium.enable { ... }` so the vhost is only present when Technitium is enabled.
- Provide `extraConfig` that defines IP matchers, proxies `/dns-query*` to `http://localhost:5353` for DoH and proxies the Web UI to `http://localhost:5380`, and import the `cloudflare_tls` snippet.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a9dd41bc832f9f03a8fd4a53f9ec)