### PR TITLE
feat: add beets music library organizer

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -55,6 +55,9 @@
   # Feishin - Web music player (Jellyfin/Navidrome/Subsonic client)
   modules.services.media.feishin.enable = true;
 
+  # Beets - Auto-organize music library from Downloads into Music
+  modules.services.media.beets.enable = true;
+
   # JellyPlex-Watched sync (continuous)
   modules.services.media.jellyplexWatched = {
     enable = true;

--- a/modules/services/media/beets.nix
+++ b/modules/services/media/beets.nix
@@ -41,10 +41,7 @@ in
 
     inboxDir = mkOption {
       type = types.str;
-      default =
-        if config.modules.services.media.jellyfin.enable
-        then "${config.modules.services.media.jellyfin.mediaDir}/Downloads"
-        else "/data/media/Downloads";
+      default = "${cfg.musicDir}/0. Import";
       description = "Directory to import new music from";
     };
 

--- a/modules/services/media/beets.nix
+++ b/modules/services/media/beets.nix
@@ -1,0 +1,120 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.beets;
+
+  beetsConfig = pkgs.writeText "beets-config.yaml" ''
+    directory: ${cfg.musicDir}
+    library: ${cfg.dataDir}/beets.db
+
+    import:
+      move: true
+      write: true
+      quiet: true
+      incremental: true
+      incremental_skip_later: true
+
+    plugins: fetchart embedart chroma
+
+    fetchart:
+      auto: yes
+
+    embedart:
+      auto: yes
+
+    ${cfg.extraConfig}
+  '';
+in
+{
+  options.modules.services.media.beets = {
+    enable = mkEnableOption "Beets music library organizer";
+
+    musicDir = mkOption {
+      type = types.str;
+      default =
+        if config.modules.services.media.jellyfin.enable
+        then "${config.modules.services.media.jellyfin.mediaDir}/Music"
+        else "/data/media/Music";
+      description = "Organized music library directory";
+    };
+
+    inboxDir = mkOption {
+      type = types.str;
+      default =
+        if config.modules.services.media.jellyfin.enable
+        then "${config.modules.services.media.jellyfin.mediaDir}/Downloads"
+        else "/data/media/Downloads";
+      description = "Directory to import new music from";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/beets";
+      description = "Directory for beets database and state";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "jellyfin";
+      description = "User to run beets as";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "media";
+      description = "Group to run beets as";
+    };
+
+    onCalendar = mkOption {
+      type = types.str;
+      default = "hourly";
+      description = "Systemd calendar expression for import schedule";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional beets YAML configuration";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
+    ];
+
+    systemd.services.beets-import = {
+      description = "Beets music library import";
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.beets}/bin/beet --config ${beetsConfig} import ${cfg.inboxDir}";
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir cfg.musicDir cfg.inboxDir ];
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+      };
+    };
+
+    systemd.timers.beets-import = {
+      description = "Beets music library import timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.onCalendar;
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/modules/services/media/beets.nix
+++ b/modules/services/media/beets.nix
@@ -17,6 +17,10 @@ let
 
     plugins: fetchart embedart chroma
 
+    paths:
+      default: $albumartist/$album ($year)/$albumartist - $album - $track - $title
+      singleton: $albumartist/$title
+
     fetchart:
       auto: yes
 

--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -2,6 +2,7 @@
 {
   # Import media service modules
   imports = [
+    ./beets.nix
     ./feishin.nix
     ./immich.nix
     ./jellyfin.nix


### PR DESCRIPTION
## Summary

- Add `modules/services/media/beets.nix` — systemd timer + oneshot service that runs `beet import` on a schedule
  - Imports from `{musicDir}/0. Import` into the organized music library
  - Runs as `jellyfin`/`media` user — already has directory access
  - `musicDir` derives from jellyfin module when enabled
  - Hourly by default; configurable via `onCalendar`
  - Plugins: fetchart, embedart, chroma (AcoustID fingerprinting)
  - `extraConfig` escape hatch for additional beets YAML
- Enable on david

## Test plan

- [ ] `nixos-rebuild dry-run` passes on david
- [ ] `systemctl status beets-import.timer` shows timer active after rebuild
- [ ] Drop a file in `/data/media/Music/0. Import` and confirm `systemctl start beets-import` organizes it