### PR TITLE
Fix: use runtime config filter for headscale v0.27+ compatibility

### DIFF
--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -303,24 +303,18 @@ in
         };
 
         # OIDC configuration (if enabled)
-        oidc = mkIf cfg.oidc.enable (
-          # Use mkForce when unstable to prevent NixOS module from adding strip_email_domain
-          (if cfg.unstable then mkForce else lib.id) {
-            issuer = cfg.oidc.issuer;
-            client_id = cfg.oidc.clientId;
-            client_secret_path = cfg.oidc.clientSecretFile;
-            scope = cfg.oidc.scope;
-            allowed_groups = cfg.oidc.allowedGroups;
-            allowed_users = [];
-            allowed_domains = [];
-            extra_params = {};
-            pkce = {
-              enabled = cfg.oidc.pkce.enabled;
-              method = cfg.oidc.pkce.method;
-            };
-            # Explicitly do NOT set strip_email_domain for v0.27+
-          }
-        );
+        oidc = mkIf cfg.oidc.enable {
+          issuer = cfg.oidc.issuer;
+          client_id = cfg.oidc.clientId;
+          client_secret_path = cfg.oidc.clientSecretFile;
+          scope = cfg.oidc.scope;
+          allowed_groups = cfg.oidc.allowedGroups;
+          pkce = {
+            enabled = cfg.oidc.pkce.enabled;
+            method = cfg.oidc.pkce.method;
+          };
+          # Note: strip_email_domain added by NixOS module is filtered out at runtime when unstable=true
+        };
 
         # Default IP prefixes for Tailscale network
         # Using 100.64.0.0/10 (CGNAT range) instead of 10.x.x.x to avoid firewall conflicts
@@ -342,6 +336,21 @@ in
           format = "text";
         };
       };
+    };
+
+    # Workaround for v0.27+ compatibility: Filter out strip_email_domain at runtime
+    # The NixOS module hardcodes this in the YAML generation, so we filter it before starting
+    systemd.services.headscale = mkIf cfg.unstable {
+      script = mkForce ''
+        # Create runtime directory
+        mkdir -p /run/headscale
+
+        # Filter out strip_email_domain from the generated config
+        ${pkgs.gnused}/bin/sed '/strip_email_domain:/d' /etc/headscale/config.yaml > /run/headscale/config-filtered.yaml
+
+        # Start headscale with filtered config
+        exec ${config.services.headscale.package}/bin/headscale serve --config /run/headscale/config-filtered.yaml
+      '';
     };
 
     # API key generation service (only if apiKeyFile is null)


### PR DESCRIPTION
## Issue

PR #120's `mkForce` approach didn't work because the NixOS headscale module generates the YAML config file with hardcoded logic that adds `strip_email_domain: true` regardless of what's in the settings attribute set.

After rebuilding pits, headscale still fails with:
```
FATAL: The "oidc.strip_email_domain" configuration key has been removed.
```

## Root Cause

The NixOS headscale module has YAML generation code that automatically adds `strip_email_domain` to the config. Using `mkForce` on the settings doesn't prevent this because the YAML is generated at build time with hardcoded logic.

## Solution

Implement a **runtime filter** that strips out the deprecated option before headscale starts:

1. Override `systemd.services.headscale.script` when `unstable = true`
2. Use `sed` to filter `strip_email_domain:` line from `/etc/headscale/config.yaml`
3. Write filtered config to `/run/headscale/config-filtered.yaml`
4. Start headscale with the filtered config

## Changes

**Module (`modules/services/infrastructure/headscale.nix`):**
- Add systemd service script override for unstable mode
- Filter config at runtime before starting headscale
- Simplified OIDC settings (removed ineffective mkForce)

## Benefits

- Works around NixOS module limitation without requiring upstream patches
- Can use headscale v0.27+ from nixpkgs-unstable
- Gets "Tags as identity" and improved SSH functionality
- No manual intervention required

## Test Plan

- [ ] Rebuild pits with new configuration
- [ ] Verify headscale v0.27+ starts successfully
- [ ] Check filtered config excludes strip_email_domain
- [ ] Confirm existing nodes remain connected
- [ ] Test OIDC authentication

## References

- PR #120: Previous compatibility attempt (mkForce approach)
- [headscale CHANGELOG](https://raw.githubusercontent.com/juanfont/headscale/main/CHANGELOG.md)