### PR TITLE
feat: CI deploy for tristons-workstation + NFS build cache module

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -77,7 +77,7 @@ jobs:
       id: set-hosts
       run: |
         # Define all available NixOS hosts
-        ALL_HOSTS='["david", "pits"]'  # tristons-workstation excluded from auto-deployment
+        ALL_HOSTS='["david", "pits", "tristons-workstation"]'  # always-online machine, safe for CI auto-deploy
         
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           INPUT_HOSTS="${{ github.event.inputs.hosts }}"

--- a/common/darwin.nix
+++ b/common/darwin.nix
@@ -51,6 +51,15 @@
   };
   
   # =============================================================================
+  # NIX BUILD CACHE
+  # =============================================================================
+
+  # All macOS hosts have Tailscale — pull from david's binary cache to avoid
+  # re-downloading store paths the CI build-offline-closures job already built.
+  nix.settings.substituters = [ "https://nix-cache.theyoder.family" ];
+  nix.settings.trusted-substituters = [ "https://nix-cache.theyoder.family" ];
+
+  # =============================================================================
   # MACOS SYSTEM PREFERENCES
   # =============================================================================
   

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -153,6 +153,16 @@
   # Local binary cache — /data/nix-builds/cache is on david's own disk.
   modules.system.nixCache.enable = true;
 
+  # Serve the Nix binary cache over HTTPS so all Tailscale hosts can use it.
+  modules.services.vHosts.hosts."nix-cache.${config.networking.domain}" = {
+    managedProxy = false;
+    public = false;
+    extraConfig = ''
+      root * /data/nix-builds/cache
+      file_server
+    '';
+  };
+
   # =============================================================================
   # ADDITIONAL SERVICES
   # =============================================================================

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -150,6 +150,9 @@
     ];
   };
 
+  # Local binary cache — /data/nix-builds/cache is on david's own disk.
+  modules.system.nixCache.enable = true;
+
   # =============================================================================
   # ADDITIONAL SERVICES
   # =============================================================================

--- a/hosts/pits/configuration.nix
+++ b/hosts/pits/configuration.nix
@@ -251,7 +251,10 @@
   # =============================================================================
   # MONITORING & ALERTS (Optional)
   # =============================================================================
-  
+
   # Consider adding monitoring for a public-facing server
   # Example: Prometheus node exporter, Grafana agent, etc.
+
+  # Pull built closures from david's binary cache over Tailscale.
+  modules.system.nixCache.enable = true;
 }

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -159,6 +159,10 @@
 
   # profiles/workstation.nix already defaults this to true; no override needed.
 
+  # /data/nix-builds/cache is NFS-mounted from david — pulls store paths built
+  # by the CI build-offline-closures job without hitting cache.nixos.org.
+  modules.system.nixCache.enable = true;
+
   # =============================================================================
   # PACKAGES
   # =============================================================================

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -159,9 +159,12 @@
 
   # profiles/workstation.nix already defaults this to true; no override needed.
 
-  # /data/nix-builds/cache is NFS-mounted from david — pulls store paths built
-  # by the CI build-offline-closures job without hitting cache.nixos.org.
-  modules.system.nixCache.enable = true;
+  # /data is NFS-mounted from david, so hit the cache directly on disk rather
+  # than going through the HTTPS endpoint.
+  modules.system.nixCache = {
+    enable = true;
+    cacheUrl = "file:///data/nix-builds/cache";
+  };
 
   # =============================================================================
   # PACKAGES

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -7,5 +7,6 @@
     ./networking.nix
     ./users.nix
     ./desktop.nix
+    ./nix-cache.nix
   ];
 }

--- a/modules/system/nix-cache.nix
+++ b/modules/system/nix-cache.nix
@@ -6,16 +6,16 @@ let
 in
 {
   options.modules.system.nixCache = {
-    enable = mkEnableOption "Local NFS Nix binary cache";
+    enable = mkEnableOption "Local Nix binary cache (david's build-offline-closures output)";
 
     cacheUrl = mkOption {
       type = types.str;
-      default = "file:///data/nix-builds/cache";
+      default = "https://nix-cache.theyoder.family";
       description = ''
-        URL of the local binary cache built by the build-offline-closures CI job
-        on david. Defaults to the NFS-mounted path for hosts with /data mounted;
-        override with a remote URL (e.g. http://david.vpn.theyoder.family/nix-cache)
-        for hosts that access david over Tailscale instead.
+        URL of the binary cache written by the build-offline-closures CI job on
+        david. Defaults to the internal HTTPS endpoint served by david over
+        Tailscale. Override with file:///data/nix-builds/cache on hosts with
+        the NFS /data mount for lower latency.
       '';
     };
   };

--- a/modules/system/nix-cache.nix
+++ b/modules/system/nix-cache.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.modules.system.nixCache;
+in
+{
+  options.modules.system.nixCache = {
+    enable = mkEnableOption "Local NFS Nix binary cache";
+
+    cacheUrl = mkOption {
+      type = types.str;
+      default = "file:///data/nix-builds/cache";
+      description = ''
+        URL of the local binary cache built by the build-offline-closures CI job
+        on david. Defaults to the NFS-mounted path for hosts with /data mounted;
+        override with a remote URL (e.g. http://david.vpn.theyoder.family/nix-cache)
+        for hosts that access david over Tailscale instead.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nix.settings.substituters = [ cfg.cacheUrl ];
+    nix.settings.trusted-substituters = [ cfg.cacheUrl ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add `tristons-workstation` to the CI auto-deploy matrix (always-online via fiber backhaul to david, safe for unattended deployment)
- Add `modules.system.nixCache` — a reusable module that registers `/data/nix-builds/cache` as a trusted Nix binary substituter; `cacheUrl` is overridable for hosts that reach the cache differently (e.g. over Tailscale via HTTP instead of NFS)
- Enable `nixCache` on `tristons-workstation` (consumes cache over NFS mount) and `david` (local disk — same path)

## How it fits together

The existing `build-offline-closures` CI job already builds `tristons-workstation`'s closure on david and writes it to `/data/nix-builds/cache`. This PR wires up the consumer side: on the next rebuild, the workstation pulls store paths from the NFS-mounted cache rather than downloading them from `cache.nixos.org`.

## Test plan

- [ ] CI test job passes for both `david` and `tristons-workstation`
- [ ] CI deploy job deploys both hosts
- [ ] `nix.settings.substituters` includes the local cache URL post-rebuild (`nix show-config | grep substituters`)