### PR TITLE
Limit test workflow pushes to main to avoid duplicate runs

### DIFF
--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -2,7 +2,8 @@ name: Test NixOS Flake Configuration
 
 on:
   push:
-    branches-ignore: []
+    branches:
+      - main
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
### Motivation
- Prevent CI from running the same `test-nixos-config` jobs twice when a branch push that targets a PR triggers both `push` and `pull_request` workflows.

### Description
- Change the workflow `on.push` from `branches-ignore: []` to explicitly only run on `main` by setting `branches: - main` in `.github/workflows/test-nixos-config.yml`.

### Testing
- No automated tests were run because this is a workflow trigger change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69816e7e5ce0832fa09ee633c46f7be7)