### PR TITLE
Change Tandoor service port from 8080 to 80

### DIFF
--- a/modules/services/productivity/tandoor.nix
+++ b/modules/services/productivity/tandoor.nix
@@ -69,7 +69,7 @@ in
         "${cfg.dataDir}/staticfiles:/opt/recipes/staticfiles:rw"
       ];
       ports = [
-        "${toString cfg.port}:8080/tcp"
+        "${toString cfg.port}:80/tcp"
       ];
       dependsOn = [ "tandoor-db_tandoor" ];
       log-driver = "journald";


### PR DESCRIPTION
## Summary
- The `vabene1111/recipes` Docker image changed its internal nginx listen port from 8080 to 80
- Updated port mapping from `6780:8080` to `6780:80` so traffic actually reaches nginx inside the container
- Without this fix, connections to Tandoor are reset since nothing listens on 8080

## Test plan
- [ ] Rebuild on david: `sudo nixos-rebuild switch --flake .#david`
- [ ] Verify Tandoor loads at its configured domain/port