### PR TITLE
fix(jellyfin): use install instead of cp to avoid read-only restart failure

### DIFF
--- a/modules/services/media/jellyfin.nix
+++ b/modules/services/media/jellyfin.nix
@@ -103,7 +103,7 @@ in
         jellyfinConfigDir = config.services.jellyfin.configDir;
       in ''
         mkdir -p ${jellyfinConfigDir}
-        cp ${reposXml} ${jellyfinConfigDir}/repositories.xml
+        install -m 644 ${reposXml} ${jellyfinConfigDir}/repositories.xml
       '';
 
     # Workaround for jellyfin hardware transcode (NVIDIA NVENC)


### PR DESCRIPTION
## Summary

- `cp` preserves Nix store file permissions (read-only), so `repositories.xml` was written as `-r--------`
- On the next `systemctl restart jellyfin`, preStart failed with "Permission denied" trying to overwrite it
- `install -m 644` sets the mode explicitly, so the file is always writable on subsequent restarts

## Root cause

Nix store paths are immutable (read-only). `cp` copies those permissions to the destination. `install` ignores source permissions and applies the specified mode.