### PR TITLE
feat: Pocket ID SSO via caddy-security

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -52,6 +52,18 @@
   # dns-sync: use local Technitium directly (avoids Caddy loopback for the API)
   modules.services.vHosts.technitium.url = "http://localhost:5380";
 
+  # =============================================================================
+  # SSO: Pocket ID via caddy-security
+  # =============================================================================
+
+  modules.services.vHosts.sso = {
+    enable = true;
+    portalDomain = "auth.${config.networking.domain}";
+    clientId = "d194f6bf-22c4-4228-898e-e5539bf92535";
+    clientSecretFile = config.age.secrets.caddy-sso-client-secret.path;
+    jwtSecretFile = config.age.secrets.caddy-sso-jwt-secret.path;
+  };
+
   # Navidrome - Music streaming server (Subsonic-compatible)
   modules.services.media.navidrome.enable = true;
 

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -34,6 +34,21 @@ with lib;
       };
     })
 
+    // (optionalAttrs config.modules.services.vHosts.sso.enable {
+      "caddy-sso-client-secret" = {
+        file = ../secrets/caddy-sso-client-secret.age;
+        owner = "caddy";
+        group = "caddy";
+        mode = "0400";
+      };
+      "caddy-sso-jwt-secret" = {
+        file = ../secrets/caddy-sso-jwt-secret.age;
+        owner = "caddy";
+        group = "caddy";
+        mode = "0400";
+      };
+    })
+
     // (optionalAttrs config.modules.services.vHosts.technitium.enable {
       "technitium-api-token" = { file = ../secrets/technitium-api-token.age; owner = "root"; group = "root"; mode = "0400"; };
     })

--- a/modules/services/infrastructure/caddy.nix
+++ b/modules/services/infrastructure/caddy.nix
@@ -3,7 +3,9 @@
 with lib;
 let
   cfg = config.modules.services.infrastructure.caddy;
+  ssoCfg = config.modules.services.vHosts.sso;
   vHosts = recursiveUpdate cfg.virtualHosts config.modules.services.vHosts.hosts;
+  ssoHosts = filterAttrs (_: h: h.enable && h.sso.enable) vHosts;
 in
 {
   options.modules.services.infrastructure.caddy = {
@@ -128,10 +130,46 @@ in
       };
       globalConfig = ''
         email ${cfg.email}
-        
+
         # Bind to both IPv4 and IPv6
         servers {
           protocols h1 h2 h3
+        }
+      '' + optionalString ssoCfg.enable ''
+
+        security {
+          oauth identity provider pocket_id {
+            realm pocket_id
+            driver generic
+            client_id ${ssoCfg.clientId}
+            client_secret {env.CADDY_SSO_CLIENT_SECRET}
+            scopes openid email profile groups
+            base_auth_url ${ssoCfg.pocketIdUrl}
+            metadata_url ${ssoCfg.pocketIdUrl}/.well-known/openid-configuration
+          }
+
+          authentication portal main {
+            crypto default token lifetime 86400
+            crypto key sign-verify {env.CADDY_SSO_JWT_SECRET}
+            enable identity provider pocket_id
+            cookie domain ${ssoCfg.cookieDomain}
+          }
+
+          ${concatStringsSep "\n\n          " (mapAttrsToList (_: hostCfg:
+            let
+              allowClause =
+                if hostCfg.sso.allowedGroups == []
+                then "allow roles authp/user authp/admin"
+                else concatStringsSep "\n          " (map (g: "allow groups ${g}") hostCfg.sso.allowedGroups);
+            in
+            ''
+              authorization policy ${hostCfg.sso.policyName}_policy {
+                set auth url https://${ssoCfg.portalDomain}
+                ${allowClause}
+                validate bearer header
+                inject headers with claims
+              }''
+          ) ssoHosts)}
         }
       '';
       extraConfig = ''
@@ -146,30 +184,39 @@ in
       '';
     };
 
-    # Create a systemd service that prepares the Cloudflare API token environment file
-    # The agenix secret contains only the raw token value (cleaner secret management)
-    # We wrap it in KEY=VALUE format at runtime for systemd's EnvironmentFile
     systemd.services.caddy-prepare-env = {
-      description = "Prepare Cloudflare API token for Caddy";
+      description = "Prepare Caddy environment secrets";
       before = [ "caddy.service" ];
       requiredBy = [ "caddy.service" ];
+      after = [ "agenix.service" ];
+      wants = [ "agenix.service" ];
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
       };
       script = ''
-        # Read the raw token from agenix secret and format it for systemd EnvironmentFile
-        TOKEN=$(cat ${config.age.secrets.cloudflare-api-token.path})
         mkdir -p /run/caddy
-        echo "CLOUDFLARE_API_TOKEN=$TOKEN" > /run/caddy/cloudflare.env
-        chmod 600 /run/caddy/cloudflare.env
-        chown caddy:caddy /run/caddy/cloudflare.env
+        echo "CLOUDFLARE_API_TOKEN=$(cat ${config.age.secrets.cloudflare-api-token.path})" > /run/caddy/caddy.env
+        ${optionalString ssoCfg.enable ''
+          echo "CADDY_SSO_CLIENT_SECRET=$(cat ${toString ssoCfg.clientSecretFile})" >> /run/caddy/caddy.env
+          echo "CADDY_SSO_JWT_SECRET=$(cat ${toString ssoCfg.jwtSecretFile})" >> /run/caddy/caddy.env
+        ''}
+        chmod 600 /run/caddy/caddy.env
+        chown caddy:caddy /run/caddy/caddy.env
       '';
     };
 
-    # Configure Caddy service to load the formatted environment file
     systemd.services.caddy.serviceConfig = {
-      EnvironmentFile = "/run/caddy/cloudflare.env";
+      EnvironmentFile = "/run/caddy/caddy.env";
+    };
+
+    # Auto-register the SSO auth portal as a vHost (DNS sync picks it up too)
+    modules.services.vHosts.hosts = mkIf ssoCfg.enable {
+      "${ssoCfg.portalDomain}" = {
+        managedProxy = false;
+        public = false;
+        extraConfig = "authenticate with main";
+      };
     };
 
     # Open firewall ports for HTTP and HTTPS
@@ -188,6 +235,13 @@ in
               hostCfg.reverseProxyAddress
             else
               "${if hostCfg.reverseProxySSL then "https" else "http"}://${hostCfg.reverseProxyHost}:${toString hostCfg.reverseProxyPort}";
+          proxyDirectives =
+            if hostCfg.sso.enable then ''
+              authorize with ${hostCfg.sso.policyName}_policy
+              reverse_proxy ${reverseProxyTarget}
+            '' else ''
+              reverse_proxy ${reverseProxyTarget}
+            '';
         in
         mkIf hostCfg.enable {
           "${hostCfg.virtualHost}" = {
@@ -200,15 +254,13 @@ in
                       remote_ip ${concatStringsSep " " cfg.internalIpRanges}
                     }
                     handle @internal {
-                      reverse_proxy ${reverseProxyTarget}
+                      ${proxyDirectives}
                     }
                     handle {
                       respond "Access Forbidden" 403
                     }
                   ''}
-                  ${optionalString hostCfg.public ''
-                    reverse_proxy ${reverseProxyTarget}
-                  ''}
+                  ${optionalString hostCfg.public proxyDirectives}
                   ${optionalString hostCfg.dnsChallenge "import cloudflare_tls"}
                   ${hostCfg.extraConfig}
                 ''

--- a/modules/services/vhosts.nix
+++ b/modules/services/vhosts.nix
@@ -7,8 +7,47 @@ let
 in
 {
   options.modules.services.vHosts = {
+    sso = {
+      enable = mkEnableOption "Pocket ID SSO for protected vHosts via caddy-security";
+
+      pocketIdUrl = mkOption {
+        type = types.str;
+        default = "https://id.theyoder.family";
+        description = "Pocket ID OIDC issuer URL.";
+      };
+
+      portalDomain = mkOption {
+        type = types.str;
+        description = "Domain for the shared authentication portal (e.g. auth.theyoder.family).";
+      };
+
+      cookieDomain = mkOption {
+        type = types.str;
+        default = config.networking.domain;
+        description = "Cookie domain for cross-subdomain SSO session sharing.";
+      };
+
+      clientId = mkOption {
+        type = types.str;
+        default = "";
+        description = "OIDC client ID registered in Pocket ID. Required when enable = true.";
+      };
+
+      clientSecretFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Runtime path to OIDC client secret. Required when enable = true.";
+      };
+
+      jwtSecretFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Runtime path to JWT signing key for session tokens. Required when enable = true.";
+      };
+    };
+
     hosts = mkOption {
-      type = types.attrsOf (types.submodule ({ name, ... }: {
+      type = types.attrsOf (types.submodule ({ name, config, ... }: {
         options = {
           enable = mkOption {
             type = types.bool;
@@ -80,6 +119,25 @@ in
             type = types.lines;
             default = "";
             description = "Additional reverse proxy config appended to this virtual host.";
+          };
+
+          sso = {
+            enable = mkOption {
+              type = types.bool;
+              default = config.sso.allowedGroups != [];
+              description = "Require SSO for this vHost. Implied when allowedGroups is non-empty.";
+            };
+            allowedGroups = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = "Pocket ID groups allowed access. Setting this implicitly enables SSO.";
+            };
+            policyName = mkOption {
+              type = types.str;
+              readOnly = true;
+              default = replaceStrings [ "." "-" ] [ "_" "_" ] name;
+              description = "Caddy authorization policy name, auto-derived from the vHost attribute key.";
+            };
           };
         };
       }));

--- a/modules/services/vhosts.nix
+++ b/modules/services/vhosts.nix
@@ -18,7 +18,8 @@ in
 
       portalDomain = mkOption {
         type = types.str;
-        description = "Domain for the shared authentication portal (e.g. auth.theyoder.family).";
+        default = "auth.${config.networking.domain}";
+        description = "Domain for the shared authentication portal.";
       };
 
       cookieDomain = mkOption {

--- a/secrets/caddy-sso-client-secret.age
+++ b/secrets/caddy-sso-client-secret.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw /rDZFZ/Kwsi2DgxuL/rFkQW/qgvX6FaW3D+ewakGTjY
+i1lLAR+maQxjXHJruSHNfy4NaeHyAkOJIr238Nax4qA
+-> ssh-ed25519 HMaD4A GFC8kQJH9k/TDLG75i4XEdLXDcEA1ycFcv+WSkzMpkA
+fMe6zbayC4HpbOPtbOMFvup/zG3ksxjAB9JaE+bf1tI
+-> ssh-ed25519 G/hviA wand92CHXLGA0OAedGCsRC34EH/Gfq8N9Erjv5qFcCI
+F3OkMY4a2jxcLCkxh9nIlm34Fcol97Cxuhw0O/61rxw
+--- NLjvfKy+WfC9RP2tgkUlC0WXf8yQRrL9Mj/DrUY+F3E
+UÆøj×1§6¨Ñ³öÏè4F¾Ï%4îT¡4~ÀD‘)p®·§ß1i¾†œý6è}»niØ1+'¤“Aƒ´

--- a/secrets/caddy-sso-jwt-secret.age
+++ b/secrets/caddy-sso-jwt-secret.age
@@ -1,0 +1,10 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw s7zZjO+jUqsGTPx7JNSr8MEG0NzbR8ZQ4RUZDPa+1mk
+LgcegztcXyOsIj1XVKfCuqxgH2UMiYbo+EUWbhjPdxE
+-> ssh-ed25519 HMaD4A C6INaiDtaKl+tmNpKX6vRuZTEhjTByl6FNmE3P1U1lI
+eRyYs3991WU9YCqXKZgNdALlxKZ/skJz5tmpHYzSu+o
+-> ssh-ed25519 G/hviA F6elZ65icOyW97jqpZxxDXgIU6e1chu5ggV3kp6ti3s
+O2icxVyb0R8h0oLi1pckffkMtvnkYHtIMxbeBvcInKo
+--- N0Dzl5eiN1LbvH3UMxzU0Bi1C5xirbp+C+IvdX+m7PM
+'¹×³ôÄÕ__‹@Q‘>cŠº+0¹Uàõæá&Az´;Hà-aOÌ¢n\‡bÂ‚‚””ˆñÉ”MÔB	«Øtý7°¶þŒP%ÄëîE'vÕþe
+¶‰*½÷»«

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -110,6 +110,10 @@ in
   # Pocket ID Encryption Key
   "pocket-id-encryption-key.age".publicKeys = davidKeys;
 
+  # Caddy SSO via Pocket ID (caddy-security)
+  "caddy-sso-client-secret.age".publicKeys = davidKeys;
+  "caddy-sso-jwt-secret.age".publicKeys = davidKeys;
+
   # Tidarr OIDC Client Secret (Pocket ID)
   "tidarr-oidc-secret.age".publicKeys = davidKeys;
 


### PR DESCRIPTION
## Summary

- Extends the vHost module with per-host `sso.allowedGroups` and global `modules.services.vHosts.sso` options
- Caddy generates a `security {}` block with one Pocket ID OIDC provider, one shared auth portal, and one authorization policy per protected vHost
- Services opt in with a single line — no service module changes required
- Auth portal (`auth.theyoder.family`) is auto-registered as a vHost including DNS sync
- Zero impact on hosts that don't enable SSO; all additions are behind `enable` guards

## Usage

```nix
# Global config (hosts/david/configuration.nix)
modules.services.vHosts.sso = {
  enable = true;
  portalDomain = "auth.theyoder.family";
  clientId = "d194f6bf-22c4-4228-898e-e5539bf92535";
  clientSecretFile = config.age.secrets.caddy-sso-client-secret.path;
  jwtSecretFile = config.age.secrets.caddy-sso-jwt-secret.path;
};

# Per-service opt-in
modules.services.vHosts.hosts."app.theyoder.family" = {
  reverseProxyPort = 8080;
  sso.allowedGroups = [ "media" ];  # implies sso.enable = true
};
```

## Pocket ID setup (manual, one-time)
- OIDC client registered with callback: `https://auth.theyoder.family/oauth2/callback`
- Logout URL: `https://auth.theyoder.family/logout`
- Secrets encrypted and committed