### PR TITLE
fix: krdp package is kdePackages.krdp

### DIFF
--- a/modules/system/krdp.nix
+++ b/modules/system/krdp.nix
@@ -53,7 +53,7 @@ in
       wantedBy = [ "graphical-session.target" ];
       after = [ "graphical-session.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.krdp}/bin/krdpserver --certificate ${certDir}/cert.pem --certificate-key ${certDir}/key.pem --plasma --port ${toString cfg.port}";
+        ExecStart = "${pkgs.kdePackages.krdp}/bin/krdpserver --certificate ${certDir}/cert.pem --certificate-key ${certDir}/key.pem --plasma --port ${toString cfg.port}";
         Restart = "on-failure";
         RestartSec = "5s";
       };


### PR DESCRIPTION
`pkgs.krdp` doesn't exist in nixpkgs 26.05. The KDE RDP server is packaged under `pkgs.kdePackages.krdp`.

Fixes tristons-workstation rebuild failures.