### PR TITLE
fix: resolve technitium crash loop on systemd 257

### DIFF
--- a/modules/services/infrastructure/technitium.nix
+++ b/modules/services/infrastructure/technitium.nix
@@ -56,6 +56,14 @@ in
       firewallUDPPorts = cfg.firewallUDPPorts;
       firewallTCPPorts = cfg.firewallTCPPorts;
     };
+
+    # Work around BindPaths conflict with DynamicUser + StateDirectory on systemd 257.
+    # The auto-generated BindPaths override breaks directory permissions for the
+    # dynamic user, causing "Access to the path 'blocklists' is denied" on startup.
+    systemd.services.technitium-dns-server.serviceConfig = {
+      BindPaths = lib.mkForce "";
+      WorkingDirectory = lib.mkForce "";
+    };
   };
 }
 


### PR DESCRIPTION
## Summary
- Technitium DNS was crash-looping (6,591 restarts) on pits due to `BindPaths` conflicting with `DynamicUser` + `StateDirectory` on systemd 257
- Clearing the auto-generated `BindPaths` and `WorkingDirectory` lets systemd handle the private state directory natively

## Tested on
- **pits** — `nixos-rebuild switch` successful, service running
- **david** — `nixos-rebuild switch` successful, service running