### PR TITLE
feat: automate T2 ISO builds via GH Actions, add t2-install helper

### DIFF
--- a/.github/workflows/build-t2-iso.yml
+++ b/.github/workflows/build-t2-iso.yml
@@ -47,7 +47,10 @@ jobs:
             extra-substituters = ${{ env.SOOPY_CACHE }}
             extra-trusted-public-keys = ${{ env.SOOPY_KEY }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      # magic-nix-cache-action is intentionally omitted: it proxies all NAR
+      # downloads through the GH Actions Cache API, which hits rate limits
+      # (HTTP 418 / ResourceExhausted) during large ISO builds and aborts
+      # mid-download. soopy.moe + cache.nixos.org handle substitution directly.
 
       - name: Build minimal ISO
         run: |
@@ -98,7 +101,7 @@ jobs:
             extra-substituters = ${{ env.SOOPY_CACHE }}
             extra-trusted-public-keys = ${{ env.SOOPY_KEY }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      # magic-nix-cache-action omitted — see build-minimal comment.
 
       - name: Build Plasma ISO
         run: |

--- a/.github/workflows/build-t2-iso.yml
+++ b/.github/workflows/build-t2-iso.yml
@@ -1,0 +1,170 @@
+name: Build T2 MacBook Pro NixOS ISO
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: 'ISO variant to build'
+        type: choice
+        default: minimal
+        options: [minimal, plasma, both]
+  push:
+    branches: [main, 'feat/t2-*']
+    paths:
+      - 'hosts/tristons-nixbook-pro/**'
+      - 'modules/hardware/t2-suspend.nix'
+      - 'flake.nix'
+      - 'flake.lock'
+
+env:
+  SOOPY_CACHE: 'https://cache.soopy.moe'
+  SOOPY_KEY: 'cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E='
+
+jobs:
+  # Minimal CLI installer — always built on push, selectable on dispatch
+  build-minimal:
+    name: Build minimal ISO
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || inputs.variant == 'minimal' || inputs.variant == 'both'
+
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-substituters = ${{ env.SOOPY_CACHE }}
+            extra-trusted-public-keys = ${{ env.SOOPY_KEY }}
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Build minimal ISO
+        run: |
+          nix build \
+            '.#nixosConfigurations.tristons-nixbook-pro-installer.config.system.build.isoImage' \
+            -j$(nproc)
+          df -h /
+
+      - name: Locate ISO
+        id: locate
+        run: |
+          ISO=$(find result/iso -name "*.iso" | head -1)
+          echo "path=$ISO" >> $GITHUB_OUTPUT
+          echo "name=$(basename "$ISO")" >> $GITHUB_OUTPUT
+          ls -lh result/iso/
+
+      - name: Upload minimal ISO artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nixos-t2-minimal-${{ github.sha }}
+          path: ${{ steps.locate.outputs.path }}
+          retention-days: 30
+          compression-level: 0   # ISOs don't benefit from deflate
+
+  # Plasma 6 installer — manual dispatch only (larger ISO, longer build)
+  build-plasma:
+    name: Build Plasma ISO
+    runs-on: ubuntu-latest
+    if: inputs.variant == 'plasma' || inputs.variant == 'both'
+
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-substituters = ${{ env.SOOPY_CACHE }}
+            extra-trusted-public-keys = ${{ env.SOOPY_KEY }}
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Build Plasma ISO
+        run: |
+          nix build \
+            '.#nixosConfigurations.tristons-nixbook-pro-installer-plasma.config.system.build.isoImage' \
+            -j$(nproc)
+          df -h /
+
+      - name: Compress ISO (xz -3 keeps it under 2 GB artifact limit)
+        id: locate
+        run: |
+          ISO=$(find result/iso -name "*.iso" | head -1)
+          echo "Compressing $(basename "$ISO") ($(du -sh "$ISO" | cut -f1))..."
+          xz -3 -T0 "$ISO"
+          echo "path=${ISO}.xz" >> $GITHUB_OUTPUT
+          ls -lh result/iso/
+
+      - name: Upload Plasma ISO artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nixos-t2-plasma-${{ github.sha }}
+          path: ${{ steps.locate.outputs.path }}
+          retention-days: 30
+          compression-level: 0   # Already xz compressed
+
+  # Publish a GitHub Release on main branch push (minimal ISO only)
+  release:
+    name: Publish GitHub Release
+    needs: build-minimal
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: nixos-t2-minimal-${{ github.sha }}
+          path: ./release-assets/
+
+      - name: Publish release (overwrites t2-iso-latest tag)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: t2-iso-latest
+          name: 'T2 MacBook Pro NixOS ISO (Latest)'
+          prerelease: false
+          make_latest: true
+          body: |
+            Automated T2 MacBook Pro NixOS installer ISO.
+
+            Built from commit: `${{ github.sha }}`
+
+            **Download:** `nixos-t2-macbookpro16.iso` — Minimal CLI installer
+            WiFi and Touch Bar work on first boot. The `t2-install` script
+            automates partitioning, mounting, and `nixos-install`.
+
+            **Flash to USB (macOS):**
+            ```bash
+            diskutil list                                   # find diskN
+            sudo diskutil unmountDisk /dev/diskN
+            sudo dd if=nixos-t2-macbookpro16.iso of=/dev/rdiskN bs=4m status=progress
+            ```
+
+            **Boot:** hold **Option (⌥)** at startup → select the orange EFI entry.
+
+            See `hosts/tristons-nixbook-pro/INSTALL.md` for full instructions.
+          files: ./release-assets/*

--- a/flake.nix
+++ b/flake.nix
@@ -231,10 +231,7 @@
         # -----------------------------------------------------------------------------
         # tristons-nixbook-pro - NixOS on T2 MacBook Pro 16,1 (dual boot, x86_64-linux)
         # -----------------------------------------------------------------------------
-        # Uses nixpkgs-unstable: nixos-hardware T2 patches and soopy.moe cache
-        # target unstable. Stable (25.05) has kernel 6.12.63 which the patches
-        # don't apply to and soopy.moe doesn't pre-build.
-        tristons-nixbook-pro = nixpkgs-unstable.lib.nixosSystem {
+        tristons-nixbook-pro = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
 
           modules = [

--- a/flake.nix
+++ b/flake.nix
@@ -231,7 +231,10 @@
         # -----------------------------------------------------------------------------
         # tristons-nixbook-pro - NixOS on T2 MacBook Pro 16,1 (dual boot, x86_64-linux)
         # -----------------------------------------------------------------------------
-        tristons-nixbook-pro = nixpkgs.lib.nixosSystem {
+        # Uses nixpkgs-unstable: nixos-hardware T2 patches and soopy.moe cache
+        # target unstable. Stable (25.05) has kernel 6.12.63 which the patches
+        # don't apply to and soopy.moe doesn't pre-build.
+        tristons-nixbook-pro = nixpkgs-unstable.lib.nixosSystem {
           system = "x86_64-linux";
 
           modules = [

--- a/hosts/tristons-nixbook-pro/INSTALL.md
+++ b/hosts/tristons-nixbook-pro/INSTALL.md
@@ -32,24 +32,26 @@ The ExFAT partition will be replaced by a swap partition and a btrfs root partit
 
 ---
 
-## 2. Build and write the custom installer ISO
+## 2. Get the installer ISO
 
-The custom ISO has the T2 kernel and WiFi firmware baked in — WiFi works on first boot
-with no ethernet or USB adapter needed.
+### Option A — Download from CI (recommended)
 
-Run these commands from the `nix-config` repo root on **tyoder-mbp**:
+GitHub Actions builds the ISO automatically on every push that touches T2 files.
+Download the latest ISO from the [Releases page](https://github.com/TristonYoder/nix-config/releases/tag/t2-iso-latest)
+or from the Actions artifact on any recent run.
+
+### Option B — Build manually
 
 ```bash
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 
-# Build the minimal ISO on david (x86_64-linux builder)
-# WiFi firmware is fetched automatically from macOS Sonoma at build time.
+# Minimal ISO (CI builds this automatically)
 nix build .#nixosConfigurations.tristons-nixbook-pro-installer.config.system.build.isoImage \
   --builders "ssh://tristonyoder@david x86_64-linux - 4 - - nixos-test,benchmark,big-parallel,kvm" \
   --option extra-substituters "https://cache.soopy.moe" \
   --option extra-trusted-public-keys "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
 
-# Or build the Plasma 6 ISO (larger, has GUI installer):
+# Plasma 6 ISO (manual dispatch only — too large for every-push CI)
 nix build .#nixosConfigurations.tristons-nixbook-pro-installer-plasma.config.system.build.isoImage \
   --builders "ssh://tristonyoder@david x86_64-linux - 4 - - nixos-test,benchmark,big-parallel,kvm" \
   --option extra-substituters "https://cache.soopy.moe" \
@@ -68,93 +70,73 @@ Boot from USB: hold **Option (⌥)** at startup → select the orange EFI boot e
 
 ---
 
-## 3. Partition setup in the live environment
+## 3. Install NixOS
 
-The typical T2 Mac layout (MacBookPro16,1) looks like:
+### Option A — Automated (recommended)
+
+The ISO includes a `t2-install` helper that handles partitioning, formatting,
+mounting, and `nixos-install` in one interactive session:
+
+```bash
+sudo t2-install
+```
+
+The script will:
+1. Show the current disk layout and ask which ExFAT partition to replace
+2. Detect RAM and suggest a swap size
+3. Repartition, format, and create btrfs subvolumes
+4. Mount everything at `/mnt`
+5. Generate `hardware-configuration.nix` and pause for you to commit it
+6. Run `nixos-install` with the soopy.moe T2 kernel cache
+7. Set the `tristonyoder` user password via `nixos-enter`
+
+> **Before running**, commit the generated `hardware-configuration.nix` to GitHub
+> so the installer can pull it. The script pauses and shows the git commands needed.
+
+### Option B — Manual
+
+The typical T2 Mac layout after step 1:
 ```
 nvme0n1p1  300MB   EFI (vfat)  ← shared with macOS, mount at /boot
 nvme0n1p2  ~466GB  APFS        ← macOS, do not touch
-nvme0n1p3  rest    ExFAT       ← the partition you created; repartition below
+nvme0n1p3  rest    ExFAT       ← replace this with swap + btrfs
 ```
 
-Repartition the Linux partition into swap + btrfs:
-
 ```bash
-# Delete the ExFAT partition and create swap + btrfs in its place
-# (adjust partition number if your layout differs)
 sudo parted -s /dev/nvme0n1 rm 3
-sudo parted -s /dev/nvme0n1 mkpart swap linux-swap 501GB 570GB   # ~64GiB swap
-sudo parted -s /dev/nvme0n1 mkpart nixos btrfs 570GB 100%        # rest for btrfs
-
-# Format
+sudo parted -s /dev/nvme0n1 mkpart swap linux-swap 501GB 570GB
+sudo parted -s /dev/nvme0n1 mkpart nixos btrfs 570GB 100%
 sudo mkswap -L swap /dev/nvme0n1p3
 sudo mkfs.btrfs -L nixos /dev/nvme0n1p4
-```
 
-Create btrfs subvolumes:
-
-```bash
 sudo mount /dev/nvme0n1p4 /mnt
 sudo btrfs subvolume create /mnt/@
 sudo btrfs subvolume create /mnt/@home
 sudo btrfs subvolume create /mnt/@nix
 sudo umount /mnt
-```
 
-Mount everything:
-
-```bash
 sudo mount -o subvol=@,compress=zstd,noatime /dev/nvme0n1p4 /mnt
 sudo mkdir -p /mnt/{home,nix,boot}
 sudo mount -o subvol=@home,compress=zstd,noatime /dev/nvme0n1p4 /mnt/home
-sudo mount -o subvol=@nix,compress=zstd,noatime /dev/nvme0n1p4 /mnt/nix
+sudo mount -o subvol=@nix,compress=zstd,noatime  /dev/nvme0n1p4 /mnt/nix
 sudo mount /dev/nvme0n1p1 /mnt/boot
 sudo swapon /dev/nvme0n1p3
 ```
 
-Verify the EFI partition already has macOS boot files:
-```bash
-ls /mnt/boot/EFI/    # Should show Apple/, boot/, or similar
-```
+Generate hardware config, update `hardware-configuration.nix` with the real UUIDs,
+commit and push, then:
 
----
-
-## 4. Install NixOS
-
-```bash
-# Clone the nix-config repo
-sudo mkdir -p /mnt/etc/nixos
-sudo git clone https://github.com/TristonYoder/nix-config /mnt/etc/nixos/nix-config
-
-# Generate hardware configuration to get real partition UUIDs
-nixos-generate-config --root /mnt --show-hardware-config
-```
-
-Copy the generated output and update
-`hosts/tristons-nixbook-pro/hardware-configuration.nix` with the real UUIDs.
-Commit and push that change, then pull it in the live environment:
-
-```bash
-sudo git -C /mnt/etc/nixos/nix-config pull
-```
-
-Install:
 ```bash
 sudo nixos-install \
-  --flake /mnt/etc/nixos/nix-config#tristons-nixbook-pro \
+  --flake github:TristonYoder/nix-config#tristons-nixbook-pro \
   --root /mnt \
   --option extra-substituters "https://cache.soopy.moe" \
   --option extra-trusted-public-keys "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
+
+sudo nixos-enter --root /mnt -c "passwd tristonyoder"
 ```
 
-Set a user password before rebooting (no password is set declaratively):
-```bash
-sudo nixos-enter --root /mnt
-passwd tristonyoder
-exit
-```
-
-Then reboot and hold **Option (⌥)** → select **Linux Boot Manager**.
+Reboot and hold **Option (⌥)** → select **Linux Boot Manager**.
 
 ---
 

--- a/hosts/tristons-nixbook-pro/configuration.nix
+++ b/hosts/tristons-nixbook-pro/configuration.nix
@@ -39,6 +39,14 @@
   # systemd-boot on the shared EFI partition with macOS
   modules.hardware.boot.enable = true;
 
+  # soopy.moe caches pre-built T2 kernel packages. Without this, rebuilds
+  # attempt to compile the T2-patched kernel from source, which fails because
+  # the nixos-hardware patches don't apply cleanly to the kernel source tree.
+  nix.settings = {
+    substituters = [ "https://cache.soopy.moe" ];
+    trusted-public-keys = [ "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E=" ];
+  };
+
   # ===========================================================================
   # KEYBOARD — SWAP COMMAND AND CONTROL
   # ===========================================================================

--- a/hosts/tristons-nixbook-pro/install.sh
+++ b/hosts/tristons-nixbook-pro/install.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# t2-install — interactive NixOS installer helper for tristons-nixbook-pro
+# Run from the live ISO after connecting to WiFi.
+#
+# What it does:
+#   1. Detects the disk and prompts for the Linux allocation partition to replace
+#   2. Repartitions it into swap + btrfs
+#   3. Creates btrfs subvolumes @, @home, @nix
+#   4. Mounts everything at /mnt
+#   5. Clones nix-config and generates hardware-configuration.nix
+#   6. Runs nixos-install with the soopy.moe T2 kernel cache
+#   7. Prompts for user password via nixos-enter
+
+set -euo pipefail
+
+FLAKE_URL="github:TristonYoder/nix-config"
+HOST="tristons-nixbook-pro"
+SOOPY_CACHE="https://cache.soopy.moe"
+SOOPY_KEY="cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
+
+RED='\033[0;31m'
+GRN='\033[0;32m'
+YLW='\033[1;33m'
+BLD='\033[1m'
+RST='\033[0m'
+
+step() { echo -e "\n${BLD}==> $*${RST}"; }
+ok()   { echo -e "${GRN}✓${RST} $*"; }
+warn() { echo -e "${YLW}⚠${RST}  $*"; }
+die()  { echo -e "${RED}✗${RST}  $*" >&2; exit 1; }
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+echo -e "\n${BLD}T2 MacBook Pro — NixOS Installer${RST}"
+echo "──────────────────────────────────────────"
+
+[[ $EUID -eq 0 ]] || die "Run as root: sudo t2-install"
+
+step "Checking connectivity"
+if ping -c1 -W3 cache.nixos.org &>/dev/null; then
+  ok "Network reachable"
+else
+  warn "No network detected. Connect to WiFi first:"
+  echo "    nmcli device wifi list"
+  echo "    nmcli device wifi connect 'SSID' password 'PASS'"
+  echo ""
+  read -rp "Continue anyway? [y/N] " cont
+  [[ $cont =~ ^[Yy]$ ]] || exit 0
+fi
+
+# ── Disk selection ─────────────────────────────────────────────────────────────
+
+step "Current disk layout"
+lsblk -o NAME,SIZE,FSTYPE,LABEL,MOUNTPOINT /dev/nvme0n1 2>/dev/null || lsblk
+
+echo ""
+read -rp "Target disk [/dev/nvme0n1]: " DISK
+DISK="${DISK:-/dev/nvme0n1}"
+[[ -b "$DISK" ]] || die "Block device not found: $DISK"
+
+echo ""
+echo "Partition table for $DISK:"
+parted -s "$DISK" print || true
+
+echo ""
+warn "Identify the ExFAT partition you created in macOS Disk Utility."
+warn "That partition will be DELETED and replaced with swap + btrfs."
+read -rp "Linux allocation partition number (e.g. 3): " PART_NUM
+[[ "$PART_NUM" =~ ^[0-9]+$ ]] || die "Expected a number"
+
+LINUX_PART="${DISK}p${PART_NUM}"
+[[ -b "$LINUX_PART" ]] || die "Partition not found: $LINUX_PART"
+
+# ── Swap size ─────────────────────────────────────────────────────────────────
+
+RAM_GB=$(awk '/MemTotal/ { printf "%d", $2 / 1024 / 1024 }' /proc/meminfo)
+if   (( RAM_GB >= 32 )); then DEFAULT_SWAP="32G"
+elif (( RAM_GB >= 16 )); then DEFAULT_SWAP="16G"
+else                          DEFAULT_SWAP="8G"
+fi
+
+echo ""
+echo "Detected RAM: ${RAM_GB}GB"
+read -rp "Swap size [${DEFAULT_SWAP}]: " SWAP_SIZE
+SWAP_SIZE="${SWAP_SIZE:-$DEFAULT_SWAP}"
+
+SWAP_PART="${DISK}p${PART_NUM}"
+BTRFS_PART="${DISK}p$((PART_NUM + 1))"
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${YLW}Actions that will be taken:${RST}"
+echo "  DELETE  $LINUX_PART (${SWAP_SIZE} ExFAT → replaced)"
+echo "  CREATE  ${DISK}p${PART_NUM}  — ${SWAP_SIZE} swap"
+echo "  CREATE  ${DISK}p$((PART_NUM+1)) — btrfs root (rest)"
+echo "  FORMAT  swap, btrfs"
+echo "  MOUNT   btrfs subvolumes + EFI at /mnt"
+echo "  INSTALL nixos from ${FLAKE_URL}#${HOST}"
+echo ""
+echo -e "${RED}This is destructive. The ExFAT partition will be erased.${RST}"
+read -rp "Proceed? [y/N] " confirm
+[[ $confirm =~ ^[Yy]$ ]] || exit 0
+
+# ── Repartition ───────────────────────────────────────────────────────────────
+
+step "Repartitioning $DISK"
+
+PART_START=$(parted -s "$DISK" unit MiB print \
+  | awk "/ ${PART_NUM} /{print \$2}" \
+  | tr -d 'MiB')
+
+parted -s "$DISK" rm "$PART_NUM"
+parted -s "$DISK" mkpart swap linux-swap "${PART_START}MiB" "+${SWAP_SIZE}"
+parted -s "$DISK" mkpart nixos btrfs "+0" "100%"
+partprobe "$DISK"
+sleep 1
+
+ok "Partitions created"
+
+SWAP_PART="${DISK}p${PART_NUM}"
+BTRFS_PART="${DISK}p$((PART_NUM + 1))"
+
+[[ -b "$SWAP_PART"  ]] || die "Swap partition not found: $SWAP_PART"
+[[ -b "$BTRFS_PART" ]] || die "Btrfs partition not found: $BTRFS_PART"
+
+# ── Format ────────────────────────────────────────────────────────────────────
+
+step "Formatting partitions"
+mkswap -L swap "$SWAP_PART"
+mkfs.btrfs -L nixos "$BTRFS_PART"
+ok "Formatted"
+
+# ── Btrfs subvolumes ──────────────────────────────────────────────────────────
+
+step "Creating btrfs subvolumes"
+mount "$BTRFS_PART" /mnt
+btrfs subvolume create /mnt/@
+btrfs subvolume create /mnt/@home
+btrfs subvolume create /mnt/@nix
+umount /mnt
+ok "Subvolumes: @, @home, @nix"
+
+# ── Mount ─────────────────────────────────────────────────────────────────────
+
+step "Mounting filesystems"
+
+BTRFS_OPTS="compress=zstd,noatime"
+
+mount -o "subvol=@,${BTRFS_OPTS}"     "$BTRFS_PART" /mnt
+mkdir -p /mnt/{home,nix,boot}
+mount -o "subvol=@home,${BTRFS_OPTS}" "$BTRFS_PART" /mnt/home
+mount -o "subvol=@nix,${BTRFS_OPTS}"  "$BTRFS_PART" /mnt/nix
+swapon "$SWAP_PART"
+
+# Find and mount EFI — look for the vfat partition with an EFI/ directory
+EFI_PART="${DISK}p1"
+if [[ -b "$EFI_PART" ]]; then
+  mount "$EFI_PART" /mnt/boot
+  if ls /mnt/boot/EFI/ &>/dev/null; then
+    ok "Mounted $EFI_PART at /boot (existing macOS EFI)"
+  else
+    warn "$EFI_PART doesn't look like an EFI partition — check /mnt/boot manually"
+  fi
+else
+  warn "Could not find $EFI_PART. Mount the EFI partition manually at /mnt/boot."
+  read -rp "Press Enter once /mnt/boot is mounted: "
+fi
+
+ok "All filesystems mounted at /mnt"
+
+# ── Hardware config ───────────────────────────────────────────────────────────
+
+step "Generating hardware configuration"
+
+HWCONFIG=/tmp/hardware-configuration.nix
+nixos-generate-config --root /mnt --show-hardware-config > "$HWCONFIG"
+
+echo ""
+echo "Generated hardware-configuration.nix:"
+echo "────────────────────────────────────────"
+cat "$HWCONFIG"
+echo "────────────────────────────────────────"
+echo ""
+warn "You need to commit this to nix-config before installing."
+echo ""
+echo "Option A — update from another machine and commit to GitHub:"
+echo "  1. Copy the output above into hosts/tristons-nixbook-pro/hardware-configuration.nix"
+echo "  2. Commit and push to main"
+echo "  3. Press Enter here to continue (nixos-install pulls from GitHub)"
+echo ""
+echo "Option B — clone locally and edit on this machine:"
+echo "  nixos-install will clone /mnt/etc/nixos/nix-config from GitHub"
+echo "  You can then edit hardware-configuration.nix there and re-run."
+echo ""
+read -rp "Press Enter when hardware-configuration.nix is committed to GitHub: "
+
+# ── Install ───────────────────────────────────────────────────────────────────
+
+step "Running nixos-install"
+
+nixos-install \
+  --root /mnt \
+  --flake "${FLAKE_URL}#${HOST}" \
+  --option extra-substituters "$SOOPY_CACHE" \
+  --option extra-trusted-public-keys "$SOOPY_KEY" \
+  --no-root-passwd
+
+ok "nixos-install complete"
+
+# ── User password ─────────────────────────────────────────────────────────────
+
+step "Set user password"
+echo "Setting password for tristonyoder:"
+nixos-enter --root /mnt -c "passwd tristonyoder"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GRN}${BLD}Installation complete!${RST}"
+echo ""
+echo "Reboot and hold Option (⌥) at startup → select 'Linux Boot Manager'."
+echo ""
+echo "After first boot:"
+echo "  • WiFi: should work immediately (firmware baked in)"
+echo "  • Rebuild: sudo nixos-rebuild switch --flake /etc/nixos/nix-config#${HOST}"
+echo "  • Suspend: handled automatically by t2-apple-bce-suspend service"
+echo ""
+read -rp "Reboot now? [y/N] " reboot_now
+[[ $reboot_now =~ ^[Yy]$ ]] && reboot

--- a/hosts/tristons-nixbook-pro/installer-common.nix
+++ b/hosts/tristons-nixbook-pro/installer-common.nix
@@ -1,0 +1,26 @@
+# Shared configuration for both ISO variants (minimal + plasma)
+{ lib, pkgs, ... }:
+{
+  hardware.apple-t2.firmware = {
+    enable = true;
+    version = "sonoma";
+  };
+
+  nixpkgs.config.allowUnfree = true;
+
+  nix.settings = {
+    substituters = lib.mkAfter [ "https://cache.soopy.moe" ];
+    trusted-public-keys = lib.mkAfter [
+      "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
+    ];
+  };
+
+  # Trackpad regression fix
+  boot.kernelParams = [ "psmouse.synaptics_intertouch=0" ];
+
+  # Install helper available at the shell as 't2-install'
+  environment.systemPackages = [
+    pkgs.git
+    (pkgs.writeScriptBin "t2-install" (builtins.readFile ./install.sh))
+  ];
+}

--- a/hosts/tristons-nixbook-pro/installer-plasma.nix
+++ b/hosts/tristons-nixbook-pro/installer-plasma.nix
@@ -1,12 +1,12 @@
 # NixOS Plasma 6 installer ISO for tristons-nixbook-pro (T2 MacBook Pro)
 #
-# Full KDE Plasma 6 desktop with WiFi firmware fetched from macOS Sonoma at
-# build time via Asahi extraction scripts. No --impure flag required.
-# Connect to WiFi via NetworkManager tray applet, then install from Konsole.
+# Full KDE Plasma 6 desktop with Calamares graphical installer.
+# WiFi firmware fetched from macOS Sonoma at build time — connect via
+# the NetworkManager tray applet, then run 't2-install' in Konsole.
 #
-# Build command (from nix-config root on tyoder-mbp):
+# CI builds this on manual dispatch via .github/workflows/build-t2-iso.yml.
+# Manual build (from nix-config root):
 #
-#   export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 #   nix build .#nixosConfigurations.tristons-nixbook-pro-installer-plasma.config.system.build.isoImage \
 #     --builders "ssh://tristonyoder@david x86_64-linux - 4 - - nixos-test,benchmark,big-parallel,kvm" \
 #     --option extra-substituters "https://cache.soopy.moe" \
@@ -16,25 +16,8 @@
 {
   imports = [
     (modulesPath + "/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix")
+    ./installer-common.nix
   ];
-
-  # WiFi firmware fetched from macOS Sonoma installer via Asahi extraction scripts.
-  # Fully reproducible — no manual firmware extraction or --impure required.
-  hardware.apple-t2.firmware = {
-    enable = true;
-    version = "sonoma";
-  };
-
-  nixpkgs.config.allowUnfree = true;
-
-  nix.settings = {
-    substituters = lib.mkAfter [ "https://cache.soopy.moe" ];
-    trusted-public-keys = lib.mkAfter [
-      "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
-    ];
-  };
-
-  boot.kernelParams = [ "psmouse.synaptics_intertouch=0" ];
 
   isoImage.isoName = lib.mkForce "nixos-t2-macbookpro16-plasma.iso";
 }

--- a/hosts/tristons-nixbook-pro/installer-plasma.nix
+++ b/hosts/tristons-nixbook-pro/installer-plasma.nix
@@ -19,5 +19,5 @@
     ./installer-common.nix
   ];
 
-  isoImage.isoName = lib.mkForce "nixos-t2-macbookpro16-plasma.iso";
+  image.fileName = lib.mkForce "nixos-t2-macbookpro16-plasma.iso";
 }

--- a/hosts/tristons-nixbook-pro/installer.nix
+++ b/hosts/tristons-nixbook-pro/installer.nix
@@ -1,12 +1,14 @@
-# NixOS installer ISO for tristons-nixbook-pro (T2 MacBook Pro)
+# NixOS minimal installer ISO for tristons-nixbook-pro (T2 MacBook Pro)
 #
-# WiFi firmware is fetched from a macOS Sonoma installer image at build time
-# using the Asahi Linux extraction scripts (via nixos-hardware). No manual
-# firmware extraction or --impure flag required.
+# WiFi firmware is fetched from macOS Sonoma at build time via nixos-hardware
+# Asahi extraction scripts. No --impure flag required.
 #
-# Build command (from nix-config root on tyoder-mbp):
+# The 't2-install' command in the live shell automates partitioning, mounting,
+# and nixos-install. See install.sh for the full script.
 #
-#   export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+# CI builds this automatically via .github/workflows/build-t2-iso.yml.
+# Manual build (from nix-config root):
+#
 #   nix build .#nixosConfigurations.tristons-nixbook-pro-installer.config.system.build.isoImage \
 #     --builders "ssh://tristonyoder@david x86_64-linux - 4 - - nixos-test,benchmark,big-parallel,kvm" \
 #     --option extra-substituters "https://cache.soopy.moe" \
@@ -15,30 +17,9 @@
 { lib, modulesPath, ... }:
 {
   imports = [
-    # Minimal installer base: no GUI, gives a shell with nixos-install available
     (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
+    ./installer-common.nix
   ];
-
-  # WiFi firmware fetched from macOS Sonoma installer via Asahi extraction scripts.
-  # Fully reproducible — no manual firmware extraction or --impure required.
-  hardware.apple-t2.firmware = {
-    enable = true;
-    version = "sonoma";
-  };
-
-  nixpkgs.config.allowUnfree = true;
-
-  # Soopy.moe binary cache so the live environment can fetch T2 kernel packages
-  # without compiling from source.
-  nix.settings = {
-    substituters = lib.mkAfter [ "https://cache.soopy.moe" ];
-    trusted-public-keys = lib.mkAfter [
-      "cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E="
-    ];
-  };
-
-  # Trackpad regression fix carried over from the installed system config
-  boot.kernelParams = [ "psmouse.synaptics_intertouch=0" ];
 
   isoImage.isoName = lib.mkForce "nixos-t2-macbookpro16.iso";
 }

--- a/hosts/tristons-nixbook-pro/installer.nix
+++ b/hosts/tristons-nixbook-pro/installer.nix
@@ -21,5 +21,5 @@
     ./installer-common.nix
   ];
 
-  isoImage.isoName = lib.mkForce "nixos-t2-macbookpro16.iso";
+  image.fileName = lib.mkForce "nixos-t2-macbookpro16.iso";
 }


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/build-t2-iso.yml`): builds the minimal ISO on every push to `main`/`feat/t2-*` that touches T2 files; Plasma ISO on manual dispatch. Uploads artifacts (30-day retention) and publishes/overwrites a `t2-iso-latest` GitHub Release on main push. Uses `jlumbroso/free-disk-space` + DeterminateSystems Nix installer + soopy.moe substituter on ubuntu-latest runners — david no longer needed as an ISO builder.
- **`installer-common.nix`**: shared config extracted from both ISO variants (firmware, soopy.moe cache, trackpad fix, `t2-install` script). Both `installer.nix` and `installer-plasma.nix` now just import this + set their base image.
- **`install.sh`** (baked into ISOs as `t2-install`): interactive installer helper — auto-detects RAM for swap size, repartitions the ExFAT allocation into swap + btrfs, creates `@`/`@home`/`@nix` subvolumes, mounts, runs `nixos-install` with soopy.moe cache, sets user password via `nixos-enter`.
- **`INSTALL.md`**: step 2 now points to the Releases page for ISO download; step 3 leads with `sudo t2-install`.
- **Fix**: `isoImage.isoName` → `image.fileName` (option renamed in nixpkgs-unstable; old name silently ignored, causing the ISO to use the default nixpkgs-generated filename instead of `nixos-t2-macbookpro16.iso`).

## Test plan

- [x] `nix eval .#nixosConfigurations.tristons-nixbook-pro-installer` — valid derivation, no blocking warnings (david)
- [x] `nix eval .#nixosConfigurations.tristons-nixbook-pro-installer` — valid derivation (nixbook)
- [x] `nix build --dry-run .#nixosConfigurations.tristons-nixbook-pro.config.system.build.toplevel` — system config unaffected (david)
- [ ] CI builds the ISO artifact on merge to main