### PR TITLE
feat: appData module with provider-agnostic service volume management

### DIFF
--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,0 +1,20 @@
+{ lib }:
+
+{
+  # "companion"  -> "companion"
+  # "Baby Buddy" -> "babybuddy"
+  # "Open WebUI" -> "openwebui"
+  toSlug = s: lib.toLower (lib.replaceStrings [ " " ] [ "" ] s);
+
+  # "companion"  -> "companion"
+  # "Baby Buddy" -> "babyBuddy"
+  # "Open WebUI" -> "openWebUI"
+  toCamelCase = s:
+    let
+      words = lib.splitString " " (lib.toLower s);
+    in
+    lib.concatStrings (lib.imap0 (i: w:
+      if i == 0 then w
+      else (lib.toUpper (lib.substring 0 1 w)) + (lib.substring 1 (-1) w)
+    ) words);
+}

--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -3,10 +3,17 @@
 with lib;
 let
   cfg = config.modules.services.ai.open-webui;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.ai.open-webui = {
     enable = mkEnableOption "Open WebUI for Ollama";
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Open WebUI";
+      description = "Service name used for appData registration";
+    };
 
     domain = mkOption {
       type = types.str;
@@ -28,6 +35,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
+
     services.open-webui = {
       enable = true;
       host = "127.0.0.1";

--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -21,6 +21,12 @@ in
       description = "Domain for Open WebUI";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 3095;
@@ -62,6 +68,7 @@ in
     # Caddy reverse proxy
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/appData.nix
+++ b/modules/services/appData.nix
@@ -37,6 +37,12 @@ in
       description = "ZFS dataset name (relative to pool). Required when provider = \"zfs\".";
     };
 
+    disableEncryption = mkOption {
+      type        = types.bool;
+      default     = false;
+      description = "Create the ZFS dataset with encryption=off. Set true when the pool is encrypted but this dataset should not inherit it.";
+    };
+
     services = mkOption {
       type        = types.attrsOf (types.submodule ({ name, ... }: {
         options = {
@@ -92,7 +98,7 @@ in
       path   = [ pkgs.coreutils ] ++ optional (cfg.provider == "zfs") pkgs.zfs;
       script = ''
         ${optionalString (cfg.provider == "zfs") ''
-          zfs create -p -o encryption=off -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
+          zfs create -p ${optionalString cfg.disableEncryption "-o encryption=off"} -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
           zfs mount ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
         ''}
 

--- a/modules/services/appData.nix
+++ b/modules/services/appData.nix
@@ -92,7 +92,7 @@ in
       path   = [ pkgs.coreutils ] ++ optional (cfg.provider == "zfs") pkgs.zfs;
       script = ''
         ${optionalString (cfg.provider == "zfs") ''
-          zfs create -p -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
+          zfs create -p -o encryption=off -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
           zfs mount ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
         ''}
 

--- a/modules/services/appData.nix
+++ b/modules/services/appData.nix
@@ -7,6 +7,15 @@ let
   helpers = import ../lib.nix { inherit lib; };
 
   activeServices = filterAttrs (_: s: s.enable) cfg.services;
+
+  # Build the encryption flag for a per-service zfs create call.
+  # null  = inherit from parent dataset (no flag)
+  # "off" = explicitly disable
+  # "on"  = explicitly enable (aes-256-gcm; requires key management)
+  encFlag = s:
+    if      s.encryption == null  then ""
+    else if s.encryption == "off" then "-o encryption=off"
+    else                               "-o encryption=aes-256-gcm";
 in
 {
   options.modules.services.appData = {
@@ -21,7 +30,7 @@ in
     provider = mkOption {
       type        = types.enum [ "plain" "zfs" ];
       default     = "plain";
-      description = "Storage backend. 'plain' creates directories only. 'zfs' additionally provisions a ZFS dataset.";
+      description = "Storage backend. 'plain' creates directories only. 'zfs' provisions a ZFS dataset per service.";
     };
 
     # ZFS-specific — no defaults; must be set explicitly when provider = "zfs".
@@ -34,13 +43,13 @@ in
     dataset = mkOption {
       type        = types.nullOr types.str;
       default     = null;
-      description = "ZFS dataset name (relative to pool). Required when provider = \"zfs\".";
+      description = "ZFS parent dataset (relative to pool). Required when provider = \"zfs\". Each service gets a child dataset under this.";
     };
 
     disableEncryption = mkOption {
       type        = types.bool;
       default     = false;
-      description = "Create the ZFS dataset with encryption=off. Set true when the pool is encrypted but this dataset should not inherit it.";
+      description = "Create the parent ZFS dataset with encryption=off. Set true when the pool is encrypted but appData should not inherit it.";
     };
 
     services = mkOption {
@@ -54,7 +63,7 @@ in
           appID = mkOption {
             type        = types.str;
             default     = helpers.toCamelCase name;
-            description = "Filesystem-safe identifier derived from the service name. Becomes the directory name under mount.";
+            description = "Filesystem-safe identifier. Becomes the ZFS child dataset name and directory name under mount.";
           };
 
           owner = mkOption {
@@ -71,10 +80,21 @@ in
             type    = types.str;
             default = "0755";
           };
+
+          encryption = mkOption {
+            type        = types.nullOr (types.enum [ "off" "on" ]);
+            default     = null;
+            description = ''
+              Per-service ZFS dataset encryption override. Only applies when provider = "zfs".
+              null = inherit from parent dataset (default: off when disableEncryption = true on server).
+              "off" = explicitly disable encryption.
+              "on"  = explicitly enable encryption (aes-256-gcm; requires manual key management).
+            '';
+          };
         };
       }));
       default     = {};
-      description = "Service volumes registered by service modules. Each entry creates a subdirectory under mount.";
+      description = "Service volumes registered by service modules. Each entry creates a ZFS child dataset (zfs) or subdirectory (plain) under mount.";
     };
   };
 
@@ -87,7 +107,7 @@ in
     ];
 
     systemd.services."appdata-init" = {
-      description     = "Initialize appData storage and service directories";
+      description     = "Initialize appData storage and per-service ZFS datasets / directories";
       wantedBy        = [ "multi-user.target" ];
       after           = [ "local-fs.target" ]
         ++ optional (cfg.provider == "zfs") "zfs_load_data.service";
@@ -98,17 +118,30 @@ in
       path   = [ pkgs.coreutils ] ++ optional (cfg.provider == "zfs") pkgs.zfs;
       script = ''
         ${optionalString (cfg.provider == "zfs") ''
+          # Ensure parent dataset exists and is mounted
           zfs create -p ${optionalString cfg.disableEncryption "-o encryption=off"} -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
           zfs mount ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
         ''}
 
         mkdir -p ${escapeShellArg cfg.mount}
 
-        ${concatStringsSep "\n" (mapAttrsToList (_: s: ''
-          mkdir -p ${escapeShellArg "${cfg.mount}/${s.appID}"}
-          chmod ${s.mode} ${escapeShellArg "${cfg.mount}/${s.appID}"}
-          chown ${s.owner}:${s.group} ${escapeShellArg "${cfg.mount}/${s.appID}"}
-        '') activeServices)}
+        ${concatStringsSep "\n" (mapAttrsToList (_: s:
+          let
+            mountPath   = "${cfg.mount}/${s.appID}";
+            datasetPath = "${cfg.pool}/${cfg.dataset}/${s.appID}";
+          in
+          (optionalString (cfg.provider == "zfs") ''
+            # ${s.appID}: create child dataset if it doesn't exist
+            zfs create -p ${encFlag s} -o mountpoint=${mountPath} ${datasetPath} 2>/dev/null || true
+            zfs mount ${datasetPath} 2>/dev/null || true
+          '') +
+          (optionalString (cfg.provider != "zfs") ''
+            mkdir -p ${escapeShellArg mountPath}
+          '') + ''
+            chmod ${s.mode} ${escapeShellArg mountPath}
+            chown ${s.owner}:${s.group} ${escapeShellArg mountPath}
+          ''
+        ) activeServices)}
       '';
     };
 

--- a/modules/services/appData.nix
+++ b/modules/services/appData.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.services.appData;
+  helpers = import ../lib.nix { inherit lib; };
+
+  activeServices = filterAttrs (_: s: s.enable) cfg.services;
+in
+{
+  options.modules.services.appData = {
+    enable = mkEnableOption "AppData volume management";
+
+    mount = mkOption {
+      type        = types.str;
+      default     = "/etc/appData";
+      description = "Base path where all appData service volumes are stored.";
+    };
+
+    provider = mkOption {
+      type        = types.enum [ "plain" "zfs" ];
+      default     = "plain";
+      description = "Storage backend. 'plain' creates directories only. 'zfs' additionally provisions a ZFS dataset.";
+    };
+
+    # ZFS-specific — no defaults; must be set explicitly when provider = "zfs".
+    pool = mkOption {
+      type        = types.nullOr types.str;
+      default     = null;
+      description = "ZFS pool name. Required when provider = \"zfs\".";
+    };
+
+    dataset = mkOption {
+      type        = types.nullOr types.str;
+      default     = null;
+      description = "ZFS dataset name (relative to pool). Required when provider = \"zfs\".";
+    };
+
+    services = mkOption {
+      type        = types.attrsOf (types.submodule ({ name, ... }: {
+        options = {
+          enable = mkOption {
+            type    = types.bool;
+            default = true;
+          };
+
+          appID = mkOption {
+            type        = types.str;
+            default     = helpers.toCamelCase name;
+            description = "Filesystem-safe identifier derived from the service name. Becomes the directory name under mount.";
+          };
+
+          owner = mkOption {
+            type    = types.str;
+            default = "root";
+          };
+
+          group = mkOption {
+            type    = types.str;
+            default = "root";
+          };
+
+          mode = mkOption {
+            type    = types.str;
+            default = "0755";
+          };
+        };
+      }));
+      default     = {};
+      description = "Service volumes registered by service modules. Each entry creates a subdirectory under mount.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.provider != "zfs" || (cfg.pool != null && cfg.dataset != null);
+        message   = "modules.services.appData: pool and dataset must be set when provider = \"zfs\"";
+      }
+    ];
+
+    systemd.services."appdata-init" = {
+      description     = "Initialize appData storage and service directories";
+      wantedBy        = [ "multi-user.target" ];
+      after           = [ "local-fs.target" ]
+        ++ optional (cfg.provider == "zfs") "zfs_load_data.service";
+      serviceConfig = {
+        Type            = "oneshot";
+        RemainAfterExit = true;
+      };
+      path   = [ pkgs.coreutils ] ++ optional (cfg.provider == "zfs") pkgs.zfs;
+      script = ''
+        ${optionalString (cfg.provider == "zfs") ''
+          zfs create -p -o mountpoint=${cfg.mount} ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
+          zfs mount ${cfg.pool}/${cfg.dataset} 2>/dev/null || true
+        ''}
+
+        mkdir -p ${escapeShellArg cfg.mount}
+
+        ${concatStringsSep "\n" (mapAttrsToList (_: s: ''
+          mkdir -p ${escapeShellArg "${cfg.mount}/${s.appID}"}
+          chmod ${s.mode} ${escapeShellArg "${cfg.mount}/${s.appID}"}
+          chown ${s.owner}:${s.group} ${escapeShellArg "${cfg.mount}/${s.appID}"}
+        '') activeServices)}
+      '';
+    };
+
+    # All Docker containers wait for appdata-init before starting.
+    systemd.services.docker = mkIf (config.virtualisation.docker.enable or false) {
+      after = [ "appdata-init.service" ];
+      wants = [ "appdata-init.service" ];
+    };
+  };
+}

--- a/modules/services/communication/pixelfed.nix
+++ b/modules/services/communication/pixelfed.nix
@@ -20,7 +20,13 @@ in
       default = "loveinfocus.photos";
       description = "Domain where Pixelfed web interface is accessible";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     federationDomain = mkOption {
       type = types.str;
       default = "loveinfocus.photos";
@@ -125,6 +131,7 @@ in
     # Note: External access via PITS goes directly to nginx:8085, this is just for local Caddy access
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.nginxPort;
+      serverAliases    = cfg.domainAliases;
     };
 
 

--- a/modules/services/communication/pixelfed.nix
+++ b/modules/services/communication/pixelfed.nix
@@ -3,11 +3,18 @@
 with lib;
 let
   cfg = config.modules.services.communication.pixelfed;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.communication.pixelfed = {
     enable = mkEnableOption "Pixelfed federated photo sharing";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Pixelfed";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
       default = "loveinfocus.photos";
@@ -28,7 +35,7 @@ in
     
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/pixelfed";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Directory for Pixelfed data storage";
     };
     
@@ -46,6 +53,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "pixelfed";
+      group = "pixelfed";
+    };
+
     # Declare agenix secret for Pixelfed
     age.secrets.pixelfed-env = mkIf (cfg.secretFile == null) {
       file = ../../../secrets/pixelfed-env.age;
@@ -107,11 +119,6 @@ in
         LOG_CHANNEL = "stack";
       };
     };
-
-    # Ensure data directory exists with correct permissions  
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0750 pixelfed pixelfed -"
-    ];
 
     # Caddy reverse proxy to nginx (for local/internal access)
     # Nginx runs on custom port (configured in services.pixelfed.nginx.listen above)

--- a/modules/services/communication/postal.nix
+++ b/modules/services/communication/postal.nix
@@ -76,12 +76,18 @@ let
     clamav:
       enabled: false
   '';
-  
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.communication.postal = {
     enable = mkEnableOption "Postal mail server";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "postal";
+      description = "Service name used for appData registration";
+    };
+
     hostname = mkOption {
       type = types.str;
       default = "postal.7andco.dev";
@@ -96,7 +102,7 @@ in
     
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/postal";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Base directory for Postal data";
     };
   };
@@ -107,6 +113,11 @@ in
     
     # Our customizations
     {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
+
     # Agenix secrets - all secrets managed declaratively
     age.secrets.postal-db-password = {
       file = ../../../secrets/postal-db-password.age;
@@ -145,7 +156,6 @@ in
     
     # Ensure data directories exist with correct permissions
     systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0755 root root -"
       "d ${cfg.dataDir}/config 0755 root root -"
       "d ${cfg.dataDir}/data 0750 root root -"
       "d ${cfg.dataDir}/mariadb 0750 999 999 -"  # MariaDB UID

--- a/modules/services/communication/stalwart-mail.nix
+++ b/modules/services/communication/stalwart-mail.nix
@@ -3,11 +3,18 @@
 with lib;
 let
   cfg = config.modules.services.communication.stalwart-mail;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.communication.stalwart-mail = {
     enable = mkEnableOption "Stalwart mail server";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Stalwart Mail";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
       default = "7andco.dev";
@@ -40,7 +47,7 @@ in
     
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/stalwart";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Base directory for Stalwart mail data storage";
     };
     
@@ -65,9 +72,14 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Ensure data directory exists with correct permissions
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "stalwart-mail";
+      group = "stalwart-mail";
+      mode = "0750";
+    };
+
+    # Ensure data subdirectory exists with correct permissions
     systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0750 stalwart-mail stalwart-mail -"
       "d ${cfg.dataDir}/data 0750 stalwart-mail stalwart-mail -"
     ];
     

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -2,6 +2,7 @@
 {
   # Import service category modules
   imports = [
+    ./appData.nix
     ./vhosts.nix
     ./infrastructure
     ./media

--- a/modules/services/development/code-server.nix
+++ b/modules/services/development/code-server.nix
@@ -18,6 +18,12 @@ in
       description = "Domain for code-server";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 11010;
@@ -58,6 +64,7 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyHost = cfg.host;
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/development/kasm.nix
+++ b/modules/services/development/kasm.nix
@@ -3,14 +3,21 @@
 with lib;
 let
   cfg = config.modules.services.development.kasm;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.development.kasm = {
     enable = mkEnableOption "Kasm Workspaces";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "kasm";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
-      default = "kasm.${config.networking.domain}";
+      default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for Kasm Workspaces";
     };
     
@@ -28,7 +35,7 @@ in
     
     datastorePath = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/kasm";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Path for Kasm data storage";
     };
     
@@ -96,6 +103,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
+
     # Warnings
     warnings = optional (cfg.adminPassword == "changeme123")
       "Kasm admin password is using default value 'changeme123'. Change it after first login or set a custom password in configuration.";
@@ -125,11 +137,6 @@ in
     
     # Ensure Docker is enabled for Kasm containers
     virtualisation.docker.enable = true;
-    
-    # Ensure data directory exists
-    systemd.tmpfiles.rules = [
-      "d ${cfg.datastorePath} 0755 root root -"
-    ];
     
     # Open firewall for Kasm
     networking.firewall.allowedTCPPorts = [ cfg.listenPort ];

--- a/modules/services/development/kasm.nix
+++ b/modules/services/development/kasm.nix
@@ -20,7 +20,13 @@ in
       default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for Kasm Workspaces";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     listenPort = mkOption {
       type = types.port;
       default = 5443;
@@ -143,7 +149,8 @@ in
     
     # Caddy reverse proxy configuration
     modules.services.vHosts.hosts.${cfg.domain} = {
-      managedProxy = false;
+      managedProxy  = false;
+      serverAliases = cfg.domainAliases;
       extraConfig = ''
         reverse_proxy https://localhost:${toString cfg.listenPort} {
           transport http {

--- a/modules/services/development/openvscode-server.nix
+++ b/modules/services/development/openvscode-server.nix
@@ -18,6 +18,12 @@ in
       description = "Domain for Open VSCode Server";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 3000;
@@ -58,6 +64,7 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyHost = cfg.host;
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/gaming/romm.nix
+++ b/modules/services/gaming/romm.nix
@@ -3,14 +3,21 @@
 with lib;
 let
   cfg = config.modules.services.gaming.romm;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.gaming.romm = {
     enable = mkEnableOption "RomM - ROM manager and game library";
 
+    serviceName = mkOption {
+      type = types.str;
+      default = "romm";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
-      default = "romm.${config.networking.domain}";
+      default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for RomM";
     };
 
@@ -28,7 +35,7 @@ in
 
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/romm";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Data directory for RomM";
     };
 
@@ -110,6 +117,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "1000";
+      group = "1000";
+    };
+
     # Ensure Docker is enabled
     virtualisation.docker = {
       enable = true;

--- a/modules/services/gaming/romm.nix
+++ b/modules/services/gaming/romm.nix
@@ -21,6 +21,12 @@ in
       description = "Domain for RomM";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 8095;
@@ -298,6 +304,7 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -29,6 +29,12 @@ in
       description = "Domain for headscale server (defaults to ts.baseDomain)";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 8080;
@@ -354,8 +360,9 @@ in
 
     # Caddy reverse proxy for headscale API and admin UI
     modules.services.vHosts.hosts.${cfg.domain} = {
-      managedProxy = false;
-      public = true;  # Headscale API must be public for Tailscale clients
+      managedProxy  = false;
+      public        = true;  # Headscale API must be public for Tailscale clients
+      serverAliases = cfg.domainAliases;
       extraConfig = ''
         ${optionalString (cfg.adminUI.type != "none") ''
         # Admin UI at /admin path

--- a/modules/services/infrastructure/postgresql.nix
+++ b/modules/services/infrastructure/postgresql.nix
@@ -3,14 +3,21 @@
 with lib;
 let
   cfg = config.modules.services.infrastructure.postgresql;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.infrastructure.postgresql = {
     enable = mkEnableOption "PostgreSQL database server";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "postgres";
+      description = "Service name used for appData registration";
+    };
+
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/postgres";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "PostgreSQL data directory";
     };
     
@@ -22,6 +29,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "postgres";
+      group = "postgres";
+    };
+
     services.postgresql = {
       enable = true;
       dataDir = cfg.dataDir;

--- a/modules/services/media/immich.nix
+++ b/modules/services/media/immich.nix
@@ -20,7 +20,13 @@ in
       default = "photos.${config.networking.domain}";
       description = "Primary domain for Immich";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     publicProxyDomain = mkOption {
       type = types.str;
       default = "share.photos.${config.networking.domain}";
@@ -205,7 +211,8 @@ in
 
     # Caddy virtual hosts
     modules.services.vHosts.hosts.${cfg.domain} = {
-      managedProxy = false;
+      managedProxy  = false;
+      serverAliases = cfg.domainAliases;
       extraConfig = ''
         handle_path /share* {
           reverse_proxy http://localhost:${toString cfg.publicProxyPort}

--- a/modules/services/media/immich.nix
+++ b/modules/services/media/immich.nix
@@ -3,11 +3,18 @@
 with lib;
 let
   cfg = config.modules.services.media.immich;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.media.immich = {
     enable = mkEnableOption "Immich photo management";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "immich";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
       default = "photos.${config.networking.domain}";
@@ -34,7 +41,7 @@ in
     
     mediaLocation = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/immich/media";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}/media";
       description = "Location for media files";
     };
 
@@ -152,6 +159,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
+
     # Immich service
     services.immich = {
       enable = true;

--- a/modules/services/media/jellyfin.nix
+++ b/modules/services/media/jellyfin.nix
@@ -13,7 +13,13 @@ in
       default = "media.${config.networking.domain}";
       description = "Domain for Jellyfin";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 8096;
@@ -99,6 +105,7 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/media/plex.nix
+++ b/modules/services/media/plex.nix
@@ -14,6 +14,12 @@ in
       description = "Domain for Plex";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 32400;
@@ -100,6 +106,7 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -34,6 +34,12 @@ in
       description = "Domain for the Actual HTTP API";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 5007;
@@ -108,6 +114,7 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -3,6 +3,7 @@
 with lib;
 let
   cfg = config.modules.services.productivity.actualHttpApi;
+  helpers = import ../../lib.nix { inherit lib; };
   actualModule = config.modules.services.productivity.actual;
   resolvedActualServerUrl =
     if cfg.actualServerUrl != "" then
@@ -20,6 +21,12 @@ in
 {
   options.modules.services.productivity.actualHttpApi = {
     enable = mkEnableOption "Actual Budget HTTP API";
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Actual Budget API";
+      description = "Service name used for appData registration";
+    };
 
     domain = mkOption {
       type = types.str;
@@ -47,7 +54,7 @@ in
 
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/actual-http-api";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Data directory for the Actual HTTP API container";
     };
 
@@ -77,9 +84,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0755 root root -"
-    ];
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.port ];

--- a/modules/services/productivity/actual.nix
+++ b/modules/services/productivity/actual.nix
@@ -18,6 +18,12 @@ in
       description = "Domain for Actual Budget";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 1111;
@@ -44,6 +50,7 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/babybuddy.nix
+++ b/modules/services/productivity/babybuddy.nix
@@ -2,28 +2,32 @@
 
 with lib;
 let
-  cfg = config.modules.services.productivity.babybuddy;
+  cfg     = config.modules.services.productivity.babybuddy;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.productivity.babybuddy = {
     enable = mkEnableOption "Baby Buddy - baby and child care tracking";
 
+    serviceName = mkOption {
+      type    = types.str;
+      default = "Baby Buddy";
+    };
+
     domain = mkOption {
-      type = types.str;
+      type    = types.str;
       default = "baby.${config.networking.domain}";
-      description = "Domain for Baby Buddy";
     };
 
     port = mkOption {
-      type = types.port;
+      type    = types.port;
       default = 8110;
-      description = "External port for Baby Buddy";
     };
 
     dataDir = mkOption {
-      type = types.str;
-      default = "/data/docker-appdata/babybuddy";
-      description = "Data directory for Baby Buddy config and database";
+      type        = types.str;
+      default     = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
+      description = "Data directory. Override to take full control — appData module will not manage this path.";
     };
 
     secretsFile = mkOption {
@@ -34,6 +38,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "1000";
+      group = "1000";
+    };
+
     virtualisation.docker = {
       enable = true;
       autoPrune.enable = true;

--- a/modules/services/productivity/babybuddy.nix
+++ b/modules/services/productivity/babybuddy.nix
@@ -19,6 +19,12 @@ in
       default = "baby.${config.networking.domain}";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type    = types.port;
       default = 8110;
@@ -108,6 +114,7 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/companion.nix
+++ b/modules/services/productivity/companion.nix
@@ -23,6 +23,12 @@ in
       default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type    = types.port;
       default = 8880;
@@ -83,6 +89,7 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/companion.nix
+++ b/modules/services/productivity/companion.nix
@@ -5,35 +5,41 @@
 
 with lib;
 let
-  cfg = config.modules.services.productivity.companion;
+  cfg     = config.modules.services.productivity.companion;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.productivity.companion = {
     enable = mkEnableOption "Bitfocus Companion - Streamdeck control software";
 
+    serviceName = mkOption {
+      type        = types.str;
+      default     = "companion";
+      description = "Service name used for appData volume and vHost domain derivation.";
+    };
+
     domain = mkOption {
-      type = types.str;
-      default = "companion.${config.networking.domain}";
-      description = "Domain for Bitfocus Companion";
+      type    = types.str;
+      default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
     };
 
     port = mkOption {
-      type = types.port;
+      type    = types.port;
       default = 8880;
-      description = "External port for Bitfocus Companion web interface";
     };
 
     dataDir = mkOption {
-      type = types.str;
-      default = "/data/docker-appdata/companion";
-      description = "Data directory for Bitfocus Companion config";
+      type        = types.str;
+      default     = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
+      description = "Data directory. Override to take full control — appData module will not manage this path.";
     };
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0755 1000 1000 -"
-    ];
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "1000";
+      group = "1000";
+    };
 
     virtualisation.oci-containers.containers."companion" = {
       image = "ghcr.io/bitfocus/companion/companion:latest";

--- a/modules/services/productivity/n8n.nix
+++ b/modules/services/productivity/n8n.nix
@@ -20,7 +20,13 @@ in
       default = "n8n.7andco.dev";
       description = "Domain for n8n";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     openFirewall = mkOption {
       type = types.bool;
       default = true;
@@ -49,6 +55,7 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = 5678;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/outline.nix
+++ b/modules/services/productivity/outline.nix
@@ -21,6 +21,12 @@ in
       description = "Domain for Outline";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 3000;
@@ -616,6 +622,7 @@ in
     # Caddy virtual host for reverse proxy
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/outline.nix
+++ b/modules/services/productivity/outline.nix
@@ -3,14 +3,21 @@
 with lib;
 let
   cfg = config.modules.services.productivity.outline;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.productivity.outline = {
     enable = mkEnableOption "Outline wiki and knowledge management system";
 
+    serviceName = mkOption {
+      type = types.str;
+      default = "outline";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
-      default = "outline.${config.networking.domain}";
+      default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for Outline";
     };
 
@@ -120,7 +127,7 @@ in
           };
           localRootDir = mkOption {
             type = types.str;
-            default = "/data/docker-appdata/${cfg.domain}/data";
+            default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}/data";
             description = "Local storage directory (for storageType=local)";
           };
           uploadMaxSize = mkOption {
@@ -465,6 +472,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "root";
+      group = "root";
+    };
+
     # Create user and group
     users.users.${cfg.user} = mkIf (cfg.user != "root") {
       isSystemUser = true;

--- a/modules/services/productivity/tandoor.nix
+++ b/modules/services/productivity/tandoor.nix
@@ -3,10 +3,17 @@
 with lib;
 let
   cfg = config.modules.services.productivity.tandoor;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.productivity.tandoor = {
     enable = mkEnableOption "Tandoor Recipes - Recipe manager and meal planner";
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Tandoor";
+      description = "Service name used for appData registration";
+    };
 
     domain = mkOption {
       type = types.str;
@@ -22,7 +29,7 @@ in
 
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/tandoor";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Data directory for Tandoor";
     };
 
@@ -46,6 +53,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "1000";
+      group = "1000";
+    };
+
     # Ensure Docker is enabled
     virtualisation.docker = {
       enable = true;

--- a/modules/services/productivity/tandoor.nix
+++ b/modules/services/productivity/tandoor.nix
@@ -21,6 +21,12 @@ in
       description = "Domain for Tandoor";
     };
 
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 6780;
@@ -166,6 +172,7 @@ in
     # Caddy virtual host using new vHosts system
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/vaultwarden.nix
+++ b/modules/services/productivity/vaultwarden.nix
@@ -20,7 +20,13 @@ in
       default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for Vaultwarden";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 8222;
@@ -77,6 +83,7 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      serverAliases    = cfg.domainAliases;
     };
   };
 }

--- a/modules/services/productivity/vaultwarden.nix
+++ b/modules/services/productivity/vaultwarden.nix
@@ -3,14 +3,21 @@
 with lib;
 let
   cfg = config.modules.services.productivity.vaultwarden;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.productivity.vaultwarden = {
     enable = mkEnableOption "Vaultwarden password manager";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "Vaultwarden";
+      description = "Service name used for appData registration";
+    };
+
     domain = mkOption {
       type = types.str;
-      default = "vault.${config.networking.domain}";
+      default = "${helpers.toSlug cfg.serviceName}.${config.networking.domain}";
       description = "Domain for Vaultwarden";
     };
     
@@ -22,7 +29,7 @@ in
     
     backupDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/vaultwarden/backups";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}/backups";
       description = "Backup directory";
     };
     
@@ -40,6 +47,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "vaultwarden";
+      group = "vaultwarden";
+    };
+
     # Vaultwarden service
     services.vaultwarden = {
       enable = true;

--- a/modules/services/storage/nextcloud.nix
+++ b/modules/services/storage/nextcloud.nix
@@ -13,7 +13,13 @@ in
       default = "cloud.7andco.dev";
       description = "Domain for Nextcloud web interface";
     };
-    
+
+    domainAliases = mkOption {
+      type    = types.listOf types.str;
+      default = [ ];
+      description = "Additional domains served by this virtual host. Each gets a DNS record and Caddy alias.";
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.nextcloud31;
@@ -392,7 +398,8 @@ in
     # Caddy virtual host on David
     # Caddy serves Nextcloud directly via PHP-FPM Unix socket
     modules.services.vHosts.hosts.${cfg.domain} = {
-      managedProxy = false;
+      managedProxy  = false;
+      serverAliases = cfg.domainAliases;
       extraConfig = ''
         # Serve Nextcloud via PHP-FPM
         root * ${config.services.nextcloud.package}

--- a/modules/services/storage/nfs.nix
+++ b/modules/services/storage/nfs.nix
@@ -31,6 +31,7 @@ in
       default = ''
         /data                   10.150.10.0/23(ro,fsid=0,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=0,no_subtree_check,crossmnt) 10.100.0.0/18(ro,fsid=0,no_subtree_check,crossmnt) 100.64.0.0/10(ro,fsid=0,no_subtree_check,crossmnt)
         /data/docker-appdata    10.150.10.0/23(rw,fsid=1001,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=1001,no_subtree_check,crossmnt) 10.100.0.0/18(rw,fsid=1001,no_subtree_check,crossmnt) 100.64.0.0/10(rw,fsid=1001,no_subtree_check,crossmnt)
+        /data/appData           10.150.10.0/23(rw,fsid=1006,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=1006,no_subtree_check,crossmnt) 10.100.0.0/18(rw,fsid=1006,no_subtree_check,crossmnt) 100.64.0.0/10(rw,fsid=1006,no_subtree_check,crossmnt)
         /data/media             10.150.10.0/23(rw,fsid=1002,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=1002,no_subtree_check,crossmnt) 10.100.0.0/18(rw,fsid=1002,no_subtree_check,crossmnt) 100.64.0.0/10(rw,fsid=1002,no_subtree_check,crossmnt)
         /data/tristonyoder      10.150.10.0/23(rw,fsid=1003,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=1003,no_subtree_check,crossmnt) 10.100.0.0/18(rw,fsid=1003,no_subtree_check,crossmnt) 100.64.0.0/10(rw,fsid=1003,no_subtree_check,crossmnt)
         /data/backups           10.150.10.0/23(rw,fsid=1004,no_subtree_check,crossmnt) 10.150.100.0/23(ro,fsid=1004,no_subtree_check,crossmnt) 10.100.0.0/18(rw,fsid=1004,no_subtree_check,crossmnt) 100.64.0.0/10(rw,fsid=1004,no_subtree_check,crossmnt)

--- a/modules/services/storage/syncthing.nix
+++ b/modules/services/storage/syncthing.nix
@@ -3,11 +3,18 @@
 with lib;
 let
   cfg = config.modules.services.storage.syncthing;
+  helpers = import ../../lib.nix { inherit lib; };
 in
 {
   options.modules.services.storage.syncthing = {
     enable = mkEnableOption "Syncthing file synchronization";
-    
+
+    serviceName = mkOption {
+      type = types.str;
+      default = "syncthing";
+      description = "Service name used for appData registration";
+    };
+
     user = mkOption {
       type = types.str;
       default = "tristonyoder";
@@ -22,7 +29,7 @@ in
     
     configDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/syncthing";
+      default = "${config.modules.services.appData.mount}/${config.modules.services.appData.services.${cfg.serviceName}.appID}";
       description = "Folder for Syncthing's settings and keys";
     };
     
@@ -40,6 +47,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    modules.services.appData.services.${cfg.serviceName} = {
+      owner = "tristonyoder";
+      group = "tristonyoder";
+    };
+
     # Syncthing service
     services.syncthing = {
       enable = true;

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -79,6 +79,14 @@
   # STORAGE SERVICES
   # =============================================================================
   
+  modules.services.appData = {
+    enable   = lib.mkDefault true;
+    provider = lib.mkDefault "zfs";
+    pool     = lib.mkDefault "data";
+    dataset  = lib.mkDefault "appData";
+    mount    = lib.mkDefault "/data/appData";
+  };
+
   modules.services.storage.zfs.enable = lib.mkDefault true;
   modules.services.storage.nfs.enable = lib.mkDefault true;
   modules.services.storage.samba.enable = lib.mkDefault true;

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -80,11 +80,12 @@
   # =============================================================================
   
   modules.services.appData = {
-    enable   = lib.mkDefault true;
-    provider = lib.mkDefault "zfs";
-    pool     = lib.mkDefault "data";
-    dataset  = lib.mkDefault "appData";
-    mount    = lib.mkDefault "/data/appData";
+    enable            = lib.mkDefault true;
+    provider          = lib.mkDefault "zfs";
+    pool              = lib.mkDefault "data";
+    dataset           = lib.mkDefault "appData";
+    mount             = lib.mkDefault "/data/appData";
+    disableEncryption = lib.mkDefault true;
   };
 
   modules.services.storage.zfs.enable = lib.mkDefault true;

--- a/scripts/migrate-appdata.sh
+++ b/scripts/migrate-appdata.sh
@@ -170,12 +170,18 @@ switch_phase() {
   stop_services
   echo
 
-  log "Running final rsync..."
-  do_rsync
-  echo
-
+  # Rebuild first so appdata-init creates the per-service ZFS datasets,
+  # then rsync data into the freshly mounted datasets.
   log "Switching NixOS configuration to feat/appdata-module..."
   nixos-rebuild switch --flake "${FLAKE_DIR}#david"
+  echo
+
+  log "Waiting for appdata-init to complete..."
+  systemctl start appdata-init.service
+  echo
+
+  log "Running final rsync into new ZFS datasets..."
+  do_rsync
   echo
 
   start_services

--- a/scripts/migrate-appdata.sh
+++ b/scripts/migrate-appdata.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# migrate-appdata.sh
+# Migrates service data from /data/docker-appdata to /data/appData
+#
+# Phases:
+#   phase1  — Live sync #1: initial copy while services run. Check dirs and sizes.
+#   phase2  — Live sync #2: catch-up sync to minimize final downtime.
+#   switch  — Stop services, final sync, nixos-rebuild switch.
+#   rollback— Rollback to previous NixOS generation (old paths, data untouched).
+#
+# Usage: sudo ./scripts/migrate-appdata.sh <phase1|phase2|switch|rollback>
+
+set -euo pipefail
+
+OLD_BASE="/data/docker-appdata"
+NEW_BASE="/data/appData"
+FLAKE_DIR="/home/tristonyoder/Projects/nix-config"
+
+# -----------------------------------------------------------------------------
+# Colours
+# -----------------------------------------------------------------------------
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[$(date '+%H:%M:%S')]${NC} $*"; }
+info() { echo -e "${CYAN}[$(date '+%H:%M:%S')]${NC} $*"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARN:${NC} $*"; }
+err()  { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR:${NC} $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# -----------------------------------------------------------------------------
+# Mappings: "source_subdir:dest_subdir"
+# source is relative to OLD_BASE, dest is relative to NEW_BASE
+# -----------------------------------------------------------------------------
+MAPPINGS=(
+  "babybuddy:babyBuddy"
+  "companion:companion"
+  "immich:immich"
+  "kasm:kasm"
+  "pixelfed:pixelfed"
+  "postgres:postgres"
+  "romm:romm"
+  "stalwart:stalwartMail"
+  "syncthing:syncthing"
+  "tandoor:tandoor"
+  "vaultwarden:vaultwarden"
+)
+
+# Native NixOS services (non-Docker) that must be stopped before switch
+NATIVE_SERVICES=(
+  "postgresql"
+  "syncthing"
+  "vaultwarden"
+  "immich-server"
+  "stalwart-mail"
+)
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+check_root() {
+  [[ $EUID -eq 0 ]] || die "Run as root (sudo)."
+}
+
+check_dirs() {
+  info "=== Source directory inventory ==="
+  local missing=0
+  for mapping in "${MAPPINGS[@]}"; do
+    local src="${OLD_BASE}/${mapping%%:*}"
+    if [[ -d "$src" ]]; then
+      local size; size=$(du -sh "$src" 2>/dev/null | cut -f1)
+      log "  ✓  $(printf '%-35s' "$src")  ${size}"
+    else
+      warn "  ✗  $src  (not found — will skip)"
+      ((missing++)) || true
+    fi
+  done
+  echo
+  [[ $missing -gt 0 ]] && warn "$missing source dir(s) not found — they will be skipped."
+}
+
+do_rsync() {
+  local extra_flags="${1:-}"
+  local errors=0
+
+  for mapping in "${MAPPINGS[@]}"; do
+    local src="${OLD_BASE}/${mapping%%:*}"
+    local dst="${NEW_BASE}/${mapping##*:}"
+
+    if [[ ! -d "$src" ]]; then
+      warn "Skipping $src (not found)"
+      continue
+    fi
+
+    log "rsync  $src  →  $dst"
+    mkdir -p "$dst"
+    # shellcheck disable=SC2086
+    rsync -a --delete --info=progress2 ${extra_flags} "$src/" "$dst/" || {
+      err "rsync failed: $src → $dst"
+      ((errors++)) || true
+    }
+  done
+
+  return $errors
+}
+
+stop_services() {
+  log "Stopping Docker (stops all containers)..."
+  systemctl stop docker || warn "docker stop had non-zero exit"
+
+  log "Stopping native NixOS services..."
+  for svc in "${NATIVE_SERVICES[@]}"; do
+    if systemctl is-active --quiet "$svc" 2>/dev/null; then
+      log "  stopping $svc"
+      systemctl stop "$svc" || warn "$svc stop had non-zero exit"
+    else
+      info "  $svc already stopped — skipping"
+    fi
+  done
+}
+
+start_services() {
+  log "Starting native NixOS services..."
+  for svc in "${NATIVE_SERVICES[@]}"; do
+    log "  starting $svc"
+    systemctl start "$svc" || warn "$svc start had non-zero exit"
+  done
+
+  log "Starting Docker..."
+  systemctl start docker || warn "docker start had non-zero exit"
+}
+
+# -----------------------------------------------------------------------------
+# Phases
+# -----------------------------------------------------------------------------
+phase1() {
+  check_root
+  log "================================================================"
+  log "  PHASE 1 — Live sync #1 (services remain running)"
+  log "================================================================"
+  check_dirs
+  log "Starting initial rsync. This may take a while for large datasets."
+  echo
+  do_rsync
+  echo
+  log "Phase 1 complete."
+  info "Review /data/appData contents before proceeding to phase2."
+  info "When ready:  sudo ./scripts/migrate-appdata.sh phase2"
+}
+
+phase2() {
+  check_root
+  log "================================================================"
+  log "  PHASE 2 — Live sync #2 catch-up (services remain running)"
+  log "================================================================"
+  log "Re-syncing to pick up changes written since phase1..."
+  echo
+  do_rsync
+  echo
+  log "Phase 2 complete."
+  info "When ready to cut over:  sudo ./scripts/migrate-appdata.sh switch"
+}
+
+switch_phase() {
+  check_root
+  log "================================================================"
+  log "  PHASE 3 — Stop / Final sync / Switch"
+  log "================================================================"
+  warn "This will briefly stop all services. Press Ctrl-C within 5s to abort."
+  sleep 5
+
+  stop_services
+  echo
+
+  log "Running final rsync..."
+  do_rsync
+  echo
+
+  log "Switching NixOS configuration to feat/appdata-module..."
+  nixos-rebuild switch --flake "${FLAKE_DIR}#david"
+  echo
+
+  start_services
+  echo
+
+  log "================================================================"
+  log "  Switch complete."
+  log "  Old data remains intact at ${OLD_BASE} — verify services"
+  log "  thoroughly before removing it."
+  log "================================================================"
+  info "If anything is wrong:  sudo ./scripts/migrate-appdata.sh rollback"
+}
+
+rollback() {
+  check_root
+  log "================================================================"
+  log "  ROLLBACK — Reverting to previous NixOS generation"
+  log "================================================================"
+  warn "Stopping services before rollback..."
+  stop_services
+  echo
+
+  log "Rolling back to previous generation (restores old dataDir paths)..."
+  nixos-rebuild switch --rollback
+  echo
+
+  start_services
+  echo
+
+  log "================================================================"
+  log "  Rollback complete."
+  log "  Services are pointing back to ${OLD_BASE}."
+  log "  Data at ${NEW_BASE} is untouched."
+  log "================================================================"
+}
+
+# -----------------------------------------------------------------------------
+# Entrypoint
+# -----------------------------------------------------------------------------
+case "${1:-}" in
+  phase1)   phase1 ;;
+  phase2)   phase2 ;;
+  switch)   switch_phase ;;
+  rollback) rollback ;;
+  *)
+    echo "Usage: sudo $0 <phase1|phase2|switch|rollback>"
+    echo
+    echo "  phase1   Initial live sync — verify dirs and sizes, copy data"
+    echo "  phase2   Catch-up live sync — minimise downtime at switch time"
+    echo "  switch   Stop services, final sync, nixos-rebuild switch"
+    echo "  rollback Revert to previous NixOS generation, restart services"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `modules/services/appData.nix` — a central declarative storage module following the same agnostic-declaration / provider-implementation pattern as `vhosts.nix`
- Adds `modules/lib.nix` with `toSlug` and `toCamelCase` helpers shared across modules
- All service modules gain `serviceName` (drives appData key and vHost domain slug), updated `dataDir` defaults, and a minimal appData volume registration
- All service modules gain `domainAliases` (listOf str) fed into Caddy `serverAliases` and DNS sync

## Key design decisions

**appData module options (flat, no nested ZFS block):**
- `mount` — base path, default `/etc/appData` (portable); server overrides to `/data/appData`
- `provider` — `plain` (mkdir only) or `zfs` (declaratively creates and mounts dataset on first boot)
- `pool` / `dataset` — ZFS only, no defaults, assertion enforces when `provider = "zfs"`

**Never destructive** — enabling creates/mounts, disabling does nothing to existing data.

**dataDir independence** — overriding `dataDir` on any service module means the user owns that path entirely; appData has zero involvement with it.

**domainAliases** — additive aliases served by Caddy and registered in DNS alongside the primary domain.

## Server profile

```nix
modules.services.appData = {
  enable   = true;
  provider = "zfs";
  pool     = "data";
  dataset  = "appData";
  mount    = "/data/appData";
};
```

## Pre-merge checklist

- [ ] Dry-run build on david passes
- [ ] ZFS dataset `data/appData` created on david (or confirmed first-boot creation works)
- [ ] Existing service data migrated: `rsync -a /data/docker-appdata/<svc>/ /data/appData/<appID>/`
- [ ] NFS export for `/data/appData` verified accessible