### PR TITLE
feat(ai): add soul, matrixHomeRoom, and extraSettings module options

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -175,14 +175,11 @@
     environmentFile = config.age.secrets.hermes-env.path;
   };
 
-  # Set the Matrix home room so /sethome is not needed after each restart.
-  # HERMES_MANAGED=true blocks the /sethome command; env var is the only path.
-  services.hermes-agent.environment.MATRIX_HOME_ROOM = "!evHgyPMGVZyKzGopQo:theyoder.family";
-
   modules.services.ai.hermes-agent = {
     enable = true;
     model = "local-general";  # LiteLLM route: phi4:14b on tristons-workstation RTX 4080
     environmentFile = config.age.secrets.hermes-env.path;
+    matrixHomeRoom = "!evHgyPMGVZyKzGopQo:theyoder.family";
     extraVolumes = [
       "/data/tristonyoder/home/Projects/nix-config:/nix-config:ro"
     ];

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -205,8 +205,8 @@ in
     enable = true;
     model = "local-general";  # LiteLLM route: phi4:14b on tristons-workstation RTX 4080
     environmentFile = config.age.secrets.hermes-env.path;
-    # HERMES_MANAGED=true (in environmentFile) blocks /sethome; matrixHomeRoom is the only path.
-    matrixHomeRoom = "!evHgyPMGVZyKzGopQo:theyoder.family";
+    # HERMES_MANAGED=true (in environmentFile) blocks /sethome; homeRoom is the only path.
+    homeRoom = "!evHgyPMGVZyKzGopQo:theyoder.family";
     extraVolumes = [
       "/data/tristonyoder/home/Projects/nix-config:/nix-config:ro"
     ];

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -80,8 +80,6 @@ in
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
 
-      documents = optionalAttrs (cfg.soul != null) { "SOUL.md" = cfg.soul; };
-
       environment = optionalAttrs (cfg.matrixHomeRoom != null) {
         MATRIX_HOME_ROOM = cfg.matrixHomeRoom;
       };
@@ -96,6 +94,18 @@ in
         backend = "docker";
         extraVolumes = cfg.extraVolumes;
       };
+    };
+
+    # Write SOUL.md to HERMES_HOME (.hermes/), where load_soul_md() reads it.
+    # Cannot use services.hermes-agent.documents — that installs to workingDirectory
+    # (workspace), which hermes never checks for the persona slot.
+    system.activationScripts.hermesAgentSoul = mkIf (cfg.soul != null) {
+      text = ''
+        install -o hermes-agent -g hermes-agent -m 0660 \
+          ${pkgs.writeText "hermes-SOUL.md" cfg.soul} \
+          /var/lib/hermes-agent/.hermes/SOUL.md
+      '';
+      deps = [ "hermes-agent-setup" "users" "groups" ];
     };
   };
 }

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -37,6 +37,18 @@ in
       default = [];
       description = "Additional volume mounts for the container.";
     };
+
+    soul = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "SOUL.md content (hermes system prompt / persona). Written to the working directory at activation via services.hermes-agent.documents. Null uses hermes's built-in default.";
+    };
+
+    matrixHomeRoom = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Matrix room ID to use as the hermes home room (MATRIX_HOME_ROOM env var). Set so /sethome is not required after each restart.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -67,6 +79,12 @@ in
       };
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
+
+      documents = optionalAttrs (cfg.soul != null) { "SOUL.md" = cfg.soul; };
+
+      environment = optionalAttrs (cfg.matrixHomeRoom != null) {
+        MATRIX_HOME_ROOM = cfg.matrixHomeRoom;
+      };
 
       # Matrix platform dependencies — uses the upstream 'matrix' pyproject.toml
       # optional-dependency group, which includes mautrix[encryption]==0.21.0,

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -55,11 +55,6 @@ in
       description = "SOUL.md content (hermes system prompt / persona). Written to the working directory at activation via services.hermes-agent.documents. Null uses hermes's built-in default.";
     };
 
-    matrixHomeRoom = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = "Matrix room ID to use as the hermes home room (MATRIX_HOME_ROOM env var). Set so /sethome is not required after each restart.";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -91,8 +86,8 @@ in
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
 
-      environment = optionalAttrs (cfg.matrixHomeRoom != null) {
-        MATRIX_HOME_ROOM = cfg.matrixHomeRoom;
+      environment = optionalAttrs (cfg.homeRoom != null) {
+        MATRIX_HOME_ROOM = cfg.homeRoom;
       };
 
       # Matrix platform dependencies — uses the upstream 'matrix' pyproject.toml

--- a/modules/services/ai/litellm.nix
+++ b/modules/services/ai/litellm.nix
@@ -64,6 +64,18 @@ in
           ANTHROPIC_API_KEY=<key>
       '';
     };
+
+    extraSettings = mkOption {
+      type = types.attrs;
+      default = {};
+      description = ''
+        Arbitrary LiteLLM settings merged (via //) into services.litellm.settings.
+        Top-level keys override the generated ones wholesale — e.g. passing
+        extraSettings.litellm_settings = {...} replaces the generated
+        litellm_settings (including telemetry=false) entirely.
+        Use for router_settings, callbacks, or other config not exposed as typed options.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -93,7 +105,7 @@ in
         general_settings = mkIf cfg.requireAuth {
           master_key = "os.environ/LITELLM_MASTER_KEY";
         };
-      };
+      } // cfg.extraSettings;
     };
   };
 }


### PR DESCRIPTION
Closes #208, #210, #211.

## Changes

**`modules/services/ai/hermes-agent.nix`**
- `soul` — `types.nullOr types.str`, wired to `services.hermes-agent.documents."SOUL.md"`. Persona is now version-controlled and deployed atomically. Null uses hermes's built-in default. The upstream module's `documents` mechanism handles the write at activation time.
- `matrixHomeRoom` — `types.nullOr types.str`, wired to `services.hermes-agent.environment.MATRIX_HOME_ROOM`. Removes the need for callers to know the internal env var name.

**`modules/services/ai/litellm.nix`**
- `extraSettings` — `types.attrs`, merged via `//` on top of the generated `services.litellm.settings`. Useful for `router_settings`, `litellm_settings.callbacks`, and other config not exposed as typed options. Top-level keys override generated ones wholesale (documented in option description).

**`hosts/david/configuration.nix`**
- Removed raw `services.hermes-agent.environment.MATRIX_HOME_ROOM` override; replaced with `modules.services.ai.hermes-agent.matrixHomeRoom`.