### PR TITLE
CI: github flake URL builds, pre-cache all closures, update notifier

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,7 @@ No rsync. No temp directories. Every rebuild — in CI and locally via `rebuild`
 |------|------|---------|-------------|-------------|
 | **david** | Main Server | ✅ | ✅ | ✅ |
 | **pits** | Edge VPS | ✅ | ✅ | ✅ |
-| **tristons-workstation** | Desktop | ✅ | ✅ | ✅ |
+| **tristons-workstation** | Desktop | ✅ | ✅ | ✅ best-effort |
 | **tristons-nixbook** | Laptop | ✅ | ❌ (offline) | ✅ best-effort |
 | **tristons-nixbook-pro** | Laptop | ✅ | ❌ (offline) | ✅ best-effort |
 
@@ -76,8 +76,8 @@ All tests are parallel. One failing host doesn't stop others.
 4. `deployment-summary` — reports overall status
 
 **Closure build order within `build-all-closures`:**
-- `david`, `pits`, `tristons-workstation` — must succeed (blocks deployment if any fail)
-- `tristons-nixbook`, `tristons-nixbook-pro` — best-effort (logged but non-blocking)
+- `david`, `pits` — must succeed (blocks deployment if either fails)
+- `tristons-workstation`, `tristons-nixbook`, `tristons-nixbook-pro` — best-effort (logged but non-blocking)
 
 ## Usage
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,388 +4,180 @@ Automated testing and deployment for all NixOS hosts using GitHub Actions.
 
 ## Overview
 
-This repository uses GitHub Actions to automatically test and deploy NixOS configurations to multiple hosts in parallel. When you push to the `main` branch, the workflows will:
+When you push to `main`, the workflows:
 
-1. ✅ Validate flake syntax
-2. ✅ Test all NixOS configurations in parallel
-3. ✅ Deploy to all hosts automatically if tests pass
+1. Validate flake syntax on the GitHub Actions runner
+2. Dry-run all NixOS host configurations on david (via `github:` flake URL)
+3. Build closures for every NixOS host on david and sign them into the binary cache
+4. Deploy to all online hosts — each host downloads pre-built paths from the cache
 
 ## Architecture
 
 ```
 Push to main
     ↓
-Syntax Check (30s)
+Syntax Check (runner, ~30s)
     ↓
-┌─────────────┬─────────────┬─────────────┐
-│   david     │    pits     │ tristons-   │
-│   TEST      │    TEST     │  desk TEST  │
-│  (2-3 min)  │  (2-3 min)  │  (2-3 min)  │
-└─────────────┴─────────────┴─────────────┘
-    ↓ All Pass
-┌─────────────┬─────────────┬─────────────┐
-│   david     │    pits     │ tristons-   │
-│   DEPLOY    │   DEPLOY    │ desk DEPLOY │
-│  (3-5 min)  │  (3-5 min)  │  (3-5 min)  │
-└─────────────┴─────────────┴─────────────┘
+┌──────────────────────────────────────┐
+│  dry-run all hosts on david          │
+│  (parallel matrix, ~2-3 min each)   │
+└──────────────────────────────────────┘
+    ↓ All pass
+Build all closures on david + sign to binary cache
+(sequential per host, ~5-20 min total)
+    ↓
+┌─────────────┬─────────────┬──────────────────────┐
+│   david     │    pits     │  tristons-workstation │
+│   DEPLOY    │   DEPLOY    │        DEPLOY         │
+│  (fast, pulls from cache) │                       │
+└─────────────┴─────────────┴──────────────────────┘
 ```
+
+No rsync. No temp directories. Every rebuild — in CI and locally via `rebuild` — hits the binary cache.
 
 ## Managed Hosts
 
-| Host | Type | Auto-Deploy |
-|------|------|-------------|
-| **david** | Main Server | ✅ Yes |
-| **pits** | Edge VPS | ✅ Yes |
-| **tristons-workstation** | Desktop | ✅ Yes |
+| Host | Type | CI Test | Auto-Deploy | Cache Build |
+|------|------|---------|-------------|-------------|
+| **david** | Main Server | ✅ | ✅ | ✅ |
+| **pits** | Edge VPS | ✅ | ✅ | ✅ |
+| **tristons-workstation** | Desktop | ✅ | ✅ | ✅ |
+| **tristons-nixbook** | Laptop | ✅ | ❌ (offline) | ✅ best-effort |
+| **tristons-nixbook-pro** | Laptop | ✅ | ❌ (offline) | ✅ best-effort |
 
 ## Workflows
 
-### Test Workflow
+### test-nixos-config.yml
 
 **Triggers:** Every push and pull request
 
-**Steps:**
-1. Check flake syntax locally (fast fail)
-2. Connect to Tailscale network
-3. Test all hosts in parallel:
-   - `david` (main server)
-   - `pits` (edge VPS)  
-   - `tristons-workstation` (desktop)
-4. Run `nixos-rebuild dry-run` on each
-5. Report independent results
+**Jobs:**
+1. `check-flake-syntax` — installs nix on the runner, runs `nix flake check --all-systems`
+2. `test-configurations` (matrix: all NixOS hosts) — SSHes to david via Tailscale and runs:
+   ```
+   sudo nixos-rebuild dry-run --flake 'github:TristonYoder/nix-config#<host>' --refresh
+   ```
 
-**Features:**
-- Parallel execution
-- Fast syntax check
-- Independent failures (one host failing doesn't stop others)
+All tests are parallel. One failing host doesn't stop others.
 
-### Deploy Workflow
+### deploy-nixos-config.yml
 
 **Triggers:**
-- Automatic after successful test on `main` branch
-- Manual trigger with host selection
+- Automatic after `test-nixos-config.yml` succeeds on `main`
+- Manual trigger (`workflow_dispatch`) with optional host selection
 
-**Steps for each host:**
-1. Create timestamped backup
-2. Run final dry-run test
-3. Deploy with `nixos-rebuild switch`
-4. Report success/failure
+**Jobs:**
+1. `prepare-deployment` — determines which hosts to deploy
+2. `build-all-closures` — SSHes to david, builds every NixOS host toplevel from `github:`, signs the closure into `/data/nix-builds/cache`
+3. `deploy-configurations` (parallel matrix) — SSHes to each online host and runs:
+   ```
+   sudo nixos-rebuild switch --flake 'github:TristonYoder/nix-config#<host>' --refresh
+   ```
+4. `deployment-summary` — reports overall status
 
-**Features:**
-- Parallel deployment
-- Selective deployment (manual)
-- Automatic backups
-- Independent failures
+**Closure build order within `build-all-closures`:**
+- `david`, `pits`, `tristons-workstation` — must succeed (blocks deployment if any fail)
+- `tristons-nixbook`, `tristons-nixbook-pro` — best-effort (logged but non-blocking)
 
 ## Usage
 
 ### Automatic Deployment
 
-Push to the `main` branch:
-
-```bash
-git checkout main
-git add .
-git commit -m "Update configurations"
-git push origin main
-```
-
-This automatically:
-1. Tests all hosts
-2. Deploys to all hosts if tests pass
+Push or merge to `main`. Tests run, then if all pass:
+1. Closures built and cached on david
+2. All online hosts deploy in parallel from the cache
 
 ### Manual Deployment
 
-Deploy to all hosts:
-1. GitHub → Actions
-2. "Deploy NixOS Flake Configuration"
-3. "Run workflow"
-4. Hosts: `all` (default)
-5. "Run workflow"
+1. GitHub → Actions → "Deploy NixOS Flake Configuration" → Run workflow
+2. Set `hosts` to `all` (default) or a comma-separated subset: `david,pits`
 
-Deploy to specific hosts:
-1. GitHub → Actions  
-2. "Deploy NixOS Flake Configuration"
-3. "Run workflow"
-4. Hosts: `david,pits` (comma-separated)
-5. "Run workflow"
-
-### Test Without Deploying
-
-Push to any branch except `main`:
+### Test a Feature Branch
 
 ```bash
-git checkout -b feature/new-feature
-git add .
-git commit -m "Test new feature"
-git push origin feature/new-feature
+git checkout -b feat/my-change
+# make changes
+git add . && git commit -m "feat: description"
+git push origin feat/my-change
 ```
 
-Tests run, but no deployment occurs.
+The test workflow runs dry-runs for every host. No deployment occurs on non-`main` branches.
+
+To test a branch locally before merging:
+```bash
+rebuild -b feat/my-change
+```
 
 ## Required GitHub Secrets
 
-Configure these in your repository settings:
-
 | Secret | Description |
 |--------|-------------|
-| `TAILSCALE_OAUTH_CLIENT_ID` | Tailscale OAuth Client ID |
-| `TAILSCALE_OAUTH_SECRET` | Tailscale OAuth Secret |
-| `NIXOS_SERVER_USER` | SSH user (github-actions) |
-| `SSH_PRIVATE_KEY` | SSH private key for all hosts |
-| `MATRIX_HOMESERVER_URL` | Matrix homeserver URL (e.g., https://matrix.theyoder.family) |
-| `MATRIX_ROOM_ID` | Matrix room ID (starts with `!`, not the alias `#`) |
-| `MATRIX_ACCESS_TOKEN` | Matrix access token for the bot user |
-
-### Setting Up Secrets
-
-1. **Tailscale OAuth:**
-   - Go to https://login.tailscale.com/admin/settings/oauth
-   - Create a new OAuth client
-   - Tag: `tag:github-actions`
-   - Copy Client ID and Secret to GitHub secrets
-
-2. **SSH Key:**
-   - Generate a dedicated SSH key: `ssh-keygen -t ed25519 -C "github-actions@david-nixos"`
-   - Add public key to each host's configuration
-   - Add private key to GitHub secrets
-
-3. **Matrix Notifications:**
-   - Create a Matrix bot user in your homeserver
-   - Generate an access token for the bot
-   - Invite the bot to your notification room
-   - Get the room ID (starts with `!`, NOT the alias that starts with `#`)
-     - From Element: Room Settings → Advanced → Room ID
-     - Example: `!abc123xyz:theyoder.family` (correct)
-     - NOT: `#systems-alerts:theyoder.family` (alias, won't work)
-   - Add secrets to GitHub repository
-
-4. **GitHub Repository:**
-   - Settings → Secrets and variables → Actions
-   - Add each secret
+| `HEADSCALE_AUTHKEY` | Headscale pre-auth key (tagged `tag:github-actions`) |
+| `HEADSCALE_LOGIN_SERVER` | Headscale control server URL |
+| `NIXOS_SERVER_USER` | SSH user (`github-actions`) |
+| `SSH_PRIVATE_KEY` | SSH private key authorized on all hosts |
+| `MATRIX_HOMESERVER_URL` | Matrix homeserver URL |
+| `MATRIX_ROOM_ID` | Matrix room ID (starts with `!`) |
+| `MATRIX_ACCESS_TOKEN` | Matrix bot access token |
 
 ## Host Configuration
 
-Each host needs:
-
-### 1. Enable GitHub Actions Module
-
-In host configuration or profile:
+Each managed NixOS host needs:
 
 ```nix
-{
-  modules.services.development.github-actions.enable = true;
-}
+{ modules.services.development.github-actions.enable = true; }
 ```
 
-### 2. Connect to Tailscale
-
-```bash
-# On each host
-sudo tailscale status  # Verify connected
-```
-
-### 3. Apply Configuration
-
-```bash
-# On each host
-sudo nixos-rebuild switch --flake .
-```
-
-This creates the `github-actions` user and authorizes the SSH key.
-
-## Tailscale ACL Configuration
-
-Add to your Tailscale ACL policy:
-
-```json
-{
-  "tagOwners": {
-    "tag:github-actions": ["your-email@example.com"]
-  },
-  "acls": [
-    {
-      "action": "accept",
-      "src": ["tag:github-actions"],
-      "dst": ["autogroup:members:*"]
-    }
-  ]
-}
-```
+This creates the `github-actions` user with sudo access and the authorized SSH key.
 
 ## Adding a New Host
 
-1. **Create host configuration** in `flake.nix`
-2. **Add to test workflow** (`.github/workflows/test-nixos-config.yml`):
+1. Create the host configuration under `hosts/<hostname>/`
+2. Add it to `flake.nix` in `nixosConfigurations`
+3. Add it to the test matrix in `test-nixos-config.yml`:
    ```yaml
    matrix:
-     host: 
-       - name: new-host
-         hostname: new-host
+     host:
+       - new-hostname
    ```
-3. **Add to deploy workflow** (`.github/workflows/deploy-nixos-config.yml`):
-   ```yaml
-   ALL_HOSTS='["david", "pits", "tristons-workstation", "new-host"]'
+4. If it should be auto-deployed, add it to `ALL_HOSTS` in `deploy-nixos-config.yml`:
+   ```bash
+   ALL_HOSTS='["david", "pits", "tristons-workstation", "new-hostname"]'
    ```
-4. **Configure the host:**
-   - Enable `modules.services.development.github-actions.enable = true`
-   - Connect to Tailscale
-   - Apply configuration
-
-## Monitoring
-
-### Matrix Notifications
-
-All GitHub Actions workflows automatically send notifications to your configured Matrix room:
-
-- **Job Start**: Notifications when jobs begin
-- **Job Success**: Notifications when jobs complete successfully
-- **Job Failure**: Notifications when jobs fail with links to logs
-
-Notifications include:
-- Workflow name
-- Host name (for matrix jobs)
-- Branch name
-- Status (Starting, Success, Failed)
-- Direct links to GitHub Actions logs
-
-### View Status
-
-**GitHub Actions Tab:**
-- See all workflow runs
-- View parallel job execution
-- Check individual host logs
-
-**Matrix Room:**
-- Real-time notifications
-- Quick status overview
-- Direct links to logs
-
-**Individual Host:**
-```bash
-ssh github-actions@hostname
-journalctl -xe
-sudo nixos-rebuild list-generations
-```
-
-### Success Indicators
-
-✅ All hosts show green checkmarks  
-✅ Deployment summary shows success  
-✅ Backups created successfully  
-✅ Services running on all hosts  
+   And add `build_and_cache new-hostname` to the `build-all-closures` job.
+5. Enable `modules.services.development.github-actions.enable = true` on the host
 
 ## Rollback
 
-### NixOS Generation Rollback
-
 ```bash
-ssh github-actions@hostname
+ssh github-actions@<hostname>.vpn.theyoder.family
 sudo nixos-rebuild switch --rollback
-```
-
-### Configuration Backup Rollback
-
-```bash
-ssh github-actions@hostname
-
-# List backups
-ls -la /var/backups/nixos/
-
-# Restore from backup
-sudo cp -r /var/backups/nixos/flake_config_TIMESTAMP/* /etc/nixos/
-cd /etc/nixos
-sudo nixos-rebuild switch --flake .#hostname
+# or switch to a specific generation:
+sudo nixos-rebuild switch --generation N
 ```
 
 ## Troubleshooting
 
-### Host Unreachable
+### Host unreachable
 
 ```bash
-# Check Tailscale
 sudo tailscale status
-
-# Test SSH
-ssh github-actions@hostname
+ssh github-actions@<hostname>.vpn.theyoder.family
 ```
 
-### Configuration Test Fails
+### Stale build (nix uses old flake ref)
+
+Always include `--refresh` when using `github:` URLs. The workflows already do this.
+Without it, nix may resolve the flake ref from a local cache and build a stale commit.
+
+### Closure build fails for an offline host
+
+`tristons-nixbook` and `tristons-nixbook-pro` failures are logged but don't block deployment.
+Their closures can be rebuilt on the next push.
+
+### See recent CI runs
 
 ```bash
-# SSH to host
-ssh github-actions@hostname
-
-# Manual test
-cd /etc/nixos
-sudo nixos-rebuild dry-run --flake .#hostname
+gh run list --branch main --limit 5
+gh run view <run-id> --log-failed
 ```
-
-### Some Hosts Fail, Others Succeed
-
-This is expected with `fail-fast: false`:
-1. Review failed host logs individually
-2. Fix configuration for failed hosts
-3. Manually re-deploy to failed hosts only
-
-## Security Considerations
-
-### SSH Keys
-- Use dedicated SSH keys for GitHub Actions
-- Store private keys securely in GitHub Secrets
-- Rotate keys periodically
-
-### Sudo Permissions
-- GitHub Actions user has full sudo access (required for nixos-rebuild)
-- Audit sudo usage in logs
-
-### Tailscale ACLs
-- Restrict `tag:github-actions` to necessary hosts
-- Regularly review ACL policies
-
-### Backups
-- Automatic backups before each deployment
-- Maintain at least 10 generations
-- Test restore procedures regularly
-
-## Best Practices
-
-1. ✅ **Test on feature branches** before merging to main
-2. ✅ **Use meaningful commit messages** for audit trail
-3. ✅ **Monitor first deployment** after changes
-4. ✅ **Keep backups** for quick rollback
-5. ✅ **Review logs** after deployment
-6. ✅ **Test rollback** procedure periodically
-7. ✅ **Update workflows** when adding/removing hosts
-8. ✅ **Secure your secrets** and rotate regularly
-
-## Performance
-
-### Parallel vs Sequential
-
-**Before (sequential):**
-- Test 3 hosts: ~9 minutes
-- Deploy 3 hosts: ~15 minutes
-- Total: ~24 minutes
-
-**After (parallel):**
-- Test 3 hosts: ~3 minutes
-- Deploy 3 hosts: ~5 minutes  
-- Total: ~8 minutes
-
-**Improvement:** 66% faster! ⚡
-
-## Resources
-
-- [Test Workflow](.github/workflows/test-nixos-config.yml)
-- [Deploy Workflow](.github/workflows/deploy-nixos-config.yml)
-- [Matrix Notification Action](.github/actions/matrix-notification)
-- [GitHub Actions Module](../modules/services/development/github-actions.nix)
-- [Tailscale Documentation](https://tailscale.com/kb/)
-
----
-
-**Last Updated:** October 13, 2025  
-**Status:** Active  
-**Managed Hosts:** 3 (david, pits, tristons-workstation)
-

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -287,6 +287,45 @@ jobs:
             }
           }' || echo "Reaction failed, continuing..."
 
+  # Trigger the update-notifier on all workstations that are reachable.
+  # For deployed hosts (workstation) this is a no-op (already on latest SHA).
+  # For offline hosts (nixbooks) this prompts the user the next time they're online.
+  notify-workstations:
+    runs-on: ubuntu-latest
+    needs: [prepare-deployment, build-all-closures, deploy-configurations]
+    if: needs.build-all-closures.result == 'success'
+
+    steps:
+    - name: Setup Tailscale (Headscale)
+      uses: tailscale/github-action@v2
+      with:
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+        tags: tag:github-actions
+        version: 1.78.1
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+
+    - name: Wait for Tailscale connection
+      run: sleep 10
+
+    - name: Trigger update check on online workstations
+      run: |
+        mkdir -p ~/.ssh
+        echo "Host *" >> ~/.ssh/config
+        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+        echo "  ConnectTimeout 5" >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+
+        for HOST in tristons-workstation tristons-nixbook tristons-nixbook-pro; do
+          echo "Notifying $HOST..."
+          ssh ${{ secrets.NIXOS_SERVER_USER }}@$HOST.vpn.theyoder.family \
+            "sudo systemctl start auto-update-check.service" \
+            && echo "✅ $HOST notified" \
+            || echo "⚠️  $HOST unreachable, skipping"
+        done
+
   deployment-summary:
     runs-on: ubuntu-latest
     needs: [prepare-deployment, build-all-closures, deploy-configurations]

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -149,12 +149,13 @@ jobs:
             echo "✅ $host cached"
           }
 
-          # Online (deploy target) hosts — failure here blocks deployment
+          # Always-online hosts — failure here blocks deployment
           build_and_cache david
           build_and_cache pits
-          build_and_cache tristons-workstation
 
-          # Offline hosts — best-effort so their closures are in cache for local rebuilds
+          # Best-effort hosts — logged but non-blocking
+          build_and_cache tristons-workstation \
+            || echo "⚠️ tristons-workstation build failed, continuing"
           build_and_cache tristons-nixbook \
             || echo "⚠️ tristons-nixbook build failed, continuing"
           build_and_cache tristons-nixbook-pro \

--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -5,7 +5,7 @@ on:
     workflows: ["Test NixOS Flake Configuration"]
     types: [ completed ]
     branches: [ main ]
-  workflow_dispatch:  # Allow manual trigger with custom inputs
+  workflow_dispatch:
     inputs:
       hosts:
         description: 'Comma-separated list of hosts to deploy (e.g., david,pits or "all")'
@@ -18,33 +18,26 @@ env:
   MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
 jobs:
-  # Determine which hosts to deploy
   prepare-deployment:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     outputs:
       hosts: ${{ steps.set-hosts.outputs.hosts }}
       parent_event_id: ${{ steps.notify-start.outputs.event_id }}
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Get commit message
       id: get-commit
       if: always()
       run: |
-        # Get commit message from GitHub event JSON to safely handle quotes and special characters
-        # Read from GITHUB_EVENT_PATH to avoid shell interpolation issues with quotes
-        # For workflow_run events, try to get commit from workflow_run.head_commit
         if [ "${{ github.event_name }}" = "workflow_run" ]; then
-          # Try to get commit message from workflow_run event structure
           COMMIT_MSG=$(jq -r '.workflow_run.head_commit.message // "Deployment triggered by workflow run" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Deployment triggered by workflow run")
         else
-          # For push and other events, get from standard location
           COMMIT_MSG=$(jq -r '.head_commit.message // .commits[0].message // "Manual trigger" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Manual trigger")
         fi
-        # If message is empty or null, use fallback
         if [ -z "$COMMIT_MSG" ] || [ "$COMMIT_MSG" = "null" ]; then
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             COMMIT_MSG="Deployment triggered by workflow run"
@@ -56,7 +49,7 @@ jobs:
         echo "commit_message<<EOF" >> $GITHUB_OUTPUT
         echo "$TRUNCATED_MSG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-    
+
     - name: Notify deployment start
       id: notify-start
       if: always()
@@ -72,40 +65,144 @@ jobs:
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-    
+
     - name: Determine deployment hosts
       id: set-hosts
       run: |
-        # Define all available NixOS hosts
-        ALL_HOSTS='["david", "pits", "tristons-workstation"]'  # always-online machine, safe for CI auto-deploy
-        
+        ALL_HOSTS='["david", "pits", "tristons-workstation"]'
+
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           INPUT_HOSTS="${{ github.event.inputs.hosts }}"
           if [ "$INPUT_HOSTS" = "all" ]; then
             echo "hosts=$ALL_HOSTS" >> $GITHUB_OUTPUT
           else
-            # Convert comma-separated list to JSON array
             HOSTS_JSON=$(echo "$INPUT_HOSTS" | jq -R -s -c 'split(",") | map(select(length > 0) | gsub("^\\s+|\\s+$";""))')
             echo "hosts=$HOSTS_JSON" >> $GITHUB_OUTPUT
           fi
         else
-          # Automatic deployment after successful test - deploy to all hosts
           echo "hosts=$ALL_HOSTS" >> $GITHUB_OUTPUT
         fi
 
-  # Deploy to all specified hosts in parallel
-  deploy-configurations:
+  # Build closures for ALL NixOS hosts on david and sign them into the binary cache.
+  # This runs before any deployment so every host can pull pre-built paths from the
+  # cache rather than building locally. Online hosts (david, pits, tristons-workstation)
+  # are built with hard failure; offline hosts (nixbook family) are best-effort.
+  build-all-closures:
     runs-on: ubuntu-latest
     needs: prepare-deployment
-    strategy:
-      matrix:
-        host: ${{ fromJson(needs.prepare-deployment.outputs.hosts) }}
-      fail-fast: false  # Continue deploying to other hosts even if one fails
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Notify building closures
+      id: notify-build-start
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          🔨 Building all host closures on david
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
+
+    - name: Setup Tailscale (Headscale)
+      uses: tailscale/github-action@v2
+      with:
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+        tags: tag:github-actions
+        version: 1.78.1
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+
+    - name: Wait for Tailscale connection
+      run: sleep 10
+
+    - name: Build and cache all closures on david
+      run: |
+        mkdir -p ~/.ssh
+        echo "Host *" >> ~/.ssh/config
+        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@david.vpn.theyoder.family << 'EOF'
+          set -e
+
+          build_and_cache() {
+            local host="$1"
+            shift
+            echo "--- Building $host ---"
+            sudo nix build \
+              "github:TristonYoder/nix-config#nixosConfigurations.$host.config.system.build.toplevel" \
+              --refresh \
+              --out-link "/tmp/nix-closure-$host" \
+              "$@"
+            STORE_PATH=$(readlink -f "/tmp/nix-closure-$host")
+            echo "Signing and caching: $STORE_PATH"
+            sudo nix copy \
+              --to "file:///data/nix-builds/cache?secret-key=/run/agenix/nix-cache-signing-key" \
+              "$STORE_PATH"
+            rm -f "/tmp/nix-closure-$host"
+            echo "✅ $host cached"
+          }
+
+          # Online (deploy target) hosts — failure here blocks deployment
+          build_and_cache david
+          build_and_cache pits
+          build_and_cache tristons-workstation
+
+          # Offline hosts — best-effort so their closures are in cache for local rebuilds
+          build_and_cache tristons-nixbook \
+            || echo "⚠️ tristons-nixbook build failed, continuing"
+          build_and_cache tristons-nixbook-pro \
+            --option extra-substituters 'https://cache.soopy.moe' \
+            --option extra-trusted-public-keys 'cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E=' \
+            || echo "⚠️ tristons-nixbook-pro build failed, continuing"
+        EOF
+
+    - name: Notify closures built
+      if: success()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ✅ All closures built and cached
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
+
+    - name: Notify closure build failure
+      if: failure()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ❌ Closure build failed — deployment blocked
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
+
+  # Deploy to all online hosts using the GitHub flake URL.
+  # Closures are already in the binary cache so each host downloads pre-built
+  # paths rather than rebuilding from source.
+  deploy-configurations:
+    runs-on: ubuntu-latest
+    needs: [prepare-deployment, build-all-closures]
+    strategy:
+      matrix:
+        host: ${{ fromJson(needs.prepare-deployment.outputs.hosts) }}
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Notify deploying host
       id: notify-deploy-start
       continue-on-error: true
@@ -117,7 +214,7 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-      
+
     - name: Setup Tailscale (Headscale)
       uses: tailscale/github-action@v2
       with:
@@ -128,98 +225,25 @@ jobs:
 
     - name: Wait for Tailscale connection
       run: sleep 10
-      
+
     - name: Deploy to ${{ matrix.host }}
       run: |
-        # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host }}.vpn.theyoder.family"
-        echo "Deploying configuration to ${{ matrix.host }} at $SERVER_HOSTNAME"
-        
-        # Configure SSH to bypass host key verification
         mkdir -p ~/.ssh
         echo "Host *" >> ~/.ssh/config
         echo "  StrictHostKeyChecking no" >> ~/.ssh/config
         echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
         chmod 600 ~/.ssh/config
-
-        # Setup SSH key
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
         chmod 600 ~/.ssh/id_ed25519
 
-        # Copy configuration to server
-        rsync -avz --delete \
-          --exclude='.git' \
-          --exclude='.github' \
-          --exclude='*.save' \
-          --exclude='nextcloud/admin-pass' \
-          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-deploy-${{ matrix.host }}/
+        SERVER_HOSTNAME="${{ matrix.host }}.vpn.theyoder.family"
+        echo "Deploying ${{ matrix.host }} from github:TristonYoder/nix-config..."
 
-        # Deploy flake configuration on server
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME << EOF
-          set -e
-          
-          # Navigate to deploy directory
-          cd /tmp/nixos-config-deploy-${{ matrix.host }}
-          
-          # Create backup directory if it doesn't exist
-          sudo mkdir -p /var/backups/nixos
-          
-          # Create timestamped backup of current flake configuration
-          BACKUP_NAME="flake_config_$(date +%Y%m%d_%H%M%S)"
-          sudo mkdir -p /var/backups/nixos/\$BACKUP_NAME
-          
-          # Backup current flake configuration if it exists
-          if [ -d "/etc/nixos" ]; then
-            sudo cp -r /etc/nixos/. /var/backups/nixos/\$BACKUP_NAME/ 2>/dev/null || true
-          fi
-          
-          # Keep only last 10 backups
-          sudo find /var/backups/nixos -maxdepth 1 -type d -name "flake_config_*" | sort | head -n -10 | xargs -r sudo rm -rf
-          
-          # Free space before deployment to avoid disk exhaustion
-          sudo nix-collect-garbage --delete-older-than 3d || true
-          sudo nix store optimise || true
+        # Closures are pre-built in the binary cache; --refresh ensures nix fetches
+        # the latest HEAD rather than a locally cached flake resolution.
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME \
+          "sudo nixos-rebuild switch --flake 'github:TristonYoder/nix-config#${{ matrix.host }}' --refresh"
 
-          # Final test before deployment using flake
-          echo "Running final configuration test for ${{ matrix.host }}..."
-          if ! sudo nixos-rebuild dry-run --flake .#${{ matrix.host }}; then
-            echo "❌ Final configuration test failed for ${{ matrix.host }}! Aborting deployment."
-            exit 1
-          fi
-          
-          # Deploy the configuration using flake
-          echo "Deploying NixOS configuration for ${{ matrix.host }}..."
-          if sudo nixos-rebuild switch --flake .#${{ matrix.host }}; then
-            echo "✅ NixOS configuration deployed successfully to ${{ matrix.host }}!"
-            echo "SUCCESS" > /tmp/nixos-deploy-result-${{ matrix.host }}.txt
-          else
-            echo "❌ NixOS configuration deployment failed for ${{ matrix.host }}!"
-            echo "FAILED" > /tmp/nixos-deploy-result-${{ matrix.host }}.txt
-            exit 1
-          fi
-        EOF
-        
-        # Get deployment result
-        DEPLOY_RESULT=$(ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME "cat /tmp/nixos-deploy-result-${{ matrix.host }}.txt")
-        
-        if [ "$DEPLOY_RESULT" = "SUCCESS" ]; then
-          echo "✅ NixOS configuration deployed successfully to ${{ matrix.host }}!"
-        else
-          echo "❌ NixOS configuration deployment failed for ${{ matrix.host }}!"
-          exit 1
-        fi
-        
-    - name: Create GitHub Deployment Record
-      if: success()
-      run: |
-        echo "✅ NixOS configuration successfully deployed to ${{ matrix.host }}"
-        
-    - name: Notify on failure
-      if: failure()
-      run: |
-        echo "❌ NixOS configuration deployment failed for ${{ matrix.host }}"
-        echo "Check the server logs for more details"
-    
     - name: Notify success
       if: success()
       continue-on-error: true
@@ -231,8 +255,7 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-        # redact_event_id: ${{ steps.notify-deploy-start.outputs['event_id'] }}
-    
+
     - name: Notify failure
       if: failure()
       continue-on-error: true
@@ -242,17 +265,16 @@ jobs:
           ❌ ${{ matrix.host }} failed
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
-        # redact_event_id: ${{ steps.notify-deploy-start.outputs['event_id'] }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-    
+
     - name: React to parent with failure emoji
       if: failure()
       run: |
         PARENT_EVENT_ID="${{ needs.prepare-deployment.outputs.parent_event_id }}"
         ROOM_ID_ENCODED=$(echo -n "${{ secrets.MATRIX_ROOM_ID }}" | jq -sRr @uri)
-        
+
         curl -X PUT "${{ secrets.MATRIX_HOMESERVER_URL }}/_matrix/client/r0/rooms/$ROOM_ID_ENCODED/send/m.reaction/$(openssl rand -hex 16)" \
           -H "Authorization: Bearer ${{ secrets.MATRIX_ACCESS_TOKEN }}" \
           -H "Content-Type: application/json" \
@@ -263,132 +285,29 @@ jobs:
               "key": "❌"
             }
           }' || echo "Reaction failed, continuing..."
-        
-  # Build closures for offline hosts (nixbook) on david after deployment
-  build-offline-closures:
-    runs-on: ubuntu-latest
-    needs: [prepare-deployment, deploy-configurations]
-    if: needs.deploy-configurations.result == 'success'
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Notify building offline closures
-      id: notify-offline-start
-      continue-on-error: true
-      uses: ./.github/actions/matrix-notification
-      with:
-        message: |
-          🔵 Building offline closures
-        room_id: ${{ secrets.MATRIX_ROOM_ID }}
-        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
-        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-
-    - name: Setup Tailscale (Headscale)
-      uses: tailscale/github-action@v2
-      with:
-        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
-        tags: tag:github-actions
-        version: 1.78.1
-        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
-
-    - name: Wait for Tailscale connection
-      run: sleep 10
-
-    - name: Build offline closures on david
-      run: |
-        SERVER_HOSTNAME="david.vpn.theyoder.family"
-
-        # Configure SSH
-        mkdir -p ~/.ssh
-        echo "Host *" >> ~/.ssh/config
-        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
-        chmod 600 ~/.ssh/config
-        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-
-        # Copy configuration to david
-        rsync -az --delete \
-          --exclude='.git' \
-          --exclude='.github' \
-          --exclude='*.save' \
-          --exclude='nextcloud/admin-pass' \
-          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-offline-build/
-
-        # Build closures for all offline hosts and store in binary cache on NFS
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME << 'EOF'
-          set -e
-          cd /tmp/nixos-config-offline-build
-
-          sudo mkdir -p /data/nix-builds/cache
-
-          build_closure() {
-            local host="$1"
-            local extra_args="${2:-}"
-            echo "Building $host closure..."
-            sudo nix build ".#nixosConfigurations.$host.config.system.build.toplevel" \
-              -o "/data/nix-builds/$host" \
-              $extra_args
-            STORE_PATH=$(readlink -f "/data/nix-builds/$host")
-            echo "Built: $STORE_PATH"
-            echo "$STORE_PATH" | sudo tee "/data/nix-builds/$host.path" > /dev/null
-            sudo nix copy --to "file:///data/nix-builds/cache?secret-key=/run/agenix/nix-cache-signing-key" "$STORE_PATH"
-            echo "✅ $host closure cached"
-          }
-
-          build_closure tristons-nixbook
-          build_closure tristons-workstation
-          build_closure tristons-nixbook-pro \
-            '--option extra-substituters https://cache.soopy.moe --option extra-trusted-public-keys cache.soopy.moe:MzBsBVPllIlCwL2PVs3BQC3Bfbp9TIgakN1xFUDEm8E='
-        EOF
-
-    - name: Notify offline closures success
-      if: success()
-      continue-on-error: true
-      uses: ./.github/actions/matrix-notification
-      with:
-        message: |
-          ✅ Offline closures built
-        room_id: ${{ secrets.MATRIX_ROOM_ID }}
-        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
-        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-
-    - name: Notify offline closures failure
-      if: failure()
-      continue-on-error: true
-      uses: ./.github/actions/matrix-notification
-      with:
-        message: |
-          ⚠️ Offline closure build failed
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        room_id: ${{ secrets.MATRIX_ROOM_ID }}
-        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
-        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-        thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-
-  # Summary job to report overall deployment status
   deployment-summary:
     runs-on: ubuntu-latest
-    needs: [prepare-deployment, deploy-configurations, build-offline-closures]
+    needs: [prepare-deployment, build-all-closures, deploy-configurations]
     if: always()
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Check deployment status
       run: |
+        if [ "${{ needs.build-all-closures.result }}" != "success" ]; then
+          echo "❌ Closure build failed — deployment did not complete."
+          exit 1
+        fi
         if [ "${{ needs.deploy-configurations.result }}" = "success" ]; then
           echo "✅ All NixOS configurations deployed successfully!"
         else
-          echo "⚠️  Some deployments may have failed. Check individual job logs."
+          echo "⚠️  Some deployments failed. Check individual job logs."
           exit 1
         fi
-    
+
     - name: Notify summary success
       if: success()
       continue-on-error: true
@@ -400,7 +319,7 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.prepare-deployment.outputs.parent_event_id }}
-    
+
     - name: Notify summary failure
       if: failure()
       continue-on-error: true

--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -13,24 +13,21 @@ env:
   MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
 jobs:
-  # First, check flake syntax locally (fast fail)
+  # Check flake syntax on the GitHub Actions runner (fast fail)
   check-flake-syntax:
     runs-on: ubuntu-latest
     outputs:
       parent_event_id: ${{ steps.send-start-notify.outputs.event_id }}
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
-    - name: Notify start
+
+    - name: Get commit message
       id: notify-start
       if: always()
       run: |
-        # Get commit message from GitHub event JSON to safely handle quotes and special characters
-        # Read from GITHUB_EVENT_PATH to avoid shell interpolation issues with quotes
         COMMIT_MSG=$(jq -r '.head_commit.message // .commits[0].message // "Manual trigger" // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "Manual trigger")
-        # If message is empty or null, use fallback
         if [ -z "$COMMIT_MSG" ] || [ "$COMMIT_MSG" = "null" ]; then
           COMMIT_MSG="Manual trigger"
         fi
@@ -38,7 +35,7 @@ jobs:
         echo "commit_message<<EOF" >> $GITHUB_OUTPUT
         echo "$TRUNCATED_MSG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-    
+
     - name: Send start notification
       id: send-start-notify
       continue-on-error: true
@@ -53,7 +50,7 @@ jobs:
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-    
+
     - name: Notify testing syntax
       id: notify-syntax-start
       continue-on-error: true
@@ -65,21 +62,20 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ steps.send-start-notify.outputs['event_id'] }}
-      
+
     - name: Install Nix
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    
+
     - name: Check flake syntax
       id: syntax-check
       run: |
         echo "Testing flake syntax..."
         nix flake check --all-systems
         echo "✅ Flake syntax check passed!"
-        echo "check_result=success" >> $GITHUB_OUTPUT
       continue-on-error: true
-    
+
     - name: Notify success
       if: success()
       continue-on-error: true
@@ -91,7 +87,6 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ steps.send-start-notify.outputs['event_id'] }}
-        # redact_event_id: ${{ steps.notify-syntax-start.outputs['event_id'] }}
 
     - name: Notify failure
       if: failure()
@@ -105,14 +100,13 @@ jobs:
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ steps.send-start-notify.outputs['event_id'] }}
-        # redact_event_id: ${{ steps.notify-syntax-start.outputs['event_id'] }}
-    
+
     - name: React to parent with failure emoji
       if: failure()
       run: |
         PARENT_EVENT_ID="${{ steps.send-start-notify.outputs['event_id'] }}"
         ROOM_ID_ENCODED=$(echo -n "${{ secrets.MATRIX_ROOM_ID }}" | jq -sRr @uri)
-        
+
         curl -X PUT "${{ secrets.MATRIX_HOMESERVER_URL }}/_matrix/client/r0/rooms/$ROOM_ID_ENCODED/redact/$PARENT_EVENT_ID/react-$(date +%s)" \
           -H "Authorization: Bearer ${{ secrets.MATRIX_ACCESS_TOKEN }}" \
           -H "Content-Type: application/json" \
@@ -124,7 +118,8 @@ jobs:
             }
           }' || echo "Reaction failed, continuing..."
 
-  # Test all NixOS configurations
+  # Test all NixOS host configurations by dry-running on david via the GitHub flake URL.
+  # All builds run on david (x86_64-linux) — no rsync, no temp dirs.
   test-configurations:
     runs-on: ubuntu-latest
     needs: check-flake-syntax
@@ -133,22 +128,17 @@ jobs:
     strategy:
       matrix:
         host:
-          - name: david
-            hostname: david
-          - name: pits
-            hostname: david  # dry-run builds on david to avoid filling pits' 50GB disk
-          - name: tristons-nixbook-pro
-            hostname: david  # dry-run builds on david (same x86_64-linux arch)
-          - name: tristons-nixbook
-            hostname: david  # dry-run builds on david (same x86_64-linux arch)
-          - name: tristons-workstation
-            hostname: david  # dry-run builds on david (same x86_64-linux arch)
-      fail-fast: false  # Continue testing other hosts even if one fails
-    
+          - david
+          - pits
+          - tristons-nixbook-pro
+          - tristons-nixbook
+          - tristons-workstation
+      fail-fast: false
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Notify start
       id: notify-start-test
       if: always()
@@ -156,12 +146,12 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          🔵 Testing ${{ matrix.host.name }}
+          🔵 Testing ${{ matrix.host }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
-      
+
     - name: Setup Tailscale (Headscale)
       uses: tailscale/github-action@v2
       with:
@@ -172,82 +162,34 @@ jobs:
 
     - name: Wait for Tailscale connection
       run: sleep 10
-      
-    - name: Test ${{ matrix.host.name }} Configuration
+
+    - name: Test ${{ matrix.host }} configuration
       run: |
-        # Connect to server via Tailscale
-        SERVER_HOSTNAME="${{ matrix.host.hostname }}.vpn.theyoder.family"
-        echo "Testing configuration for ${{ matrix.host.name }} on $SERVER_HOSTNAME"
-        
-        # Configure SSH to bypass host key verification
         mkdir -p ~/.ssh
         echo "Host *" >> ~/.ssh/config
         echo "  StrictHostKeyChecking no" >> ~/.ssh/config
         echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
         chmod 600 ~/.ssh/config
-
-        # Setup SSH key
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
         chmod 600 ~/.ssh/id_ed25519
 
-        # Copy configuration to server
-        rsync -avz --delete \
-          --exclude='.git' \
-          --exclude='.github' \
-          --exclude='*.save' \
-          --exclude='nextcloud/admin-pass' \
-          ./ ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME:/tmp/nixos-config-test-${{ matrix.host.name }}/
+        # All NixOS configs are tested on david (x86_64-linux) via the GitHub flake URL.
+        # --refresh ensures nix fetches the latest pushed commit rather than a cached ref.
+        echo "Testing ${{ matrix.host }} on david..."
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@david.vpn.theyoder.family \
+          "sudo nixos-rebuild dry-run --flake 'github:TristonYoder/nix-config#${{ matrix.host }}' --refresh"
 
-        # Test configuration on server
-        ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME << EOF
-          set -e
-          
-          # Navigate to test directory
-          cd /tmp/nixos-config-test-${{ matrix.host.name }}
-          
-          # Test the NixOS configuration using flake
-          echo "Testing NixOS configuration for ${{ matrix.host.name }}..."
-          if sudo nixos-rebuild dry-run --flake .#${{ matrix.host.name }}; then
-            echo "✅ Configuration test passed for ${{ matrix.host.name }}!"
-            echo "SUCCESS" > /tmp/nixos-test-result-${{ matrix.host.name }}.txt
-          else
-            echo "❌ Configuration test failed for ${{ matrix.host.name }}!"
-            echo "FAILED" > /tmp/nixos-test-result-${{ matrix.host.name }}.txt
-            exit 1
-          fi
-        EOF
-        
-        # Get test result
-        TEST_RESULT=$(ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME "cat /tmp/nixos-test-result-${{ matrix.host.name }}.txt")
-        
-        if [ "$TEST_RESULT" = "SUCCESS" ]; then
-          echo "✅ NixOS configuration test passed for ${{ matrix.host.name }}!"
-        else
-          echo "❌ NixOS configuration test failed for ${{ matrix.host.name }}!"
-          exit 1
-        fi
-        
-    - name: Set GitHub status
-      if: always()
-      run: |
-        if [ "${{ job.status }}" = "success" ]; then
-          echo "✅ ${{ matrix.host.name }} configuration test passed"
-        else
-          echo "❌ ${{ matrix.host.name }} configuration test failed"
-        fi
-    
     - name: Notify success
       if: success()
       continue-on-error: true
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ✅ ${{ matrix.host.name }} passed
+          ✅ ${{ matrix.host }} passed
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
-        # redact_event_id: ${{ steps.notify-start-test.outputs['event_id'] }}
 
     - name: Notify failure
       if: failure()
@@ -255,14 +197,13 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ❌ ${{ matrix.host.name }} failed
+          ❌ ${{ matrix.host }} failed
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
         thread_id: ${{ needs.check-flake-syntax.outputs.parent_event_id }}
-        # redact_event_id: ${{ steps.notify-start-test.outputs['event_id'] }}
-    
+
     - name: React to parent with failure emoji
       if: failure()
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,13 +115,24 @@ hostname  # Returns: tyoder-mbp, Tristons-MacBook-Pro, david, tristons-workstati
   - No need to SSH elsewhere
 
 **Remote testing from macOS** (when NOT on target host):
-```bash
-# Test on david (most common - server with all services)
-ssh github-actions@david "cd /home/github-actions/nix-config && git fetch origin && git checkout <branch> && git pull origin <branch> && sudo nixos-rebuild dry-run --flake .#david"
 
-# Or build without activation
-ssh github-actions@david "cd /home/github-actions/nix-config && sudo nixos-rebuild build --flake .#david"
+Push your branch first, then SSH to david and use the `github:` flake URL — no rsync needed:
+
+```bash
+# Dry-run any NixOS host config on david
+ssh github-actions@david.vpn.theyoder.family \
+  "sudo nixos-rebuild dry-run --flake 'github:TristonYoder/nix-config#david' --refresh"
+
+# Build without activation
+ssh github-actions@david.vpn.theyoder.family \
+  "sudo nixos-rebuild build --flake 'github:TristonYoder/nix-config#david' --refresh"
+
+# Test a specific branch
+ssh github-actions@david.vpn.theyoder.family \
+  "sudo nixos-rebuild dry-run --flake 'github:TristonYoder/nix-config/feat/my-branch#david' --refresh"
 ```
+
+**`--refresh` is required** with `github:` URLs so nix fetches the latest pushed commit rather than a cached ref.
 
 **Local testing on NixOS** (when already on target host):
 ```bash
@@ -423,7 +434,7 @@ gh run view <run-id> --log-failed
 grep -n "error\|Error\|failed\|Failed" <saved-log-file> | tail -60
 ```
 
-The CI matrix runs jobs for each host (e.g. `test-configurations (david, david)`). The rsync file listing is verbose — skip past it to find the actual `nixos-rebuild dry-run` error.
+The CI matrix runs jobs for each host (e.g. `test-configurations (tristons-workstation)`). Each job SSHes to david and runs `nixos-rebuild dry-run --flake github:...#<host> --refresh`. The error will be in the SSH step output — no rsync noise to skip past.
 
 ### Docker Compose Services
 

--- a/common/linux.nix
+++ b/common/linux.nix
@@ -1,13 +1,17 @@
 # Common configuration for all Linux/NixOS hosts
 # This file contains settings shared across all NixOS machines
 
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, self, ... }:
 
 {
   # =============================================================================
   # NIX SETTINGS (NixOS specific)
   # =============================================================================
   
+  # Bake the git commit SHA into the running system so update-notifier can
+  # compare against the latest deployed SHA from the GitHub Actions API.
+  system.configurationRevision = self.rev or "dirty";
+
   nix.settings = {
     # Enable store optimization (safe on NixOS)
     auto-optimise-store = true;

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
           ];
           
           specialArgs = {
-            inherit nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake;
           };
         };
 
@@ -184,7 +184,7 @@
           ];
           
           specialArgs = {
-            inherit nixpkgs nixpkgs-unstable iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable iopenpod-flake;
           };
         };
 
@@ -224,7 +224,7 @@
           ];
 
           specialArgs = {
-            inherit nixpkgs nixpkgs-unstable iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable iopenpod-flake;
           };
         };
 
@@ -254,7 +254,7 @@
           ];
 
           specialArgs = {
-            inherit nixpkgs nixpkgs-unstable iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable iopenpod-flake;
           };
         };
 
@@ -326,11 +326,11 @@
           ];
           
           specialArgs = {
-            inherit nixpkgs nixpkgs-unstable;
+            inherit self nixpkgs nixpkgs-unstable;
           };
         };
       };
-      
+
       # =============================================================================
       # DARWIN CONFIGURATIONS (macOS)
       # =============================================================================

--- a/modules/system/auto-update.nix
+++ b/modules/system/auto-update.nix
@@ -4,7 +4,7 @@ with lib;
 let
   cfg = config.modules.system.auto-update;
 
-  # Helper to run kdialog as the graphical session user
+  # Run kdialog in the context of the logged-in graphical user.
   run-dialog = pkgs.writeShellScript "run-dialog" ''
     USER="$1"
     shift
@@ -17,150 +17,150 @@ let
       ${pkgs.kdePackages.kdialog}/bin/kdialog "$@" 2>/dev/null
   '';
 
-  # Script to check if a newer closure is available on the NFS share
+  # Apply the update by switching to the latest GitHub flake build.
+  # Runs as root (system service), so no sudo needed.
+  apply-update = pkgs.writeShellScript "apply-update" ''
+    set -e
+    HOST="$(${pkgs.hostname}/bin/hostname)"
+    echo "Rebuilding $HOST from github:${cfg.repoOwner}/${cfg.repoName}#$HOST ..."
+    /run/current-system/sw/bin/nixos-rebuild switch \
+      --flake "github:${cfg.repoOwner}/${cfg.repoName}#$HOST" \
+      --refresh
+  '';
+
+  # Check GitHub Actions for the latest successful deploy run.
+  # Compares its SHA to the running system's configurationRevision and
+  # prompts the user (via kdialog) if an update is available.
   check-update = pkgs.writeShellScript "check-update" ''
-    PATH_FILE="${cfg.nfsMountPoint}/${config.networking.hostName}.path"
+    set -euo pipefail
 
-    # Check if NFS mount is accessible and path file exists
-    if [ ! -f "$PATH_FILE" ]; then
+    # Latest SHA from the last successful deploy run on GitHub
+    LATEST_SHA=$(${pkgs.curl}/bin/curl -sf --max-time 10 \
+      "https://api.github.com/repos/${cfg.repoOwner}/${cfg.repoName}/actions/workflows/${cfg.workflowFile}/runs?status=success&branch=${cfg.branch}&per_page=1" \
+      | ${pkgs.jq}/bin/jq -r '.workflow_runs[0].head_sha // empty' \
+      || true)
+
+    if [ -z "$LATEST_SHA" ]; then
+      exit 0  # GitHub unreachable or no successful runs yet
+    fi
+
+    # SHA baked into the running system by system.configurationRevision
+    CURRENT_SHA=$(cat /run/current-system/configuration-revision 2>/dev/null || echo "unknown")
+
+    if [ "$LATEST_SHA" = "$CURRENT_SHA" ]; then
+      exit 0  # Already up to date
+    fi
+
+    # Don't re-prompt for a version the user already deferred
+    DEFERRED_FILE="/var/cache/auto-update-deferred"
+    if [ -f "$DEFERRED_FILE" ] && [ "$(cat "$DEFERRED_FILE")" = "$LATEST_SHA" ]; then
       exit 0
     fi
 
-    AVAILABLE_PATH=$(cat "$PATH_FILE" 2>/dev/null)
-    CURRENT_PATH=$(readlink -f /run/current-system)
+    # Find the logged-in graphical session user
+    DISPLAY_USER=$(${pkgs.systemd}/bin/loginctl list-sessions --no-legend \
+      | while read -r sid uid user seat rest; do
+          TYPE=$(${pkgs.systemd}/bin/loginctl show-session "$sid" -p Type --value 2>/dev/null)
+          if [ "$TYPE" = "wayland" ] || [ "$TYPE" = "x11" ]; then
+            echo "$user"
+            break
+          fi
+        done)
 
-    if [ -z "$AVAILABLE_PATH" ] || [ "$AVAILABLE_PATH" = "$CURRENT_PATH" ]; then
-      exit 0
-    fi
-
-    # Find graphical session user via loginctl
-    DISPLAY_USER=$(${pkgs.systemd}/bin/loginctl list-sessions --no-legend | while read -r sid uid user seat rest; do
-      TYPE=$(${pkgs.systemd}/bin/loginctl show-session "$sid" -p Type --value 2>/dev/null)
-      if [ "$TYPE" = "wayland" ] || [ "$TYPE" = "x11" ]; then
-        echo "$user"
-        break
-      fi
-    done)
     if [ -z "$DISPLAY_USER" ]; then
-      exit 0
+      exit 0  # No graphical session — timer/login trigger will retry
     fi
 
-    # Check if we already notified for this version
-    NOTIFIED_FILE="/tmp/auto-update-notified"
-    if [ -f "$NOTIFIED_FILE" ] && [ "$(cat "$NOTIFIED_FILE")" = "$AVAILABLE_PATH" ]; then
-      exit 0
-    fi
+    SHORT_SHA=$(echo "$LATEST_SHA" | cut -c1-7)
 
-    # Show dialog as the logged-in user
     ${run-dialog} "$DISPLAY_USER" \
-      --title "System Update" \
-      --yesno "A system update is available.\n\nApply now?" \
-      && ACCEPTED=1 || ACCEPTED=0
+      --title "System Update Available" \
+      --yesno "A new system build is ready ($SHORT_SHA).\n\nApply now? This runs 'nixos-rebuild switch'." \
+      && APPLY=1 || APPLY=0
 
-    if [ "$ACCEPTED" = "1" ]; then
+    if [ "$APPLY" = "1" ]; then
       ${run-dialog} "$DISPLAY_USER" \
         --title "System Update" \
-        --passivepopup "Applying system update..." 5 &
+        --passivepopup "Applying update $SHORT_SHA — this may take a few minutes..." 10 &
 
-      if ${apply-update} "$AVAILABLE_PATH"; then
+      if ${apply-update}; then
+        rm -f "$DEFERRED_FILE"
         ${run-dialog} "$DISPLAY_USER" \
           --title "System Update" \
-          --passivepopup "System update applied successfully." 10
+          --passivepopup "Update applied. Now running $SHORT_SHA." 10
       else
         ${run-dialog} "$DISPLAY_USER" \
           --title "System Update" \
-          --error "System update failed.\nCheck: journalctl -u auto-update-check"
+          --error "Update failed.\nSee: journalctl -u auto-update-check"
       fi
     else
-      # User declined - don't ask again for this version
-      echo "$AVAILABLE_PATH" > "$NOTIFIED_FILE"
+      # Remember this SHA so we don't re-prompt until a newer build lands
+      echo "$LATEST_SHA" > "$DEFERRED_FILE"
     fi
-  '';
-
-  # Script to apply the update
-  apply-update = pkgs.writeShellScript "apply-update" ''
-    set -e
-    STORE_PATH="$1"
-    CACHE_PATH="${cfg.nfsMountPoint}/cache"
-
-    echo "Copying closure from binary cache..."
-    ${pkgs.nix}/bin/nix copy --from "file://$CACHE_PATH" --no-check-sigs "$STORE_PATH"
-
-    echo "Setting system profile..."
-    ${pkgs.nix}/bin/nix-env -p /nix/var/nix/profiles/system --set "$STORE_PATH"
-
-    echo "Switching to new configuration..."
-    "$STORE_PATH"/bin/switch-to-configuration switch
-
-    echo "Update complete."
   '';
 in
 {
   options.modules.system.auto-update = {
-    enable = mkEnableOption "Automatic update checking from NFS binary cache";
+    enable = mkEnableOption "Update notifier — prompts the graphical user when a new CI build is available";
 
-    buildHost = mkOption {
+    repoOwner = mkOption {
       type = types.str;
-      default = "david.theyoder.family";
-      description = "Hostname of the build server that provides closures via NFS";
+      default = "TristonYoder";
     };
 
-    nfsMountPoint = mkOption {
+    repoName = mkOption {
       type = types.str;
-      default = "/mnt/nix-builds";
-      description = "Local mount point for the NFS share containing built closures";
+      default = "nix-config";
     };
 
-    nfsDevice = mkOption {
+    workflowFile = mkOption {
       type = types.str;
-      default = "david.theyoder.family:/data/nix-builds";
-      description = "NFS device string for the builds share";
+      default = "deploy-nixos-config.yml";
+      description = "Workflow file whose last successful run defines the current deployed version";
     };
 
-    checkInterval = mkOption {
+    branch = mkOption {
       type = types.str;
-      default = "30min";
-      description = "How often to check for updates (systemd calendar format)";
+      default = "main";
     };
   };
 
   config = mkIf cfg.enable {
-    # Mount the nix-builds NFS share (automount so it doesn't block boot)
-    fileSystems.${cfg.nfsMountPoint} = {
-      device = cfg.nfsDevice;
-      fsType = "nfs";
-      options = [
-        "noauto"
-        "x-systemd.automount"
-        "x-systemd.idle-timeout=600"
-        "x-systemd.mount-timeout=10"
-        "soft"
-        "timeo=50"
-        "retrans=3"
-        "ro"
-      ];
-    };
-
-    # Timer to periodically check for updates
-    systemd.timers.auto-update-check = {
-      description = "Check for system updates on NFS";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnBootSec = "5min";
-        OnUnitActiveSec = cfg.checkInterval;
-        RandomizedDelaySec = "5min";
-      };
-    };
+    # State dir for the deferred-version marker
+    systemd.tmpfiles.rules = [
+      "d /var/cache 755 root root -"
+    ];
 
     systemd.services.auto-update-check = {
-      description = "Check for and apply system updates from NFS binary cache";
+      description = "Check for NixOS updates via GitHub Actions API";
       serviceConfig = {
         Type = "oneshot";
         ExecStart = check-update;
       };
-      path = [ pkgs.nix pkgs.coreutils ];
+      path = with pkgs; [ nix curl jq coreutils systemd util-linux ];
     };
 
-    environment.systemPackages = [ pkgs.nfs-utils ];
+    # Hourly recurring check
+    systemd.timers.auto-update-check = {
+      description = "Hourly NixOS update check";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";   # also fires shortly after boot / autologin
+        OnCalendar = "hourly";
+        RandomizedDelaySec = "5min";
+        Persistent = true;
+      };
+    };
+
+    # On-login trigger: fires when the main user's D-Bus session socket appears,
+    # which happens when their graphical session starts.
+    systemd.paths.auto-update-on-login = {
+      description = "Trigger update check on user graphical login";
+      wantedBy = [ "paths.target" ];
+      pathConfig = {
+        PathExists = "/run/user/${toString config.modules.system.users.mainUser.uid}/bus";
+      };
+      unitConfig.Unit = "auto-update-check.service";
+    };
   };
 }

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -20,6 +20,7 @@
   modules.system.networking.enable = lib.mkDefault true;
   modules.system.users.enable = lib.mkDefault true;
   modules.system.desktop.enable = lib.mkDefault true;
+  modules.system.auto-update.enable = lib.mkDefault true;
 
   # =============================================================================
   # DEVELOPMENT SERVICES (minimal set)


### PR DESCRIPTION
## Summary

- Replace rsync-based CI with `github:TristonYoder/nix-config#<host>` flake URLs throughout — no temp directories, no config copies
- Pre-build all host closures on david before any deployment so every host pulls from the binary cache instead of building locally
- Add an update notifier on desktop/laptop hosts that prompts the user via kdialog when a new CI build is available

## Changes

### CI workflows

**test-nixos-config.yml**
- Simplified matrix to flat host list
- Test step: SSH to david, run `nixos-rebuild dry-run --flake 'github:...#<host>' --refresh` — one line, no rsync

**deploy-nixos-config.yml**
- New `build-all-closures` job (runs before deployment): SSHes to david, builds every NixOS host toplevel from the `github:` URL, signs the full closure into `/data/nix-builds/cache`
  - `david` and `pits` must succeed (blocks deployment)
  - `tristons-workstation`, `tristons-nixbook`, `tristons-nixbook-pro` are best-effort (non-blocking)
- `deploy-configurations`: removed rsync, backup, GC, and final dry-run; now just `nixos-rebuild switch --flake 'github:...#<host>' --refresh`
- Removed `build-offline-closures` post-deploy job (merged into `build-all-closures`)
- New `notify-workstations` job: after build+deploy, SSHes to each workstation and triggers `auto-update-check.service`; offline hosts are skipped silently

### Update notifier (`modules/system/auto-update.nix`)

Replaces the old NFS path-file check with a GitHub Actions API query:

- Fetches the SHA of the last successful `deploy-nixos-config.yml` run
- Compares against `system.configurationRevision` baked into `/run/current-system/configuration-revision`
- Shows a kdialog prompt; "Yes" runs `nixos-rebuild switch --flake github:...#<host> --refresh`; "No" defers without re-prompting until a newer SHA lands

Three trigger sources:
1. **Hourly timer** (`OnCalendar=hourly`, plus `OnBootSec=2min`)
2. **On login** — systemd path unit on `/run/user/<uid>/bus`
3. **CI push** — `notify-workstations` job triggers `systemctl start auto-update-check.service` via SSH

### Supporting changes

- `common/linux.nix`: `system.configurationRevision = self.rev or "dirty"` — bakes the git SHA into every NixOS system
- `flake.nix`: all NixOS `specialArgs` gain `inherit self`
- `profiles/desktop.nix`: `modules.system.auto-update.enable = lib.mkDefault true`