### PR TITLE
Upgrade pocket-id to nixpkgs-unstable unified module

### DIFF
--- a/modules/services/infrastructure/pocket-id.nix
+++ b/modules/services/infrastructure/pocket-id.nix
@@ -1,22 +1,26 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, nixpkgs-unstable, ... }:
 
 with lib;
 let
   cfg = config.modules.services.infrastructure.pocket-id;
+  pkgs-unstable = import nixpkgs-unstable {
+    system = pkgs.system;
+    config.allowUnfree = true;
+  };
 in
 {
   options.modules.services.infrastructure.pocket-id = {
     enable = mkEnableOption "Pocket ID authentication service";
-    
+
     domain = mkOption {
       type = types.str;
       default = "id.theyoder.family";
       description = "Domain for Pocket ID";
     };
-    
+
     port = mkOption {
       type = types.port;
-      default = 8090;
+      default = 3002;
       description = "Pocket ID port";
     };
 
@@ -25,46 +29,40 @@ in
       default = "/data/docker-appdata/pocket-id/data";
       description = "Data directory for Pocket ID";
     };
-    
+
     trustProxy = mkOption {
       type = types.bool;
       default = true;
       description = "Trust proxy headers for Pocket ID";
+    };
+
+    analyticsDisabled = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Disable analytics in Pocket ID";
     };
   };
 
   config = mkIf cfg.enable {
     services.pocket-id = {
       enable = true;
+      package = pkgs-unstable.pocket-id;
       dataDir = cfg.dataDir;
       settings = {
         APP_URL = "https://${cfg.domain}";
-        PUBLIC_APP_URL = "https://${cfg.domain}";
         TRUST_PROXY = cfg.trustProxy;
+        ANALYTICS_DISABLED = cfg.analyticsDisabled;
         PORT = cfg.port;
       };
     };
 
     services.caddy.virtualHosts.${cfg.domain} = mkIf config.modules.services.infrastructure.caddy.enable {
       extraConfig = ''
-        # Route API requests to backend (port 8080)
-        handle /api/* {
-          reverse_proxy http://localhost:8080 {
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-            header_up X-Forwarded-Host {host}
-          }
-        }
-
-        # Route everything else to frontend (port 8090)
-        handle {
-          reverse_proxy http://localhost:${toString cfg.port} {
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-            header_up X-Forwarded-Host {host}
-          }
+        reverse_proxy http://localhost:${toString cfg.port} {
+          header_up X-Real-IP {remote_host}
+          header_up X-Forwarded-For {remote_host}
+          header_up X-Forwarded-Proto {scheme}
+          header_up X-Forwarded-Host {host}
         }
 
         import cloudflare_tls


### PR DESCRIPTION
## Summary

- Migrates pocket-id from separate frontend/backend architecture to unified nixpkgs-unstable module
- Consolidates to single port configuration (3002, down from 8090 frontend + 8080 backend)
- Simplifies Caddy reverse proxy to single endpoint routing
- Adds analytics disable option (defaults to true)

## Changes

- **Package source**: Explicitly uses `pkgs-unstable.pocket-id` from nixpkgs-unstable
- **Port consolidation**: Changed default port from 8090 to 3002 for unified service
- **Caddy config**: Removed `/api/*` split routing, now single reverse proxy endpoint
- **Settings**: Added `ANALYTICS_DISABLED`, removed `PUBLIC_APP_URL` (not needed in unified module)

## Test plan

- [ ] Verify flake check passes (`nix flake check`)
- [ ] Deploy to host with `sudo nixos-rebuild switch --flake .#david`
- [ ] Confirm pocket-id service starts successfully
- [ ] Verify authentication flow works at https://id.theyoder.family
- [ ] Check service logs for errors: `journalctl -u pocket-id -f`