### PR TITLE
Upgrade headscale to v0.28.0 from nixpkgs-unstable

### DIFF
--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -1,8 +1,15 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, nixpkgs-unstable, ... }:
 
 with lib;
 let
   cfg = config.modules.services.infrastructure.headscale;
+  # Get unstable packages with unfree allowed
+  unstable = import nixpkgs-unstable {
+    system = pkgs.system;
+    config = {
+      allowUnfree = true;
+    };
+  };
 in
 {
   # Admin UI imports (unconditional - each module has its own enable logic)
@@ -15,6 +22,12 @@ in
 
   options.modules.services.infrastructure.headscale = {
     enable = mkEnableOption "Headscale coordination server for Tailscale";
+
+    unstable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Use headscale from nixpkgs-unstable (recommended for latest version v0.28.0+)";
+    };
 
     # Domain Configuration
     baseDomain = mkOption {
@@ -233,6 +246,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Use headscale from unstable if enabled
+    nixpkgs.overlays = mkIf cfg.unstable [
+      (final: prev: {
+        headscale = unstable.headscale;
+      })
+    ];
+
     # Native NixOS headscale service
     services.headscale = {
       enable = true;

--- a/profiles/edge.nix
+++ b/profiles/edge.nix
@@ -37,6 +37,7 @@
   # Headscale coordination server (self-hosted Tailscale control plane)
   modules.services.infrastructure.headscale = {
     enable = lib.mkDefault true;
+    unstable = lib.mkDefault true;  # Use v0.28.0+ from nixpkgs-unstable
     # Use vpn.<baseDomain> as base_domain for MagicDNS
     # This makes devices accessible as hostname.vpn.<baseDomain>
     baseDomain = lib.mkDefault "vpn.${config.networking.domain}";


### PR DESCRIPTION
## Summary

Upgrades headscale from v0.25.1 to v0.28.0 by adding an `unstable` option to the headscale module that enables using the latest version from nixpkgs-unstable.

## Motivation

Current version (v0.25.1) is 3 minor versions behind. v0.28.0 includes critical improvements:

- **"Tags as identity"** functionality aligning with Tailscale's model (fixes SSH policy issues)
- Smarter map updates reducing bandwidth usage
- Enhanced security for pre-authentication keys (bcrypt hashing)
- Improved SSH policy validation
- Requires minimum Tailscale client version v1.74.0

## Changes

**Module Changes (`modules/services/infrastructure/headscale.nix`):**
- Add `unstable` option (type: bool, default: false)
- Import `nixpkgs-unstable` parameter
- Use overlay to replace headscale package when `unstable = true`

**Profile Changes (`profiles/edge.nix`):**
- Enable `unstable = true` by default for headscale in edge profile
- Applies to pits host running headscale

## Migration Path

The module defaults to stable (v0.25.1) for backward compatibility. The edge profile explicitly enables unstable to upgrade pits to v0.28.0.

Sequential upgrade path if needed: v0.25.1 → v0.26.x → v0.27.x → v0.28.0

## Test Plan

- [ ] GitHub Actions test workflow validates flake syntax
- [ ] Deploy to pits and verify headscale starts successfully
- [ ] Check headscale version matches v0.28.0
- [ ] Verify existing nodes remain connected
- [ ] Test GitHub Actions deployment with new SSH policy handling
- [ ] Confirm MagicDNS and OIDC continue working