### PR TITLE
Fix XWayland eager startup for NVIDIA Wayland

### DIFF
--- a/modules/system/desktop.nix
+++ b/modules/system/desktop.nix
@@ -29,6 +29,23 @@ in
     services.displayManager.sddm.enable = true;
     services.desktopManager.plasma6.enable = true;
 
+    # Force XWayland to start eagerly at login so DISPLAY is always set.
+    # Without this, NVIDIA proprietary drivers leave XWayland on-demand,
+    # causing Qt apps with hardcoded QT_QPA_PLATFORM=xcb to crash.
+    systemd.tmpfiles.rules = [
+      "d /tmp/.X11-unix 1777 root root -"
+    ];
+    systemd.user.services.xwayland-init = {
+      description = "Force XWayland initialization";
+      wantedBy = [ "graphical-session.target" ];
+      after = [ "plasma-kwin_wayland.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.xorg.xdpyinfo}/bin/xdpyinfo -display :0";
+        SuccessExitStatus = "0 1";
+      };
+    };
+
     # Sound configuration with PipeWire
     services.pulseaudio.enable = mkIf cfg.enableSound false;
     security.rtkit.enable = mkIf cfg.enableSound true;


### PR DESCRIPTION
## Summary
- Force XWayland to initialize at login via a systemd user service that runs `xdpyinfo -display :0`
- Ensures `/tmp/.X11-unix` exists via tmpfiles rule
- Fixes Qt apps crashing with SIGABRT on NVIDIA Wayland where XWayland starts on-demand and DISPLAY is unset

## Context
NVIDIA proprietary drivers leave XWayland on-demand in Plasma 6, so `DISPLAY` is never set until an X11 client connects. Many Qt apps (emulators, etc.) have wrappers that hardcode `QT_QPA_PLATFORM=xcb`, which crashes without a valid DISPLAY.

## Test plan
- [ ] Rebuild david and verify SDDM/Plasma starts normally
- [ ] Confirm `DISPLAY` is set in the Plasma session after login
- [ ] Launch dolphin-emu and other Qt emulators from the desktop