### PR TITLE
Add ssh-ng://david as a trusted Nix substituter for Linux hosts

### DIFF
--- a/common/linux.nix
+++ b/common/linux.nix
@@ -11,6 +11,7 @@
   nix.settings = {
     # Enable store optimization (safe on NixOS)
     auto-optimise-store = true;
+    trusted-substituters = [ "ssh-ng://david" ];
   };
   
   # =============================================================================
@@ -100,4 +101,3 @@
     loader.timeout = 2;
   };
 }
-


### PR DESCRIPTION
### Motivation
- Configure Nix on all Linux/NixOS hosts to trust the `ssh-ng://david` substituter so systems can fetch binary substitutes from David.

### Description
- Add `trusted-substituters = [ "ssh-ng://david" ]` to `nix.settings` in `common/linux.nix`.

### Testing
- No automated tests were run; this is a single-line configuration change that was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a7e906c0832f93e4bed327a968f5)