### PR TITLE
feat: add tidal-dl package to system packages

### DIFF
--- a/common/system.nix
+++ b/common/system.nix
@@ -71,6 +71,9 @@ in
     dig
     nmap
 
+    # Media tools
+    tidal-dl
+
     # AI tools (from unstable for latest features)
     pkgs-unstable.gemini-cli
     pkgs-unstable.claude-code


### PR DESCRIPTION
## Summary
- Adds tidal-dl music downloader to common system packages
- Available on all hosts (NixOS and Darwin)

## Test plan
- [ ] Rebuild Darwin configuration: `darwin-rebuild switch --flake .`
- [ ] Rebuild NixOS configuration: `sudo nixos-rebuild switch --flake .`
- [ ] Verify tidal-dl is available: `which tidal-dl`