### PR TITLE
feat: swap Command and Control keys on tristons-nixbook

### DIFF
--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -45,6 +45,15 @@
   };
 
   # =============================================================================
+  # KEYBOARD LAYOUT - SWAP COMMAND AND CONTROL
+  # =============================================================================
+
+  # MacBook keyboard has Command (Super) next to spacebar where Ctrl
+  # would be on a PC keyboard. Swap them so the familiar Command key
+  # position acts as Ctrl.
+  services.xserver.xkb.options = "ctrl:swap_lwin_lctl,ctrl:swap_rwin_rctl";
+
+  # =============================================================================
   # ADDITIONAL PACKAGES FOR LAPTOP
   # =============================================================================
 

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -49,9 +49,20 @@
   # =============================================================================
 
   # MacBook keyboard has Command (Super) next to spacebar where Ctrl
-  # would be on a PC keyboard. Swap them so the familiar Command key
-  # position acts as Ctrl.
-  services.xserver.xkb.options = "ctrl:swap_lwin_lctl,ctrl:swap_rwin_rctl";
+  # would be on a PC keyboard. Use keyd to swap at the kernel level
+  # so it works in Wayland, X11, and TTY.
+  services.keyd = {
+    enable = true;
+    keyboards.default = {
+      ids = [ "*" ];
+      settings.main = {
+        leftmeta = "leftcontrol";
+        leftcontrol = "leftmeta";
+        rightmeta = "rightcontrol";
+        rightcontrol = "rightmeta";
+      };
+    };
+  };
 
   # =============================================================================
   # ADDITIONAL PACKAGES FOR LAPTOP

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -25,6 +25,26 @@
   };
 
   # =============================================================================
+  # NFS MOUNTS
+  # =============================================================================
+
+  # Mount david's /data directory via NFS
+  # Uses automount so it doesn't block boot if david is unreachable
+  fileSystems."/data" = {
+    device = "david.theyoder.family:/data";
+    fsType = "nfs";
+    options = [
+      "noauto"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=600"
+      "x-systemd.mount-timeout=10"
+      "soft"
+      "timeo=50"
+      "retrans=3"
+    ];
+  };
+
+  # =============================================================================
   # ADDITIONAL PACKAGES FOR LAPTOP
   # =============================================================================
 
@@ -35,5 +55,8 @@
 
     # Development tools
     vscode
+
+    # NFS client support
+    nfs-utils
   ];
 }


### PR DESCRIPTION
## Summary
- Swap Command (Super) and Control keys on tristons-nixbook using keyd
- Operates at kernel evdev level so it works in Wayland, X11, and TTY
- MacBook Command key position now acts as Ctrl for familiar muscle memory