### PR TITLE
feat: Add Open VSCode Server module

### DIFF
--- a/modules/services/development/default.nix
+++ b/modules/services/development/default.nix
@@ -5,6 +5,7 @@
     ./vscode-server.nix
     ./github-actions.nix
     ./kasm.nix
+    ./openvscode-server.nix
   ];
 }
 

--- a/modules/services/development/openvscode-server.nix
+++ b/modules/services/development/openvscode-server.nix
@@ -1,8 +1,12 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, nixpkgs-unstable, ... }:
 
 with lib;
 let
   cfg = config.modules.services.development.openvscode-server;
+  pkgs-unstable = import nixpkgs-unstable {
+    system = pkgs.system;
+    config.allowUnfree = true;
+  };
 in
 {
   options.modules.services.development.openvscode-server = {
@@ -15,7 +19,7 @@ in
     };
 
     port = mkOption {
-      type = types.int;
+      type = types.port;
       default = 3000;
       description = "Port for Open VSCode Server";
     };
@@ -40,9 +44,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Open VSCode Server service
+    # Open VSCode Server service (using unstable version)
     services.openvscode-server = {
       enable = true;
+      package = pkgs-unstable.openvscode-server;
       host = cfg.host;
       port = cfg.port;
       user = cfg.user;

--- a/modules/services/development/openvscode-server.nix
+++ b/modules/services/development/openvscode-server.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.development.openvscode-server;
+in
+{
+  options.modules.services.development.openvscode-server = {
+    enable = mkEnableOption "Open VSCode Server for web-based development";
+
+    domain = mkOption {
+      type = types.str;
+      default = "vscode.7co.dev";
+      description = "Domain for Open VSCode Server";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 3000;
+      description = "Port for Open VSCode Server";
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Host address to bind to";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "tristonyoder";
+      description = "User to run Open VSCode Server as";
+    };
+
+    withoutConnectionToken = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Disable connection token requirement (use with reverse proxy auth)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Open VSCode Server service
+    services.openvscode-server = {
+      enable = true;
+      host = cfg.host;
+      port = cfg.port;
+      user = cfg.user;
+      withoutConnectionToken = cfg.withoutConnectionToken;
+    };
+
+    # Caddy virtual host for reverse proxy
+    services.caddy.virtualHosts.${cfg.domain} = mkIf config.modules.services.infrastructure.caddy.enable {
+      extraConfig = ''
+        reverse_proxy http://${cfg.host}:${toString cfg.port}
+        import cloudflare_tls
+      '';
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -110,6 +110,7 @@
   modules.services.development.vscode-server.enable = lib.mkDefault true;
   modules.services.development.github-actions.enable = lib.mkDefault true;
   modules.services.development.kasm.enable = lib.mkDefault true;
+  modules.services.development.openvscode-server.enable = lib.mkDefault true;
 
   # =============================================================================
   # AI SERVICES


### PR DESCRIPTION
Adds #70 openvscode-server module to development services with:
- Configurable domain, port, and host settings
- Integration with Caddy reverse proxy
- Default configuration for vscode.7co.dev
- Enabled by default in server profile