### PR TITLE
fix: correct Tandoor container port mapping

### DIFF
--- a/docker/productivity/tandoor.nix
+++ b/docker/productivity/tandoor.nix
@@ -31,7 +31,7 @@
       "/data/docker-appdata/tandoor/staticfiles:/opt/recipes/staticfiles:rw"
     ];
     ports = [
-      "6780:8080/tcp"
+      "6780:80/tcp"
     ];
     dependsOn = [
       "tandoor-db_tandoor"


### PR DESCRIPTION
## Summary
- The `vabene1111/recipes` Docker image changed its internal nginx listen port from 8080 to 80
- Updated port mapping from `6780:8080` to `6780:80` so traffic actually reaches nginx inside the container
- Without this fix, connections to Tandoor are reset since nothing listens on 8080

## Test plan
- [ ] Rebuild on david: `sudo nixos-rebuild switch --flake .#david`
- [ ] Verify Tandoor loads at its configured domain/port