### PR TITLE
fix(feishin): set serverName to music.<domain>

### DIFF
--- a/modules/services/media/feishin.nix
+++ b/modules/services/media/feishin.nix
@@ -28,7 +28,7 @@ in
 
     serverName = mkOption {
       type = types.str;
-      default = "feishin.${config.networking.domain}";
+      default = "music.${config.networking.domain}";
       description = "Pre-defined server name";
     };
 

--- a/modules/services/media/feishin.nix
+++ b/modules/services/media/feishin.nix
@@ -28,7 +28,7 @@ in
 
     serverName = mkOption {
       type = types.str;
-      default = "jellyfin";
+      default = "feishin.${config.networking.domain}";
       description = "Pre-defined server name";
     };
 


### PR DESCRIPTION
Default serverName to music.<domain> (the friendly alias) instead of the feishin subdomain.