### PR TITLE
Use system timezone in all Docker container modules

### DIFF
--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -33,6 +33,7 @@ in
       host = "127.0.0.1";
       port = cfg.port;
       environment = {
+        TZ = config.time.timeZone;
         OLLAMA_BASE_URL = cfg.ollamaHost;
         WEBUI_AUTH = "True";
         ENABLE_SIGNUP = "True";

--- a/modules/services/communication/postal.nix
+++ b/modules/services/communication/postal.nix
@@ -154,6 +154,7 @@ in
     # Override the generated container configurations to use proper paths and environment files
     virtualisation.oci-containers.containers."postal_mariadb" = {
       environment = lib.mkForce {
+        TZ = config.time.timeZone;
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD = "no";
         MARIADB_DATABASE = "postal";
         MARIADB_ROOT_PASSWORD = "PLACEHOLDER";  # Will be overridden by environmentFile
@@ -168,6 +169,7 @@ in
     
     virtualisation.oci-containers.containers."postal_runner" = {
       environment = lib.mkForce {
+        TZ = config.time.timeZone;
         MAIN_DB_DATABASE = "postal";
         MAIN_DB_HOST = "mariadb";
         MAIN_DB_PASSWORD = "PLACEHOLDER";  # Will be overridden by environmentFile
@@ -195,6 +197,7 @@ in
     
     virtualisation.oci-containers.containers."postal_worker" = {
       environment = lib.mkForce {
+        TZ = config.time.timeZone;
         MAIN_DB_DATABASE = "postal";
         MAIN_DB_HOST = "mariadb";
         MAIN_DB_PASSWORD = "PLACEHOLDER";  # Will be overridden by environmentFile
@@ -220,6 +223,7 @@ in
     
     virtualisation.oci-containers.containers."postal_smtp" = {
       environment = lib.mkForce {
+        TZ = config.time.timeZone;
         MAIN_DB_DATABASE = "postal";
         MAIN_DB_HOST = "mariadb";
         MAIN_DB_PASSWORD = "PLACEHOLDER";  # Will be overridden by environmentFile

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -12,6 +12,9 @@ let
   baseEnvironment = cfg.environment
     // optionalAttrs (resolvedActualServerUrl != "") {
       ACTUAL_SERVER_URL = resolvedActualServerUrl;
+    }
+    // {
+      TZ = config.time.timeZone;
     };
 in
 {

--- a/modules/services/productivity/tandoor.nix
+++ b/modules/services/productivity/tandoor.nix
@@ -58,6 +58,7 @@ in
       image = "vabene1111/recipes";
       environmentFiles = [ cfg.secretsFile ];
       environment = {
+        TZ = config.time.timeZone;
         DB_ENGINE = "django.db.backends.postgresql";
         POSTGRES_DB = cfg.dbName;
         POSTGRES_HOST = "db_tandoor";


### PR DESCRIPTION
## Summary

- Standardize timezone handling across all Docker container modules by referencing `config.time.timeZone`
- Ensures consistent timezone behavior controlled by the system-wide setting in `common/system.nix`
- Current system timezone: `America/Indiana/Indianapolis`

## Changes

Updated 4 modules to include `TZ = config.time.timeZone` in container environment variables:

- **tandoor.nix**: Main container now uses system timezone
- **actual-http-api.nix**: Added TZ to baseEnvironment configuration
- **postal.nix**: All 4 containers (mariadb, runner, worker, smtp) now use system timezone
- **open-webui.nix**: Environment block includes system timezone

## Benefits

- Consistent timezone across all services
- Single point of configuration in `common/system.nix`
- Individual hosts can override if needed
- No hardcoded timezone values in service modules

## Test Plan

- [ ] Verify configuration builds successfully with `nix flake check`
- [ ] Deploy to test host and confirm containers start properly
- [ ] Check container logs show correct timezone
- [ ] Verify services display correct timestamps in their UIs