### PR TITLE
feat(storage): USB MP3 player sync from Jellyfin playlists

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -130,6 +130,12 @@
 
   modules.services.storage.wiiHddSync.enable = true;
 
+  modules.services.storage.mp3PlayerSync = {
+    enable = true;
+    uuid = "EC95-4FBB";
+    playlistDir = "/data/media/Music/Playlists";
+  };
+
   # =============================================================================
   # ADDITIONAL SERVICES
   # =============================================================================

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -133,7 +133,11 @@
   modules.services.storage.mp3PlayerSync = {
     enable = true;
     uuid = "EC95-4FBB";
-    playlistDir = "/data/media/Music/Playlists";
+    playlists = [
+      "/data/media/Music/m3u/playlist/Judah Jams.m3u"
+      "/data/media/Music/m3u/playlist/Judah's Fav TOP.m3u"
+      "/data/media/Music/m3u/playlist/Judahstep.m3u"
+    ];
   };
 
   # =============================================================================

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -133,10 +133,9 @@
   modules.services.storage.mp3PlayerSync = {
     enable = true;
     uuid = "EC95-4FBB";
+    jellyfinApiKeyFile = config.age.secrets.jellyfin-api-key.path;
     playlists = [
-      "/data/media/Music/m3u/playlist/Judah Jams.m3u"
-      "/data/media/Music/m3u/playlist/Judah\u2019s Fav TOP.m3u"
-      "/data/media/Music/m3u/playlist/Judahstep.m3u"
+      "Judah Jams 2"
     ];
   };
 

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -135,7 +135,7 @@
     uuid = "EC95-4FBB";
     playlists = [
       "/data/media/Music/m3u/playlist/Judah Jams.m3u"
-      "/data/media/Music/m3u/playlist/Judah's Fav TOP.m3u"
+      "/data/media/Music/m3u/playlist/Judah\u2019s Fav TOP.m3u"
       "/data/media/Music/m3u/playlist/Judahstep.m3u"
     ];
   };

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -92,6 +92,10 @@ with lib;
       "jellyfin-token" = { file = ../secrets/jellyfin-token.age; owner = "jellyplex-watched"; group = "jellyplex-watched"; mode = "0400"; };
     })
 
+    // (optionalAttrs (config.networking.hostName == "david" && config.modules.services.storage.mp3PlayerSync.enable) {
+      "jellyfin-api-key" = { file = ../secrets/jellyfin-api-key.age; mode = "0400"; };
+    })
+
     // (optionalAttrs (config.networking.hostName == "pits") {
       # PITS secrets here
     });

--- a/modules/services/storage/default.nix
+++ b/modules/services/storage/default.nix
@@ -6,6 +6,7 @@
     ./nextcloud.nix
     ./samba.nix
     ./syncthing.nix
+    ./mp3-player-sync.nix
     ./wii-hdd-sync.nix
     ./zfs.nix
   ];

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -4,7 +4,7 @@ with lib;
 let
   cfg = config.modules.services.storage.mp3PlayerSync;
   mountPoint = "/mnt/mp3-player";
-  playlistNamesFile = pkgs.writeText "mp3-sync-playlist-names" (concatStringsSep "\n" cfg.playlists);
+  playlistNamesFile = pkgs.writeText "mp3-sync-playlist-names" (concatStringsSep "\n" cfg.playlists + "\n");
 in
 {
   options.modules.services.storage.mp3PlayerSync = {

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -60,12 +60,14 @@ in
 
           # Build list of wanted files from each playlist in the configured list.
           # M3U entries may be absolute paths — strip the music library prefix to get relative paths.
-          echo "Building file list from playlists..."
+          # tr strips Windows-style \r so CRLF playlists don't corrupt filenames.
+          echo "Building file list from playlists..." >&2
           while IFS= read -r playlist; do
-            [ -f "$playlist" ] || { echo "Warning: playlist not found: $playlist"; continue; }
-            echo "  $playlist"
+            [ -f "$playlist" ] || { echo "Warning: playlist not found: $playlist" >&2; continue; }
+            echo "  $playlist" >&2
             grep -v '^#' "$playlist" | grep -v '^$'
           done < "${playlistsFile}" \
+            | tr -d '\r' \
             | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
             | sort -u \
             > "$WANTED_LIST"

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -4,11 +4,11 @@ with lib;
 let
   cfg = config.modules.services.storage.mp3PlayerSync;
   mountPoint = "/mnt/mp3-player";
-  playlistsFile = pkgs.writeText "mp3-sync-playlists" (concatStringsSep "\n" cfg.playlists);
+  playlistNamesFile = pkgs.writeText "mp3-sync-playlist-names" (concatStringsSep "\n" cfg.playlists);
 in
 {
   options.modules.services.storage.mp3PlayerSync = {
-    enable = mkEnableOption "USB MP3 player playlist sync";
+    enable = mkEnableOption "USB MP3 player Jellyfin playlist sync";
 
     uuid = mkOption {
       type = types.str;
@@ -18,13 +18,24 @@ in
     musicLibrary = mkOption {
       type = types.str;
       default = "/data/media/Music";
-      description = "Root of the local music library";
+      description = "Root of the local music library (used to derive relative paths for rsync)";
+    };
+
+    jellyfinUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8096";
+      description = "Base URL of the Jellyfin server";
+    };
+
+    jellyfinApiKeyFile = mkOption {
+      type = types.str;
+      description = "Path to file containing the Jellyfin API key";
     };
 
     playlists = mkOption {
       type = types.listOf types.str;
-      description = "List of .m3u playlist file paths to sync to the player";
-      example = [ "/data/media/Music/m3u/playlist/Judah Jams.m3u" ];
+      description = "Jellyfin playlist names to sync to the player";
+      example = [ "Judah Jams 2" ];
     };
   };
 
@@ -34,9 +45,9 @@ in
       "d ${mountPoint} 0755 root root -"
     ];
 
-    # Oneshot service: mount -> build file list from playlists -> sync -> delete removed tracks -> unmount
+    # Oneshot service: mount -> resolve playlists via Jellyfin API -> sync -> delete removed tracks -> unmount
     systemd.services.mp3-player-sync = {
-      description = "Sync playlists to USB MP3 player";
+      description = "Sync Jellyfin playlists to USB MP3 player";
       after = [ "network.target" ];
 
       serviceConfig = {
@@ -47,6 +58,8 @@ in
           DEVICE="/dev/disk/by-uuid/${cfg.uuid}"
           MOUNT="${mountPoint}"
           MUSIC="${cfg.musicLibrary}"
+          JELLYFIN="${cfg.jellyfinUrl}"
+          API_KEY=$(cat "${cfg.jellyfinApiKeyFile}")
           WANTED_LIST="/tmp/mp3-sync-files.txt"
 
           echo "Mounting $DEVICE -> $MOUNT..."
@@ -59,25 +72,48 @@ in
           }
           trap cleanup EXIT
 
-          # Build list of wanted files from each playlist in the configured list.
-          # M3U entries may be absolute paths — strip the music library prefix to get relative paths.
-          # tr strips Windows-style \r so CRLF playlists don't corrupt filenames.
-          echo "Building file list from playlists..." >&2
-          while IFS= read -r playlist; do
-            [ -f "$playlist" ] || { echo "Warning: playlist not found: $playlist" >&2; continue; }
-            echo "  $playlist" >&2
-            grep -v '^#' "$playlist" | grep -v '^$'
-          done < "${playlistsFile}" \
-            | tr -d '\r' \
-            | ${pkgs.gnused}/bin/sed -e "s|^$MUSIC/||" -e "s|^\./||" \
-            | sort -u \
-            > "$WANTED_LIST"
+          # Resolve each playlist name to file paths via the Jellyfin API.
+          # The Path field is admin-only, so this requires an admin API key.
+          echo "Resolving playlists from Jellyfin..."
+          : > "$WANTED_LIST"
+
+          while IFS= read -r PLAYLIST_NAME; do
+            [ -z "$PLAYLIST_NAME" ] && continue
+            echo "  Looking up: $PLAYLIST_NAME"
+
+            # Find playlist ID by name
+            PLAYLIST_ID=$(${pkgs.curl}/bin/curl -sf \
+              -H "X-Emby-Token: $API_KEY" \
+              "$JELLYFIN/Items?IncludeItemTypes=Playlist&Recursive=true&SearchTerm=$(${pkgs.python3}/bin/python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$PLAYLIST_NAME")" \
+              | ${pkgs.jq}/bin/jq -r --arg name "$PLAYLIST_NAME" \
+                  '.Items[] | select(.Name == $name) | .Id' \
+              | head -1)
+
+            if [ -z "$PLAYLIST_ID" ]; then
+              echo "  Warning: playlist not found in Jellyfin: $PLAYLIST_NAME" >&2
+              continue
+            fi
+
+            echo "  Found playlist ID: $PLAYLIST_ID"
+
+            # Get all items in the playlist and extract their file paths
+            ${pkgs.curl}/bin/curl -sf \
+              -H "X-Emby-Token: $API_KEY" \
+              "$JELLYFIN/Playlists/$PLAYLIST_ID/Items?Fields=Path&Limit=10000" \
+              | ${pkgs.jq}/bin/jq -r '.Items[].Path' \
+              | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
+              >> "$WANTED_LIST"
+
+          done < "${playlistNamesFile}"
+
+          # Deduplicate
+          sort -u -o "$WANTED_LIST" "$WANTED_LIST"
 
           COUNT=$(wc -l < "$WANTED_LIST")
           echo "Found $COUNT unique tracks across playlists."
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "No tracks found in playlists — aborting to avoid wiping device."
+            echo "No tracks found — aborting to avoid wiping device."
             exit 1
           fi
 

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -69,7 +69,7 @@ in
             grep -v '^#' "$playlist" | grep -v '^$'
           done < "${playlistsFile}" \
             | tr -d '\r' \
-            | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
+            | ${pkgs.gnused}/bin/sed -e "s|^$MUSIC/||" -e "s|^\./||" \
             | sort -u \
             > "$WANTED_LIST"
 

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -77,6 +77,18 @@ in
           echo "Resolving playlists from Jellyfin..."
           : > "$WANTED_LIST"
 
+          # Get admin user ID (required by the playlist items endpoint)
+          USER_ID=$(${pkgs.curl}/bin/curl -sf \
+            -H "X-Emby-Token: $API_KEY" \
+            "$JELLYFIN/Users?isAdministrator=true" \
+            | ${pkgs.jq}/bin/jq -r '.[0].Id')
+
+          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+            echo "Error: could not retrieve admin user ID from Jellyfin" >&2
+            exit 1
+          fi
+          echo "Using admin user ID: $USER_ID"
+
           while IFS= read -r PLAYLIST_NAME; do
             [ -z "$PLAYLIST_NAME" ] && continue
             echo "  Looking up: $PLAYLIST_NAME"
@@ -99,7 +111,7 @@ in
             # Get all items in the playlist and extract their file paths
             ${pkgs.curl}/bin/curl -sf \
               -H "X-Emby-Token: $API_KEY" \
-              "$JELLYFIN/Playlists/$PLAYLIST_ID/Items?Fields=Path&Limit=10000" \
+              "$JELLYFIN/Playlists/$PLAYLIST_ID/Items?userId=$USER_ID&Fields=Path&Limit=10000" \
               | ${pkgs.jq}/bin/jq -r '.Items[].Path' \
               | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
               >> "$WANTED_LIST"

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -1,0 +1,116 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.storage.mp3PlayerSync;
+  mountPoint = "/mnt/mp3-player";
+in
+{
+  options.modules.services.storage.mp3PlayerSync = {
+    enable = mkEnableOption "USB MP3 player playlist sync";
+
+    uuid = mkOption {
+      type = types.str;
+      description = "FAT32 partition UUID of the MP3 player";
+    };
+
+    musicLibrary = mkOption {
+      type = types.str;
+      default = "/data/media/Music";
+      description = "Root of the local music library";
+    };
+
+    playlistDir = mkOption {
+      type = types.str;
+      description = "Directory containing playlist files to sync";
+    };
+
+    playlistPattern = mkOption {
+      type = types.str;
+      default = "*.m3u";
+      description = "Glob pattern for playlist files within playlistDir";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Ensure mount point exists
+    systemd.tmpfiles.rules = [
+      "d ${mountPoint} 0755 root root -"
+    ];
+
+    # Oneshot service: mount -> build file list from playlists -> sync -> delete removed tracks -> unmount
+    systemd.services.mp3-player-sync = {
+      description = "Sync playlists to USB MP3 player";
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "mp3-player-sync" ''
+          set -euo pipefail
+          DEVICE="/dev/disk/by-uuid/${cfg.uuid}"
+          MOUNT="${mountPoint}"
+          MUSIC="${cfg.musicLibrary}"
+          PLAYLIST_DIR="${cfg.playlistDir}"
+          WANTED_LIST="/tmp/mp3-sync-files.txt"
+
+          echo "Mounting $DEVICE -> $MOUNT..."
+          ${pkgs.util-linux}/bin/mount -t vfat -o uid=1000,gid=1000,umask=002,flush "$DEVICE" "$MOUNT"
+
+          cleanup() {
+            echo "Unmounting $MOUNT..."
+            ${pkgs.util-linux}/bin/umount "$MOUNT" || true
+            rm -f "$WANTED_LIST"
+          }
+          trap cleanup EXIT
+
+          # Build list of wanted files from all matching playlists
+          # M3U entries may be absolute paths — strip the music library prefix to get relative paths
+          echo "Building file list from playlists in $PLAYLIST_DIR..."
+          ${pkgs.findutils}/bin/find "$PLAYLIST_DIR" -name "${cfg.playlistPattern}" -type f \
+            -exec grep -h -v '^#' {} + \
+            | grep -v '^$' \
+            | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
+            | sort -u \
+            > "$WANTED_LIST"
+
+          COUNT=$(wc -l < "$WANTED_LIST")
+          echo "Found $COUNT unique tracks across playlists."
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No tracks found in playlists — aborting to avoid wiping device."
+            exit 1
+          fi
+
+          # Copy wanted files to device, preserving Artist/Album/track structure
+          echo "Syncing tracks to device..."
+          ${pkgs.rsync}/bin/rsync -av \
+            --files-from="$WANTED_LIST" \
+            --no-perms --no-owner --no-group \
+            "$MUSIC/" "$MOUNT/" || { rc=$?; [ $rc -eq 23 ] || exit $rc; }
+
+          # Delete files on device that are no longer in any playlist
+          echo "Removing tracks no longer in any playlist..."
+          ${pkgs.findutils}/bin/find "$MOUNT" -type f \
+            \( -iname "*.mp3" -o -iname "*.flac" -o -iname "*.ogg" -o -iname "*.aac" -o -iname "*.m4a" \) \
+            | while IFS= read -r f; do
+                rel="''${f#$MOUNT/}"
+                if ! grep -qxF "$rel" "$WANTED_LIST"; then
+                  echo "Removing: $rel"
+                  rm "$f"
+                fi
+              done
+
+          # Prune empty directories left behind by removals
+          ${pkgs.findutils}/bin/find "$MOUNT" -type d -empty -delete 2>/dev/null || true
+
+          echo "Sync complete."
+        '';
+      };
+    };
+
+    # Trigger the sync service when the player is plugged in
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_UUID}=="${cfg.uuid}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="mp3-player-sync.service"
+    '';
+  };
+}

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -4,6 +4,7 @@ with lib;
 let
   cfg = config.modules.services.storage.mp3PlayerSync;
   mountPoint = "/mnt/mp3-player";
+  playlistsFile = pkgs.writeText "mp3-sync-playlists" (concatStringsSep "\n" cfg.playlists);
 in
 {
   options.modules.services.storage.mp3PlayerSync = {
@@ -20,15 +21,10 @@ in
       description = "Root of the local music library";
     };
 
-    playlistDir = mkOption {
-      type = types.str;
-      description = "Directory containing playlist files to sync";
-    };
-
-    playlistPattern = mkOption {
-      type = types.str;
-      default = "*.m3u";
-      description = "Glob pattern for playlist files within playlistDir";
+    playlists = mkOption {
+      type = types.listOf types.str;
+      description = "List of .m3u playlist file paths to sync to the player";
+      example = [ "/data/media/Music/m3u/playlist/Judah Jams.m3u" ];
     };
   };
 
@@ -50,7 +46,6 @@ in
           DEVICE="/dev/disk/by-uuid/${cfg.uuid}"
           MOUNT="${mountPoint}"
           MUSIC="${cfg.musicLibrary}"
-          PLAYLIST_DIR="${cfg.playlistDir}"
           WANTED_LIST="/tmp/mp3-sync-files.txt"
 
           echo "Mounting $DEVICE -> $MOUNT..."
@@ -63,12 +58,14 @@ in
           }
           trap cleanup EXIT
 
-          # Build list of wanted files from all matching playlists
-          # M3U entries may be absolute paths — strip the music library prefix to get relative paths
-          echo "Building file list from playlists in $PLAYLIST_DIR..."
-          ${pkgs.findutils}/bin/find "$PLAYLIST_DIR" -name "${cfg.playlistPattern}" -type f \
-            -exec grep -h -v '^#' {} + \
-            | grep -v '^$' \
+          # Build list of wanted files from each playlist in the configured list.
+          # M3U entries may be absolute paths — strip the music library prefix to get relative paths.
+          echo "Building file list from playlists..."
+          while IFS= read -r playlist; do
+            [ -f "$playlist" ] || { echo "Warning: playlist not found: $playlist"; continue; }
+            echo "  $playlist"
+            grep -v '^#' "$playlist" | grep -v '^$'
+          done < "${playlistsFile}" \
             | ${pkgs.gnused}/bin/sed "s|^$MUSIC/||" \
             | sort -u \
             > "$WANTED_LIST"

--- a/modules/services/storage/mp3-player-sync.nix
+++ b/modules/services/storage/mp3-player-sync.nix
@@ -41,6 +41,7 @@ in
 
       serviceConfig = {
         Type = "oneshot";
+        TimeoutStartSec = "infinity";
         ExecStart = pkgs.writeShellScript "mp3-player-sync" ''
           set -euo pipefail
           DEVICE="/dev/disk/by-uuid/${cfg.uuid}"

--- a/secrets/jellyfin-api-key.age
+++ b/secrets/jellyfin-api-key.age
@@ -1,0 +1,5 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw 7PhpeKJUvqEkV9JCOwe9aY6DbicSBCaqgDErYGsgImQ
+wTclkNuS2nWXcA/kmvalzKh8TLok0U/Ad++6svtiVTk
+--- MxKCVVjDyV+ojWkJhtKAtQHVZXK0FLAW/eC8uIaHzsk
+ñTÉUþ 1(ˆA]¼üôy×Ü½°9pžCEßË¨“€©¢‹t`CpDD[cêuŠ?ÌTpO­ÑˆÌ¢$.¯ý€

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -115,6 +115,9 @@ in
 
   # Jellyfin token for JellyPlex-Watched
   "jellyfin-token.age".publicKeys = davidKeys;
+
+  # Jellyfin API key for mp3-player-sync
+  "jellyfin-api-key.age".publicKeys = davidKeys;
   
   # =============================================================================
   # SHARED SECRETS (All Servers)


### PR DESCRIPTION
## Summary

- Adds `modules/services/storage/mp3-player-sync.nix` — a new NixOS module that automatically syncs music to a USB MP3 player when plugged in, using the same udev → systemd oneshot pattern as `wii-hdd-sync`
- Playlists are resolved via the Jellyfin API (admin API key), so changes in Jellyfin propagate automatically — no separate M3U files to manage
- Syncs only tracks in the configured playlists, preserving Artist/Album/track directory structure; removes tracks that were removed from playlists
- Enabled on david with UUID `EC95-4FBB` (62GB ACTIONS M6), starting with the "Judah Jams 2" playlist

## How it works

1. udev matches the device UUID on plug-in and starts `mp3-player-sync.service`
2. Service mounts the FAT32 device, queries Jellyfin for each configured playlist name, and extracts server-side file paths
3. rsync copies wanted tracks from the music library to the device
4. Deletion pass removes any audio files on the device not in the current playlist set
5. Empty directories are pruned, device is unmounted

## Configuration

```nix
modules.services.storage.mp3PlayerSync = {
  enable = true;
  uuid = "<device-uuid>";           # from lsblk -o NAME,UUID
  jellyfinApiKeyFile = config.age.secrets.jellyfin-api-key.path;
  playlists = [ "Playlist Name" ];  # Jellyfin playlist names
};
```

## Test plan

- [x] Device detected via udev on plug-in
- [x] Jellyfin API resolves playlist → track file paths
- [x] rsync copies tracks preserving directory structure
- [x] Deletion pass removes tracks no longer in any playlist without touching tracks that are still wanted
- [x] Service completes and unmounts cleanly