### PR TITLE
fix(plex): add SupplementaryGroups to service for DVR write access

### DIFF
--- a/modules/services/media/plex.nix
+++ b/modules/services/media/plex.nix
@@ -98,6 +98,10 @@ in
     users.groups.media = { };
     users.users.plex.extraGroups = [ "media" "video" "render" ];
 
+    # The plex package uses a bubblewrap FHS wrapper that drops supplementary groups
+    # from /etc/group. Explicitly set them here so DVR can write to media directories.
+    systemd.services.plex.serviceConfig.SupplementaryGroups = "media video render";
+
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
     };


### PR DESCRIPTION
## Problem

Plex DVR recordings were failing with **"No write access to destination"** for all shows since the `e17be79` setgid permissions change.

Root cause: the plex package wraps the server in a bubblewrap FHS environment, which drops supplementary groups. The running process ends up with only group `193` (plex) — missing `media` (970), `video` (26), and `render` (303).

Media directories are `2775 tristonyoder:media` (group-write, no world-write). Without the `media` group at runtime, Plex cannot write recording files, move grabs from `.grab/` staging to the library, or create new show directories.

Confirmed via:
- `/proc/3051/status` → `Groups: 193` (only plex, missing media/video/render)
- Plex logs: `Operation for '...' completed with status error (No write access to destination)`
- Database: all grabs since Mar 19 have `status=5` (failed); last successful recording was Mar 19 00:37, hours before the setgid rebuild

## Fix

Add `SupplementaryGroups = "media video render"` to the plex systemd service config. This bypasses the bwrap group-dropping issue and ensures the process has the groups it needs regardless of bwrap's behavior.