### PR TITLE
feat: add music-alac-sync nightly service

### DIFF
--- a/docker/media/media-aq.nix
+++ b/docker/media/media-aq.nix
@@ -10,6 +10,57 @@
 # Auto-generated using compose2nix v0.2.3-pre.
 { config, pkgs, lib, ... }:
 
+let
+  tiddlConfig = pkgs.writeText "tiddl-config.toml" ''
+    enable_cache = true
+    debug = false
+
+    [templates]
+    default = "{album.artist}/{album.title} ({album.date:%Y})/{item.number:02d} - {item.title_version}"
+    track = "{album.artist}/{album.title} ({album.date:%Y})/{item.number:02d} - {item.title_version}"
+    video = "{album.artist}/videos/{item.artist} - {item.title}"
+    album = "{album.artist}/{album.title} ({album.date:%Y})/{item.number:02d} - {item.title_version}"
+    playlist = "{album.artist}/{album.title} ({album.date:%Y})/{item.number:02d} - {item.title_version}"
+    mix = "{album.artist}/{album.title} ({album.date:%Y})/{item.number:02d} - {item.title_version}"
+
+    [download]
+    track_quality = "max"
+    video_quality = "fhd"
+    skip_existing = true
+    threads_count = 4
+    download_path = "/music"
+    scan_path = "/music"
+    singles_filter = "include"
+    videos_filter = "none"
+    # "none" skips Atmos tracks; "allow" downloads both regular and Atmos; "only" for Atmos only
+    atmos_filter = "allow"
+    update_mtime = false
+    rewrite_metadata = true
+
+    [metadata]
+    enable = true
+    lyrics = true
+    cover = true
+
+    [cover]
+    save = true
+    size = 1280
+    allowed = ["playlist"]
+
+    [cover.templates]
+    playlist = "playlists/{playlist.title}/cover"
+
+    [m3u]
+    save = true
+    allowed = ["mix", "playlist"]
+
+    [m3u.templates]
+    album = "m3u/{type}/{album.artist} - {album.title}"
+    playlist = "m3u/{type}/{playlist.title}"
+    mix = "m3u/{type}/{now:%x}"
+  '';
+in
+
 {
   # Runtime
   virtualisation.docker = {
@@ -513,6 +564,7 @@
       ExecStartPre = [
         "+${pkgs.bash}/bin/bash -c '${lib.concatStringsSep " && " [
           "mkdir -p /data/docker-appdata/tidarr/.tiddl"
+          "${pkgs.coreutils}/bin/cp ${tiddlConfig} /data/docker-appdata/tidarr/.tiddl/config.toml"
           "chown -R 1000:1000 /data/docker-appdata/tidarr"
           "mkdir -p /run/tidarr"
           "echo \"PLEX_TOKEN=$(cat ${config.age.secrets.plex-token.path})\" > /run/tidarr/tidarr.env"

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -64,6 +64,9 @@
   # Music dedup - Daily hard-link deduplication of the music library
   modules.services.media.musicDedup.enable = true;
 
+  # Music ALAC sync - Nightly convert Music → AppleMusic (ALAC, mirrors adds/deletes/renames)
+  modules.services.media.musicAlacSync.enable = true;
+
   # JellyPlex-Watched sync (continuous)
   modules.services.media.jellyplexWatched = {
     enable = true;

--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -8,6 +8,7 @@
     ./jellyfin.nix
     ./jellyplex-watched.nix
     ./jellyseerr.nix
+    ./music-alac-sync.nix
     ./music-dedup.nix
     ./navidrome.nix
     ./plex.nix

--- a/modules/services/media/music-alac-sync.nix
+++ b/modules/services/media/music-alac-sync.nix
@@ -57,7 +57,8 @@ in
           copied=0
           errors=0
           cd "$MUSIC"
-          while IFS= read -r -d "" rel; do
+          # fd 3 carries the find stream so ffmpeg/cp don't consume stdin and corrupt the path stream
+          while IFS= read -r -d "" rel <&3; do
             rel="''${rel#./}"
             src="$MUSIC/$rel"
             dest_dir="$APPLE_MUSIC/$(dirname "$rel")"
@@ -88,7 +89,7 @@ in
               cp "$src" "$dest"
               copied=$((copied + 1))
             fi
-          done < <(find . -type f -print0)
+          done 3< <(find . -type f -print0)
           echo "  Converted $converted audio file(s), copied $copied other file(s), $errors error(s)."
 
           # 2. Reverse sync: remove files from AppleMusic whose source no longer exists.
@@ -97,7 +98,7 @@ in
           echo "Reverse sync: removing orphaned files from AppleMusic..."
           removed=0
           cd "$APPLE_MUSIC"
-          while IFS= read -r -d "" rel; do
+          while IFS= read -r -d "" rel <&3; do
             rel="''${rel#./}"
             dest="$APPLE_MUSIC/$rel"
             dir="$(dirname "$rel")"
@@ -122,7 +123,7 @@ in
               rm "$dest"
               removed=$((removed + 1))
             fi
-          done < <(find . -type f -print0)
+          done 3< <(find . -type f -print0)
 
           # Clean up directories that became empty after removals
           find "$APPLE_MUSIC" -mindepth 1 -type d -empty -delete 2>/dev/null || true

--- a/modules/services/media/music-alac-sync.nix
+++ b/modules/services/media/music-alac-sync.nix
@@ -33,10 +33,11 @@ in
       serviceConfig = {
         Type = "oneshot";
         ExecStart = pkgs.writeShellScript "music-alac-sync" ''
-          set -euo pipefail
+          set -uo pipefail
           MUSIC="${cfg.musicDir}"
           APPLE_MUSIC="${cfg.appleMusicDir}"
           FFMPEG="${pkgs.ffmpeg}/bin/ffmpeg"
+          REALPATH="${pkgs.coreutils}/bin/realpath"
 
           echo "=== music-alac-sync: $(date) ==="
 
@@ -54,8 +55,9 @@ in
           echo "Forward sync: converting new audio files to ALAC..."
           converted=0
           copied=0
-          while IFS= read -r src; do
-            rel="''${src#$MUSIC/}"
+          errors=0
+          while IFS= read -r -d "" src; do
+            rel=$($REALPATH --relative-to="$MUSIC" "$src")
             dest_dir="$APPLE_MUSIC/$(dirname "$rel")"
             base="$(basename "$rel")"
             stem="''${base%.*}"
@@ -72,23 +74,28 @@ in
             mkdir -p "$dest_dir"
             if is_audio "$ext"; then
               echo "  Converting: $rel"
-              $FFMPEG -i "$src" -c:a alac -c:v copy -map_metadata 0 "$dest" -y -loglevel error
-              converted=$((converted + 1))
+              if ! $FFMPEG -i "$src" -c:a alac -c:v copy -map_metadata 0 "$dest" -y -loglevel error 2>&1; then
+                echo "  ERROR: failed to convert $rel"
+                rm -f "$dest"
+                errors=$((errors + 1))
+              else
+                converted=$((converted + 1))
+              fi
             else
               echo "  Copying: $rel"
               cp "$src" "$dest"
               copied=$((copied + 1))
             fi
-          done < <(find "$MUSIC" -type f | sort)
-          echo "  Converted $converted audio file(s), copied $copied other file(s)."
+          done < <(find "$MUSIC" -type f -print0)
+          echo "  Converted $converted audio file(s), copied $copied other file(s), $errors error(s)."
 
           # 2. Reverse sync: remove files from AppleMusic whose source no longer exists.
           #    For .m4a files, check for any audio source extension with the same stem.
           #    For all other files, check for the exact same relative path.
           echo "Reverse sync: removing orphaned files from AppleMusic..."
           removed=0
-          while IFS= read -r dest; do
-            rel="''${dest#$APPLE_MUSIC/}"
+          while IFS= read -r -d "" dest; do
+            rel=$($REALPATH --relative-to="$APPLE_MUSIC" "$dest")
             dir="$(dirname "$rel")"
             base="$(basename "$rel")"
             stem="''${base%.*}"
@@ -111,7 +118,7 @@ in
               rm "$dest"
               removed=$((removed + 1))
             fi
-          done < <(find "$APPLE_MUSIC" -type f | sort)
+          done < <(find "$APPLE_MUSIC" -type f -print0)
 
           # Clean up directories that became empty after removals
           find "$APPLE_MUSIC" -mindepth 1 -type d -empty -delete 2>/dev/null || true

--- a/modules/services/media/music-alac-sync.nix
+++ b/modules/services/media/music-alac-sync.nix
@@ -1,0 +1,135 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.musicAlacSync;
+in
+{
+  options.modules.services.media.musicAlacSync = {
+    enable = mkEnableOption "nightly Music to ALAC sync for Apple Music";
+
+    musicDir = mkOption {
+      type = types.str;
+      default = "/data/media/Music";
+      description = "Source music library path";
+    };
+
+    appleMusicDir = mkOption {
+      type = types.str;
+      default = "/data/media/AppleMusic";
+      description = "Destination ALAC library path mirroring the source";
+    };
+
+    calendar = mkOption {
+      type = types.str;
+      default = "04:17";
+      description = "Systemd OnCalendar expression for when to run";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.music-alac-sync = {
+      description = "Sync Music library to ALAC for Apple Music";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "music-alac-sync" ''
+          set -euo pipefail
+          MUSIC="${cfg.musicDir}"
+          APPLE_MUSIC="${cfg.appleMusicDir}"
+          FFMPEG="${pkgs.ffmpeg}/bin/ffmpeg"
+
+          echo "=== music-alac-sync: $(date) ==="
+
+          # Returns 0 if the extension is a supported audio format
+          is_audio() {
+            case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+              flac|mp3|m4a|wav|aiff|aif|ogg|opus|wma) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # 1. Forward sync: for each file in Music, ensure AppleMusic is up to date.
+          #    Audio files are converted to ALAC .m4a; all other files are copied as-is.
+          #    Files whose destination already exists are skipped (no re-encoding).
+          echo "Forward sync: converting new audio files to ALAC..."
+          converted=0
+          copied=0
+          while IFS= read -r src; do
+            rel="''${src#$MUSIC/}"
+            dest_dir="$APPLE_MUSIC/$(dirname "$rel")"
+            base="$(basename "$rel")"
+            stem="''${base%.*}"
+            ext="''${base##*.}"
+
+            if is_audio "$ext"; then
+              dest="$dest_dir/$stem.m4a"
+            else
+              dest="$dest_dir/$base"
+            fi
+
+            [ -f "$dest" ] && continue
+
+            mkdir -p "$dest_dir"
+            if is_audio "$ext"; then
+              echo "  Converting: $rel"
+              $FFMPEG -i "$src" -c:a alac -c:v copy -map_metadata 0 "$dest" -y -loglevel error
+              converted=$((converted + 1))
+            else
+              echo "  Copying: $rel"
+              cp "$src" "$dest"
+              copied=$((copied + 1))
+            fi
+          done < <(find "$MUSIC" -type f | sort)
+          echo "  Converted $converted audio file(s), copied $copied other file(s)."
+
+          # 2. Reverse sync: remove files from AppleMusic whose source no longer exists.
+          #    For .m4a files, check for any audio source extension with the same stem.
+          #    For all other files, check for the exact same relative path.
+          echo "Reverse sync: removing orphaned files from AppleMusic..."
+          removed=0
+          while IFS= read -r dest; do
+            rel="''${dest#$APPLE_MUSIC/}"
+            dir="$(dirname "$rel")"
+            base="$(basename "$rel")"
+            stem="''${base%.*}"
+            ext="''${base##*.}"
+
+            found=0
+            if [ "$ext" = "m4a" ]; then
+              for src_ext in flac mp3 m4a wav aiff aif ogg opus wma; do
+                if [ -f "$MUSIC/$dir/$stem.$src_ext" ]; then
+                  found=1
+                  break
+                fi
+              done
+            else
+              [ -f "$MUSIC/$rel" ] && found=1
+            fi
+
+            if [ "$found" = "0" ]; then
+              echo "  Removing orphan: $rel"
+              rm "$dest"
+              removed=$((removed + 1))
+            fi
+          done < <(find "$APPLE_MUSIC" -type f | sort)
+
+          # Clean up directories that became empty after removals
+          find "$APPLE_MUSIC" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+
+          echo "  Removed $removed orphaned file(s)."
+          echo "=== music-alac-sync done ==="
+        '';
+      };
+    };
+
+    systemd.timers.music-alac-sync = {
+      description = "Nightly Music to ALAC sync timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.calendar;
+        Persistent = true;
+        Unit = "music-alac-sync.service";
+      };
+    };
+  };
+}

--- a/modules/services/media/music-alac-sync.nix
+++ b/modules/services/media/music-alac-sync.nix
@@ -77,12 +77,57 @@ in
             mkdir -p "$dest_dir"
             if is_audio "$ext"; then
               echo "  Converting: $rel"
-              if ! $FFMPEG -i "$src" -c:a alac -c:v copy -map_metadata 0 "$dest" -y -loglevel error 2>&1; then
-                echo "  ERROR: failed to convert $rel"
-                rm -f "$dest"
-                errors=$((errors + 1))
+
+              # Check whether the source already has an embedded image stream
+              src_has_cover=0
+              if ${pkgs.ffmpeg}/bin/ffprobe -i "$src" -show_streams -select_streams v \
+                  -loglevel error 2>/dev/null | grep -q "codec_type=video"; then
+                src_has_cover=1
+              fi
+
+              # If no embedded art, look for a cover image file alongside the source
+              cover_file=""
+              if [ "$src_has_cover" = "0" ]; then
+                for cover_name in cover.jpg cover.png folder.jpg folder.png; do
+                  if [ -f "$(dirname "$src")/$cover_name" ]; then
+                    cover_file="$(dirname "$src")/$cover_name"
+                    break
+                  fi
+                done
+              fi
+
+              # -map 0         — include all streams from source (audio + embedded art)
+              # -map_metadata 0 — copy all metadata tags (title, artist, album, year, genre, lyrics, ISRC…)
+              # -map_chapters 0 — copy chapter markers (useful for audiobooks)
+              # -c:a alac      — convert audio to Apple Lossless
+              # -c:v copy      — copy embedded image stream without re-encoding
+              if [ -n "$cover_file" ]; then
+                # Source has no embedded art but a cover file exists — inject it
+                if ! $FFMPEG -i "$src" -i "$cover_file" \
+                    -map 0:a -map 1:v \
+                    -map_metadata 0 -map_chapters 0 \
+                    -c:a alac -c:v mjpeg \
+                    -metadata:s:v:0 title="Album cover" \
+                    -metadata:s:v:0 comment="Cover (front)" \
+                    "$dest" -y -loglevel error 2>&1; then
+                  echo "  ERROR: failed to convert $rel"
+                  rm -f "$dest"
+                  errors=$((errors + 1))
+                else
+                  converted=$((converted + 1))
+                fi
               else
-                converted=$((converted + 1))
+                if ! $FFMPEG -i "$src" \
+                    -map 0 \
+                    -map_metadata 0 -map_chapters 0 \
+                    -c:a alac -c:v copy \
+                    "$dest" -y -loglevel error 2>&1; then
+                  echo "  ERROR: failed to convert $rel"
+                  rm -f "$dest"
+                  errors=$((errors + 1))
+                else
+                  converted=$((converted + 1))
+                fi
               fi
             else
               echo "  Copying: $rel"

--- a/modules/services/media/music-alac-sync.nix
+++ b/modules/services/media/music-alac-sync.nix
@@ -37,7 +37,6 @@ in
           MUSIC="${cfg.musicDir}"
           APPLE_MUSIC="${cfg.appleMusicDir}"
           FFMPEG="${pkgs.ffmpeg}/bin/ffmpeg"
-          REALPATH="${pkgs.coreutils}/bin/realpath"
 
           echo "=== music-alac-sync: $(date) ==="
 
@@ -52,12 +51,15 @@ in
           # 1. Forward sync: for each file in Music, ensure AppleMusic is up to date.
           #    Audio files are converted to ALAC .m4a; all other files are copied as-is.
           #    Files whose destination already exists are skipped (no re-encoding).
+          #    Run find from within $MUSIC so paths are always relative — no stripping needed.
           echo "Forward sync: converting new audio files to ALAC..."
           converted=0
           copied=0
           errors=0
-          while IFS= read -r -d "" src; do
-            rel=$($REALPATH --relative-to="$MUSIC" "$src")
+          cd "$MUSIC"
+          while IFS= read -r -d "" rel; do
+            rel="''${rel#./}"
+            src="$MUSIC/$rel"
             dest_dir="$APPLE_MUSIC/$(dirname "$rel")"
             base="$(basename "$rel")"
             stem="''${base%.*}"
@@ -86,7 +88,7 @@ in
               cp "$src" "$dest"
               copied=$((copied + 1))
             fi
-          done < <(find "$MUSIC" -type f -print0)
+          done < <(find . -type f -print0)
           echo "  Converted $converted audio file(s), copied $copied other file(s), $errors error(s)."
 
           # 2. Reverse sync: remove files from AppleMusic whose source no longer exists.
@@ -94,8 +96,10 @@ in
           #    For all other files, check for the exact same relative path.
           echo "Reverse sync: removing orphaned files from AppleMusic..."
           removed=0
-          while IFS= read -r -d "" dest; do
-            rel=$($REALPATH --relative-to="$APPLE_MUSIC" "$dest")
+          cd "$APPLE_MUSIC"
+          while IFS= read -r -d "" rel; do
+            rel="''${rel#./}"
+            dest="$APPLE_MUSIC/$rel"
             dir="$(dirname "$rel")"
             base="$(basename "$rel")"
             stem="''${base%.*}"
@@ -118,7 +122,7 @@ in
               rm "$dest"
               removed=$((removed + 1))
             fi
-          done < <(find "$APPLE_MUSIC" -type f -print0)
+          done < <(find . -type f -print0)
 
           # Clean up directories that became empty after removals
           find "$APPLE_MUSIC" -mindepth 1 -type d -empty -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Adds `modules/services/media/music-alac-sync.nix` — a nightly systemd service that mirrors `/data/media/Music` as ALAC `.m4a` into `/data/media/AppleMusic`
- Forward sync converts audio files (flac, mp3, wav, etc.) to ALAC on first encounter; skips already-converted files so nothing is re-encoded
- Non-audio files (artwork, lyrics) are copied as-is
- Reverse sync removes orphans from AppleMusic when source files are deleted or renamed
- Enabled on david, runs at 4:17 AM daily (after music-dedup at 3:17 AM)

## Notes

- `find` is run from within the source directory (`cd "$MUSIC" && find .`) to avoid prefix-stripping issues with absolute paths
- Library contains symlinks; paths through them show a harmless double-slash in logs but resolve correctly on Linux