### PR TITLE
Mount david's /data via NFS on tristons-nixbook

### DIFF
--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -25,6 +25,26 @@
   };
 
   # =============================================================================
+  # NFS MOUNTS
+  # =============================================================================
+
+  # Mount david's /data directory via NFS
+  # Uses automount so it doesn't block boot if david is unreachable
+  fileSystems."/data" = {
+    device = "david.theyoder.family:/data";
+    fsType = "nfs";
+    options = [
+      "noauto"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=600"
+      "x-systemd.mount-timeout=10"
+      "soft"
+      "timeo=50"
+      "retrans=3"
+    ];
+  };
+
+  # =============================================================================
   # ADDITIONAL PACKAGES FOR LAPTOP
   # =============================================================================
 
@@ -35,5 +55,8 @@
 
     # Development tools
     vscode
+
+    # NFS client support
+    nfs-utils
   ];
 }


### PR DESCRIPTION
## Summary
- Adds NFS automount of `david.theyoder.family:/data` at `/data` on tristons-nixbook
- Uses soft mount with timeouts to avoid hangs when david is unreachable
- Mounts on first access via systemd automount, unmounts after 10 min idle

## Test plan
- [ ] Rebuild tristons-nixbook with `sudo nixos-rebuild switch --flake .#tristons-nixbook`
- [ ] Verify mount triggers on `ls /data`
- [ ] Confirm read-write access to `/data/tristonyoder`
- [ ] Test behavior when david is unreachable (should return errors, not hang)