### PR TITLE
fix: enable NVIDIA NVENC hardware transcoding for Jellyfin

### DIFF
--- a/modules/services/media/jellyfin.nix
+++ b/modules/services/media/jellyfin.nix
@@ -52,8 +52,17 @@ in
     # Minimal hardening overrides required for CUDA
     systemd.services.jellyfin.serviceConfig = mkIf cfg.enableHardwareTranscode {
       PrivateDevices = mkForce false;
-      DeviceAllow = mkForce [ ];
-      DevicePolicy = mkForce "auto";
+      DevicePolicy = mkForce "closed";
+      DeviceAllow = mkForce [
+        # DRM/GPU render nodes
+        "char-drm rw"
+        # NVIDIA devices (major 195, 238-242)
+        "/dev/nvidia0 rw"
+        "/dev/nvidiactl rw"
+        "/dev/nvidia-modeset rw"
+        "/dev/nvidia-uvm rw"
+        "/dev/nvidia-uvm-tools rw"
+      ];
       NoNewPrivileges = mkForce false;
       SystemCallFilter = mkForce [ ];
       ProtectKernelModules = mkForce false;


### PR DESCRIPTION
## Summary
- Relax systemd hardening settings blocking CUDA/NVENC initialization
- Add jellyfin user to video/render groups
- Set LD_LIBRARY_PATH for NVIDIA libraries

## Changes
| Setting | Value | Reason |
|---------|-------|--------|
| PrivateDevices | false | GPU device access |
| DevicePolicy | auto | Unrestricted device access |
| NoNewPrivileges | false | CUDA driver initialization |
| SystemCallFilter | empty | CUDA syscalls |
| ProtectKernelModules | false | NVIDIA kernel module access |
| MemoryDenyWriteExecute | false | CUDA JIT compilation |

## Test plan
- [x] Tested playback with NVENC transcoding on david