### PR TITLE
feat: allow sudo via SSH agent key (pam_ssh_agent_auth)

### DIFF
--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -17,6 +17,16 @@ in
       '';
     };
 
+    enableSshAgentSudo = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Allow sudo to authenticate via a forwarded/local SSH agent key (pam_ssh_agent_auth)
+        instead of a Unix password, using mainUser.sshKeys as the trusted key list.
+        Lets a fresh host with no password ever set still be administered remotely over SSH.
+      '';
+    };
+
     mainUser = {
       name = mkOption {
         type = types.str;
@@ -61,6 +71,18 @@ in
   };
 
   config = mkIf cfg.enable {
+    security.pam.sshAgentAuth = mkIf cfg.enableSshAgentSudo {
+      enable = true;
+      authorizedKeysFiles = [ "/etc/ssh/authorized_keys.d/%u" ];
+    };
+
+    security.pam.services.sudo.sshAgentAuth = cfg.enableSshAgentSudo;
+
+    environment.etc."ssh/authorized_keys.d/${cfg.mainUser.name}" = mkIf cfg.enableSshAgentSudo {
+      text = concatStringsSep "\n" cfg.mainUser.sshKeys + "\n";
+      mode = "0444";
+    };
+
     users.users.${cfg.mainUser.name} = {
       isNormalUser = true;
       description = cfg.mainUser.description;

--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -76,7 +76,7 @@ in
       authorizedKeysFiles = [ "/etc/ssh/authorized_keys.d/%u" ];
     };
 
-    security.pam.services.sudo.sshAgentAuth = cfg.enableSshAgentSudo;
+    security.pam.services.sudo.sshAgentAuth = mkIf cfg.enableSshAgentSudo true;
 
     users.users.${cfg.mainUser.name} = {
       isNormalUser = true;

--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -78,11 +78,6 @@ in
 
     security.pam.services.sudo.sshAgentAuth = cfg.enableSshAgentSudo;
 
-    environment.etc."ssh/authorized_keys.d/${cfg.mainUser.name}" = mkIf cfg.enableSshAgentSudo {
-      text = concatStringsSep "\n" cfg.mainUser.sshKeys + "\n";
-      mode = "0444";
-    };
-
     users.users.${cfg.mainUser.name} = {
       isNormalUser = true;
       description = cfg.mainUser.description;


### PR DESCRIPTION
## Summary
- Adds `modules.system.users.enableSshAgentSudo` (default `true`), wiring `security.pam.sshAgentAuth` for the `sudo` PAM service, trusting the same keys already in `mainUser.sshKeys` / each user's `openssh.authorizedKeys.keys`.
- Lets a freshly-installed host with no Unix password ever set still be administered remotely over SSH (agent-forwarded key satisfies sudo instead of a password prompt).

Motivated by tristons-workstation's first install: no password was ever configured for `tristonyoder`, and `nixos-rebuild`/`tailscale up` need root, so the only way to escalate was physical console access (systemd-boot `init=/bin/sh` rescue). This closes that gap going forward.

## Test plan
- [x] `nixos-rebuild dry-run` on tristons-workstation, david, and pits via david (cross-arch dry-run) — all build cleanly
- [ ] After merge, verify `sudo -A` (or equivalent agent-backed sudo) actually authenticates on a real host with an agent-forwarded key