### PR TITLE
fix: pin tristonyoder/carolineyoder UIDs across all hosts

### DIFF
--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -24,6 +24,19 @@ in
         description = "Main user account name";
       };
 
+      uid = mkOption {
+        type = types.int;
+        default = 1000;
+        description = ''
+          Fixed UID, pinned so it's identical on every host. Without this,
+          NixOS auto-assigns UIDs in user-creation order, which can silently
+          diverge per host (confirmed: tristons-workstation assigned 1001
+          while every other host has 1000) and breaks NFS (sec=sys checks
+          raw numeric UID, not username — a mismatch causes "permission
+          denied" reading a perfectly valid, correctly-owned directory).
+        '';
+      };
+
       description = mkOption {
         type = types.str;
         default = "Triston Yoder";
@@ -63,6 +76,7 @@ in
   config = mkIf cfg.enable {
     users.users.${cfg.mainUser.name} = {
       isNormalUser = true;
+      uid = cfg.mainUser.uid;
       description = cfg.mainUser.description;
       extraGroups = cfg.mainUser.extraGroups;
       packages = cfg.mainUser.packages;
@@ -71,8 +85,10 @@ in
     };
 
     # Caroline Yoder user account (only on hosts with data drive)
+    # uid pinned to match david (1002) for the same NFS reason as mainUser.uid above.
     users.users.carolineyoder = mkIf cfg.useDataDrive {
       isNormalUser = true;
+      uid = 1002;
       description = "Caroline Yoder";
       extraGroups = [ "nextcloud" ];
       packages = with pkgs; [

--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -34,6 +34,13 @@ in
           while every other host has 1000) and breaks NFS (sec=sys checks
           raw numeric UID, not username — a mismatch causes "permission
           denied" reading a perfectly valid, correctly-owned directory).
+
+          Only affects NEW accounts: NixOS's user activation refuses to
+          change the UID of an account that already exists (logs a
+          "not applying UID change" warning instead). A host whose UID has
+          already drifted needs a one-time manual fix before rebuilding:
+          `sudo usermod -u <uid> <name>` (and chown any locally-owned files
+          if the account has real local data, not just an NFS-backed home).
         '';
       };
 


### PR DESCRIPTION
## Summary
- Adds `modules.system.users.mainUser.uid` (default `1000`) and pins `carolineyoder`'s UID to `1002`, matching david.
- Without an explicit `uid`, NixOS assigns UIDs in user-creation order, which silently diverged on tristons-workstation's first install: `tristonyoder` got `1001` and `carolineyoder` got `1000` (reversed from david's `1000`/`1002`).
- This broke the NFS-backed home directory in a confusing way — `sec=sys` NFS auth checks the raw numeric UID, not the username, so the workstation's `tristonyoder` (UID 1001) got "permission denied" trying to access `/data/tristonyoder/home`, a directory it should rightfully own, because the server only recognizes UID 1000 as that owner.

## Test plan
- [x] `nixos-rebuild dry-run --flake .#david` — david's `tristonyoder`/`carolineyoder` are already 1000/1002, so this is a no-op there as expected
- [ ] `nixos-rebuild dry-run --flake .#tristons-workstation` — confirm clean eval (running now)
- [ ] After merge, rebuild tristons-workstation for real and confirm `id tristonyoder` reports `1000` and the NFS home directory is finally readable/writable