### PR TITLE
Revert headscale v0.27+ upgrade attempts

### DIFF
--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -1,15 +1,8 @@
-{ config, lib, pkgs, nixpkgs-unstable, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 let
   cfg = config.modules.services.infrastructure.headscale;
-  # Get unstable packages with unfree allowed
-  unstable = import nixpkgs-unstable {
-    system = pkgs.system;
-    config = {
-      allowUnfree = true;
-    };
-  };
 in
 {
   # Admin UI imports (unconditional - each module has its own enable logic)
@@ -22,12 +15,6 @@ in
 
   options.modules.services.infrastructure.headscale = {
     enable = mkEnableOption "Headscale coordination server for Tailscale";
-
-    unstable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Use headscale from nixpkgs-unstable (recommended for latest version v0.28.0+)";
-    };
 
     # Domain Configuration
     baseDomain = mkOption {
@@ -246,13 +233,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Use headscale from unstable if enabled
-    nixpkgs.overlays = mkIf cfg.unstable [
-      (final: prev: {
-        headscale = unstable.headscale;
-      })
-    ];
-
     # Native NixOS headscale service
     services.headscale = {
       enable = true;
@@ -313,7 +293,6 @@ in
             enabled = cfg.oidc.pkce.enabled;
             method = cfg.oidc.pkce.method;
           };
-          # Note: strip_email_domain added by NixOS module is filtered out at runtime when unstable=true
         };
 
         # Default IP prefixes for Tailscale network
@@ -336,21 +315,6 @@ in
           format = "text";
         };
       };
-    };
-
-    # Workaround for v0.27+ compatibility: Filter out strip_email_domain at runtime
-    # The NixOS module hardcodes this in the YAML generation, so we filter it before starting
-    systemd.services.headscale = mkIf cfg.unstable {
-      script = mkForce ''
-        # Create runtime directory
-        mkdir -p /run/headscale
-
-        # Filter out strip_email_domain from the generated config
-        ${pkgs.gnused}/bin/sed '/strip_email_domain:/d' /etc/headscale/config.yaml > /run/headscale/config-filtered.yaml
-
-        # Start headscale with filtered config
-        exec ${config.services.headscale.package}/bin/headscale serve --config /run/headscale/config-filtered.yaml
-      '';
     };
 
     # API key generation service (only if apiKeyFile is null)

--- a/profiles/edge.nix
+++ b/profiles/edge.nix
@@ -37,7 +37,6 @@
   # Headscale coordination server (self-hosted Tailscale control plane)
   modules.services.infrastructure.headscale = {
     enable = lib.mkDefault true;
-    unstable = lib.mkDefault false;  # TEMPORARILY DISABLED: v0.27+ compatibility fix not working yet
     # Use vpn.<baseDomain> as base_domain for MagicDNS
     # This makes devices accessible as hostname.vpn.<baseDomain>
     baseDomain = lib.mkDefault "vpn.${config.networking.domain}";


### PR DESCRIPTION
## Overview

Reverts all changes from PR #119, #120, and #122 to restore the codebase to a clean state with working headscale v0.25.1.

## Why Revert?

After three failed attempts to upgrade headscale to v0.27+, we're left with:
- `unstable` option (unused - set to false)
- Compatibility workarounds (unused - never worked)
- Extra complexity with no benefit

Better to have a clean codebase with simple, working v0.25.1 than unused/broken upgrade code.

## What This Removes

**From `modules/services/infrastructure/headscale.nix`:**
- `unstable` option and all related code
- `nixpkgs-unstable` import and overlay
- Runtime config filtering systemd override
- Compatibility comments

**From `profiles/edge.nix`:**
- `unstable = false` line

## Result

Clean, simple headscale module running v0.25.1 (stable, working).

## Future Upgrade

Tracked in issue #123. Will upgrade when NixOS headscale module is updated in nixpkgs-unstable to support v0.27+.

## Reverted Commits

- 36e9ba1 PR #122: Hotfix to disable unstable
- 87049aa PR #120: Compatibility layer attempt  
- cde2c75 PR #119: Add unstable option

## Verification

After merge and rebuild:
- [ ] Headscale v0.25.1 still running
- [ ] No change in functionality (already on v0.25.1)
- [ ] Codebase cleaner without unused code