### PR TITLE
Update Headscale DNS servers and search domains

### DIFF
--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -47,7 +47,6 @@ in
           searchDomains = mkOption {
             type = types.listOf types.str;
             default = unique [
-              cfg.baseDomain
               config.networking.domain
               "7andco.studio"
               "7co.dev"
@@ -266,7 +265,12 @@ in
           base_domain = cfg.baseDomain;
           magic_dns = true;
           nameservers = {
-            global = [ "1.1.1.1" "1.0.0.1" ];
+            global = [
+              "100.75.81.4"
+              "fd7a:115c:a1e0:7cfc:118d:7504:ea5e:8cc0"
+              "100.85.170.40"
+              "fd7a:115c:a1e0:be1:14a9:7bf2:55ce:615c"
+            ];
           };
           search_domains = unique cfg.dns.searchDomains;
         };


### PR DESCRIPTION
### Motivation

- Configure Headscale MagicDNS to use the provided primary and secondary IPv4/IPv6 nameservers so clients resolve via the requested DNS servers.
- Avoid including the (vpn) base domain in the default Headscale search domains to prevent redundant automatic addition of `vpn.<domain>`.

### Description

- Updated `modules/services/infrastructure/headscale.nix` to remove `cfg.baseDomain` from the default `dns.searchDomains` list.
- Replaced the previous global nameservers with the supplied addresses by setting `dns.nameservers.global` to the four provided IPv4/IPv6 entries in `modules/services/infrastructure/headscale.nix`.
- Changes were staged and committed with the message `Update headscale DNS settings`.

### Testing

- No automated tests were run for this change.

------
#101 