### PR TITLE
Ensure edge Tailscale login server uses https

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -121,8 +121,8 @@ jobs:
     - name: Setup Tailscale
       uses: tailscale/github-action@v2
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+        args: --login-server=${{ secrets.HEADSCALE_LOGIN_SERVER }}
         tags: tag:github-actions
         
     - name: Wait for Tailscale connection

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -161,8 +161,8 @@ jobs:
     - name: Setup Tailscale
       uses: tailscale/github-action@v2
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+        args: --login-server=${{ secrets.HEADSCALE_LOGIN_SERVER }}
         tags: tag:github-actions
         
     - name: Wait for Tailscale connection

--- a/modules/services/infrastructure/tailscale.nix
+++ b/modules/services/infrastructure/tailscale.nix
@@ -25,6 +25,12 @@ in
       default = true;
       description = "Advertise as exit node";
     };
+
+    loginServer = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Custom login server URL (e.g., Headscale server URL)";
+    };
     
     enableIPForwarding = mkOption {
       type = types.bool;
@@ -40,6 +46,7 @@ in
       useRoutingFeatures = "both";
       extraUpFlags = [
         (optionalString cfg.enableSSH "--ssh")
+        (optionalString (cfg.loginServer != null) "--login-server=${cfg.loginServer}")
         "--advertise-routes=${cfg.advertiseRoutes}"
         (optionalString cfg.advertiseExitNode "--advertise-exit-node")
         "--snat-subnet-routes=false"
@@ -59,4 +66,3 @@ in
     };
   };
 }
-

--- a/profiles/edge.nix
+++ b/profiles/edge.nix
@@ -30,6 +30,7 @@
   
   # Tailscale for secure networking back to main infrastructure
   modules.services.infrastructure.tailscale.enable = lib.mkDefault true;
+  modules.services.infrastructure.tailscale.loginServer = lib.mkDefault "https://${config.modules.services.infrastructure.headscale.domain}";
   
   # Technitium DNS Server for edge DNS resolution
   modules.services.infrastructure.technitium.enable = lib.mkDefault true;


### PR DESCRIPTION
### Motivation
- Make Tailscale login server configuration explicit and correct for Headscale by ensuring the URL includes the `https://` scheme and provide a configurable option for custom login servers.
- Allow GitHub Actions to authenticate to Headscale using an auth key and pass the login server to the Tailscale action for self-hosted control planes.

### Description
- Add a new `loginServer` option (`nullOr string`) to `modules/services/infrastructure/tailscale.nix` to allow configuring a custom login server URL.
- Pass `--login-server=${cfg.loginServer}` to `tailscale up` via `extraUpFlags` when `loginServer` is set.
- Update GitHub Actions workflows (`.github/workflows/deploy-nixos-config.yml` and `test-nixos-config.yml`) to use `authkey: ${{ secrets.HEADSCALE_AUTHKEY }}` and include `args: --login-server=${{ secrets.HEADSCALE_LOGIN_SERVER }}` for the `tailscale/github-action@v2` step.
- Change `profiles/edge.nix` to set `modules.services.infrastructure.tailscale.loginServer` to an explicit HTTPS URL derived from `config.modules.services.infrastructure.headscale.domain` (`"https://${config.modules.services.infrastructure.headscale.domain}"`).

### Testing
- No automated tests were executed for this PR because the changes are configuration and workflow updates only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869ac71f64832f978f74d5fe779a18)