### PR TITLE
feat: migrate GitHub Actions networking from Tailscale cloud to Heads…

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -118,13 +118,13 @@ jobs:
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
       
-    - name: Setup Tailscale
+    - name: Setup Tailscale (Headscale)
       uses: tailscale/github-action@v2
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
-        
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+
     - name: Wait for Tailscale connection
       run: sleep 10
       

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -124,7 +124,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -132,7 +132,7 @@ jobs:
     - name: Deploy to ${{ matrix.host }}
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host }}"
+        SERVER_HOSTNAME="${{ matrix.host }}.vpn.theyoder.family"
         echo "Deploying configuration to ${{ matrix.host }} at $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -123,6 +123,7 @@ jobs:
       with:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
+        version: 1.78.1
         args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Deploy to ${{ matrix.host }}
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host }}"
+        SERVER_HOSTNAME="${{ matrix.host }}.vpn.theyoder.family"
         echo "Deploying configuration to ${{ matrix.host }} at $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -124,7 +124,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -132,7 +132,7 @@ jobs:
     - name: Deploy to ${{ matrix.host }}
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host }}.vpn.theyoder.family"
+        SERVER_HOSTNAME="${{ matrix.host }}"
         echo "Deploying configuration to ${{ matrix.host }} at $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -19,8 +19,8 @@ name: NixOS Flake Updater
 #   - GITHUB_TOKEN: For PR/issue creation (automatically provided)
 #   - SSH_PRIVATE_KEY: SSH key for connecting to NixOS hosts
 #   - NIXOS_SERVER_USER: Username for SSH connections
-#   - TAILSCALE_OAUTH_CLIENT_ID: Tailscale OAuth credentials
-#   - TAILSCALE_OAUTH_SECRET: Tailscale OAuth credentials
+#   - HEADSCALE_LOGIN_SERVER: Headscale coordination server URL
+#   - HEADSCALE_AUTHKEY: Headscale preauth key for node registration
 #   - MATRIX_HOMESERVER_URL: Matrix notification server
 #   - MATRIX_ROOM_ID: Matrix room for notifications
 #   - MATRIX_ACCESS_TOKEN: Matrix authentication token
@@ -212,12 +212,12 @@ jobs:
       with:
         ref: ${{ needs.update-flake.outputs.branch_name }}
 
-    - name: Setup Tailscale
+    - name: Setup Tailscale (Headscale)
       uses: tailscale/github-action@v2
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection
       run: sleep 10

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -218,7 +218,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -239,7 +239,7 @@ jobs:
       # Typical dry-runs: 3-5 minutes; updates with downloads: 10-30 minutes
       timeout-minutes: 60
       run: |
-        HOST="${{ matrix.host.hostname }}"
+        HOST="${{ matrix.host.hostname }}.vpn.theyoder.family"
         echo "Testing configuration on ${{ matrix.host.name }} at $HOST..."
 
         # Verify SSH connection with retry logic
@@ -287,7 +287,7 @@ jobs:
     - name: Cleanup test directory
       if: always()
       run: |
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }} \
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }}.vpn.theyoder.family \
           "rm -rf /tmp/nixos-flake-update-test-${{ matrix.host.name }}" || true
 
   # Create PR if all tests passed

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -218,7 +218,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -239,7 +239,7 @@ jobs:
       # Typical dry-runs: 3-5 minutes; updates with downloads: 10-30 minutes
       timeout-minutes: 60
       run: |
-        HOST="${{ matrix.host.hostname }}.vpn.theyoder.family"
+        HOST="${{ matrix.host.hostname }}"
         echo "Testing configuration on ${{ matrix.host.name }} at $HOST..."
 
         # Verify SSH connection with retry logic
@@ -287,7 +287,7 @@ jobs:
     - name: Cleanup test directory
       if: always()
       run: |
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }}.vpn.theyoder.family \
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }} \
           "rm -rf /tmp/nixos-flake-update-test-${{ matrix.host.name }}" || true
 
   # Create PR if all tests passed

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -239,7 +239,7 @@ jobs:
       # Typical dry-runs: 3-5 minutes; updates with downloads: 10-30 minutes
       timeout-minutes: 60
       run: |
-        HOST="${{ matrix.host.hostname }}"
+        HOST="${{ matrix.host.hostname }}.vpn.theyoder.family"
         echo "Testing configuration on ${{ matrix.host.name }} at $HOST..."
 
         # Verify SSH connection with retry logic
@@ -287,7 +287,7 @@ jobs:
     - name: Cleanup test directory
       if: always()
       run: |
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }} \
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@${{ matrix.host.hostname }}.vpn.theyoder.family \
           "rm -rf /tmp/nixos-flake-update-test-${{ matrix.host.name }}" || true
 
   # Create PR if all tests passed

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -217,6 +217,7 @@ jobs:
       with:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
+        version: 1.78.1
         args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -163,6 +163,7 @@ jobs:
       with:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
+        version: 1.78.1
         args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -172,7 +172,7 @@ jobs:
     - name: Test ${{ matrix.host.name }} Configuration
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host.hostname }}"
+        SERVER_HOSTNAME="${{ matrix.host.hostname }}.vpn.theyoder.family"
         echo "Testing configuration for ${{ matrix.host.name }} on $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -158,13 +158,13 @@ jobs:
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
       
-    - name: Setup Tailscale
+    - name: Setup Tailscale (Headscale)
       uses: tailscale/github-action@v2
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
-        
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+
     - name: Wait for Tailscale connection
       run: sleep 10
       

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -164,7 +164,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -172,7 +172,7 @@ jobs:
     - name: Test ${{ matrix.host.name }} Configuration
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host.hostname }}"
+        SERVER_HOSTNAME="${{ matrix.host.hostname }}.vpn.theyoder.family"
         echo "Testing configuration for ${{ matrix.host.name }} on $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -164,7 +164,7 @@ jobs:
         authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
         tags: tag:github-actions
         version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }} --accept-dns
 
     - name: Wait for Tailscale connection
       run: sleep 10
@@ -172,7 +172,7 @@ jobs:
     - name: Test ${{ matrix.host.name }} Configuration
       run: |
         # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host.hostname }}.vpn.theyoder.family"
+        SERVER_HOSTNAME="${{ matrix.host.hostname }}"
         echo "Testing configuration for ${{ matrix.host.name }} on $SERVER_HOSTNAME"
         
         # Configure SSH to bypass host key verification

--- a/modules/services/infrastructure/tailscale.nix
+++ b/modules/services/infrastructure/tailscale.nix
@@ -31,6 +31,12 @@ in
       default = true;
       description = "Enable kernel-level IP forwarding for routing";
     };
+
+    loginServer = mkOption {
+      type = types.str;
+      default = "https://ts.theyoder.family";
+      description = "Headscale login server URL (empty uses default Tailscale coordination)";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -39,6 +45,7 @@ in
       enable = true;
       useRoutingFeatures = "both";
       extraUpFlags = [
+        (optionalString (cfg.loginServer != "") "--login-server=${cfg.loginServer}")
         (optionalString cfg.enableSSH "--ssh")
         "--advertise-routes=${cfg.advertiseRoutes}"
         (optionalString cfg.advertiseExitNode "--advertise-exit-node")


### PR DESCRIPTION
Replace Tailscale OAuth authentication with Headscale preauth key in all CI/CD workflows. Add loginServer option to tailscale.nix module defaulting to the self-hosted Headscale coordination server.