### PR TITLE
fix(feishin): default serverLock to false to allow blank passwords

### DIFF
--- a/modules/services/media/feishin.nix
+++ b/modules/services/media/feishin.nix
@@ -56,7 +56,7 @@ in
 
     serverLock = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "When true and server name/type/url are set, only username/password can be toggled";
     };
   };


### PR DESCRIPTION
serverLock=true causes feishin to enforce a non-empty password field, breaking accounts with no Jellyfin password. Default to false.