### PR TITLE
feat(darwin): switch to CLI tailscale with background daemon

### DIFF
--- a/home/tristonyoder-darwin.nix
+++ b/home/tristonyoder-darwin.nix
@@ -11,7 +11,6 @@
   home.packages = with pkgs; [
     # macOS-specific tools
     syncthing
-    tailscale
 
     # Emulators
     dolphin-emu  # GameCube and Wii emulator
@@ -204,7 +203,6 @@
       # System Utilities
       "hazel"
       "lunar"
-      "tailscale"
 
       # Virtualization
       "parallels"
@@ -292,6 +290,8 @@
       { id = "1559269364"; name = "Notion Web Clipper"; }
       { id = "1246969117"; name = "Steam Link"; }
       { id = "1295203466"; name = "Windows App"; }
+      { id = "6470928235"; name = "Manet Music"; }
+      { id = "6593660679"; name = "Streamyfin"; }
     ];
   };
 }

--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -38,6 +38,9 @@
   
   # nix-daemon is now managed unconditionally by nix-darwin when nix.enable is on
   
+  # Tailscale daemon (CLI mode, supports SSH and background operation)
+  services.tailscale.enable = true;
+
   # Enable Touch ID for sudo
   security.pam.services.sudo_local.touchIdAuth = true;
   


### PR DESCRIPTION
Replace homebrew cask and home.packages tailscale entry with `services.tailscale.enable = true` in the darwin profile.

## Why
- Only the CLI daemon (`tailscaled`) supports Tailscale SSH on macOS — both GUI variants (App Store and cask) explicitly do not
- Mirrors how tailscale is managed on Linux hosts

## Notes
- After rebuild, authenticate with: `sudo tailscale up --login-server=https://ts.theyoder.family --ssh`
- If upgrading an existing install, fully remove the old GUI app before rebuilding to avoid two daemons conflicting