### PR TITLE
feat(ai): expand hermes with scheduling, homelab MCP, and integrations

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -211,18 +211,42 @@ in
       "/data/tristonyoder/home/Projects/nix-config:/nix-config:ro"
     ];
 
-    # Nightly scan watches the core stack; weekly storage report includes the
-    # tank pool. Digest and vault maintenance run on defaults.
+    # ── Infrastructure monitoring ─────────────────────────────────────────────
     nightlyAnomalyScan.services = [
       "jellyfin" "immich-server" "vaultwarden" "postgresql" "caddy"
       "matrix-synapse" "litellm" "hermes-agent"
     ];
     nightlyAnomalyScan.pools = [ "tank" ];
-    weeklyStorageReport.enable = true;
 
-    # Homelab MCP enabled — gives hermes structured tools for service/ZFS queries.
-    # allowRestarts left false until a Matrix-confirmation skill is in place.
+    # ── Life management ───────────────────────────────────────────────────────
+    # Immich integration — On This Day + smart album skill
+    immich.enable       = true;
+    immich.apiUrl       = "http://localhost:${toString config.modules.services.media.immich.port}";
+    immich.apiKeyEnvVar = "IMMICH_API_KEY";
+
+    # Actual Budget — weekly pulse + monthly report
+    actualBudget.enable       = true;
+    actualBudget.apiUrl       = "http://localhost:${toString config.modules.services.productivity.actualHttpApi.port}";
+    actualBudget.apiKeyEnvVar = "ACTUAL_HTTP_API_KEY";
+
+    # Relationship CRM — Sunday nudge at 10am
+    relationshipCrm.enable = true;
+
+    # Focus mode skill (triggered by conversation, no schedule)
+    focusMode.enable = true;
+
+    # Weekly review — Friday 4pm
+    weeklyReview.enable = true;
+
+    # Homelab MCP — structured tools for service/ZFS/disk/media queries
     homelabMcp.enable = true;
+    homelabMcp.allowRestarts = false;
+
+    # Vaultwarden audit — disabled until bw CLI is available in executor
+    vaultwardenAudit.enable = false;
+
+    # Notion sync — disabled until Notion workspace is wired
+    notionSync.enable = false;
   };
 
   modules.services.ai.open-webui = {

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -203,13 +203,26 @@ in
 
   modules.services.ai.hermes-agent = {
     enable = true;
-    model = "local-general";  # LiteLLM route: phi4:14b on tristons-workstation RTX 4080
+    model  = "local-general";  # LiteLLM route: phi4:14b on tristons-workstation RTX 4080
     environmentFile = config.age.secrets.hermes-env.path;
     # HERMES_MANAGED=true (in environmentFile) blocks /sethome; homeRoom is the only path.
     homeRoom = "!evHgyPMGVZyKzGopQo:theyoder.family";
     extraVolumes = [
       "/data/tristonyoder/home/Projects/nix-config:/nix-config:ro"
     ];
+
+    # Nightly scan watches the core stack; weekly storage report includes the
+    # tank pool. Digest and vault maintenance run on defaults.
+    nightlyAnomalyScan.services = [
+      "jellyfin" "immich-server" "vaultwarden" "postgresql" "caddy"
+      "matrix-synapse" "litellm" "hermes-agent"
+    ];
+    nightlyAnomalyScan.pools = [ "tank" ];
+    weeklyStorageReport.enable = true;
+
+    # Homelab MCP enabled — gives hermes structured tools for service/ZFS queries.
+    # allowRestarts left false until a Matrix-confirmation skill is in place.
+    homelabMcp.enable = true;
   };
 
   modules.services.ai.open-webui = {

--- a/modules/services/ai/default.nix
+++ b/modules/services/ai/default.nix
@@ -4,6 +4,7 @@
     # from the upstream NousResearch flake, which is only imported on david.
     # It's added directly to david's module list in flake.nix alongside
     # hermes-agent.nixosModules.default.
+    ./hermes-homelab-mcp.nix
     ./litellm.nix
     ./ollama.nix
     ./open-webui.nix

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -3,27 +3,167 @@
 with lib;
 let
   cfg = config.modules.services.ai.hermes-agent;
+
+  # ---------------------------------------------------------------------------
+  # Cron job seed script
+  # Manages a "nix-managed" subset of ~/.hermes/cron/jobs.json.
+  # Idempotent: removes stale nix-managed entries, inserts current ones.
+  # Does not touch user-created jobs (no "nix-managed" tag).
+  # ---------------------------------------------------------------------------
+  allScheduledTasks = cfg.scheduledTasks
+    ++ optional cfg.digest.enable {
+        name  = "nix-morning-digest";
+        cron  = cfg.digest.cron;
+        prompt = ''
+          Post a morning digest to the Matrix ${
+            if cfg.matrixNotificationRoom != null
+            then "notification room"
+            else "home room"
+          }. Include:
+          1. Any services that restarted or failed overnight (check journalctl -p err --since yesterday)
+          2. ZFS pool health summary (zpool status -x)
+          3. Disk usage on / and /data if above 80%
+          4. A one-line note if anything needs attention, otherwise just "All clear."
+          Keep it short — bullet points, no preamble.
+        '';
+      }
+    ++ optional cfg.nixUpdateSummary.enable {
+        name  = "nix-weekly-update-summary";
+        cron  = cfg.nixUpdateSummary.cron;
+        prompt = ''
+          Check the nix-config repo for any pending flake input updates.
+          Run: cd /nix-config && git pull && nix flake metadata --json
+          Summarise which inputs are behind HEAD (if any), what major version
+          changes are implied, and whether anything looks risky. Post to Matrix.
+        '';
+      }
+    ++ optional cfg.nightlyAnomalyScan.enable {
+        name  = "nix-nightly-anomaly-scan";
+        cron  = cfg.nightlyAnomalyScan.cron;
+        prompt = ''
+          Silent anomaly scan — only post to Matrix if something is wrong.
+          Check:
+          - journalctl -p err --since "2 hours ago" (filter noise like avahi/systemd-resolved)
+          ${optionalString (cfg.nightlyAnomalyScan.services != [])
+            "- systemctl is-active ${concatStringsSep " " cfg.nightlyAnomalyScan.services}"}
+          ${optionalString (cfg.nightlyAnomalyScan.pools != [])
+            "- zpool status ${concatStringsSep " " cfg.nightlyAnomalyScan.pools}"}
+          If everything is healthy, do nothing (no message). Only speak up
+          when there is a real problem.
+        '';
+      }
+    ++ optional cfg.monthlyVaultMaintenance.enable {
+        name  = "nix-monthly-vault-maintenance";
+        cron  = cfg.monthlyVaultMaintenance.cron;
+        prompt = ''
+          Monthly vault maintenance pass:
+          1. Review memories/ — merge duplicates, mark stale entries for removal
+          2. Review skills/ — note any skills that haven't been used in 30 days
+          3. Commit any changes to the vault git repo
+          4. If vault has a remote, push.
+          Post a one-line summary to Matrix when done.
+        '';
+      }
+    ++ optional (cfg.vaultwardenAudit.enable) {
+        name  = "nix-monthly-password-audit";
+        cron  = cfg.vaultwardenAudit.cron;
+        prompt = ''
+          Vaultwarden audit pass. Using the Vaultwarden API at ${cfg.vaultwardenAudit.apiUrl}:
+          1. List items and flag any with passwords older than 180 days
+          2. Flag any HTTP (non-HTTPS) URIs
+          3. Flag any entries with no password (username-only)
+          Do NOT read or expose any passwords. Post a summary count to Matrix
+          (e.g. "3 stale, 1 HTTP URI, 0 empty"). If nothing to flag, skip.
+        '';
+      }
+    ++ optional cfg.weeklyStorageReport.enable {
+        name  = "nix-weekly-storage-report";
+        cron  = cfg.weeklyStorageReport.cron;
+        prompt = ''
+          Weekly storage report. Run:
+          - df -h (highlight anything above 75%)
+          - zfs list -o name,used,avail,refer -s used | head -20
+          - du -sh /data/tristonyoder/home/vaults/hermes-brain (vault size)
+          Post a compact table to Matrix. Warn if any dataset is above 80%.
+        '';
+      };
+
+  # Python script that seeds/reconciles nix-managed cron jobs in jobs.json
+  cronSeedScript = pkgs.writeText "hermes-cron-seed.py" ''
+    #!/usr/bin/env python3
+    """
+    Seed nix-declared cron jobs into ~/.hermes/cron/jobs.json.
+    Idempotent: tagged entries are replaced on every activation.
+    User-created jobs (no "nix-managed" tag) are never touched.
+    """
+    import json, os, sys, uuid, tempfile
+    from pathlib import Path
+    from datetime import datetime, timezone
+
+    CRON_DIR = Path(os.environ["HERMES_HOME"]) / "cron"
+    JOBS_FILE = CRON_DIR / "jobs.json"
+    CRON_DIR.mkdir(parents=True, exist_ok=True)
+
+    declared = json.loads(sys.argv[1])
+
+    # Load existing jobs (may not exist yet)
+    try:
+        jobs = json.loads(JOBS_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        jobs = []
+
+    # Remove stale nix-managed entries
+    jobs = [j for j in jobs if "nix-managed" not in j.get("tags", [])]
+
+    # Add current nix-managed entries
+    now = datetime.now(timezone.utc).isoformat()
+    for task in declared:
+        # Stable ID derived from name so activation is truly idempotent
+        stable_id = "nix-" + uuid.uuid5(uuid.NAMESPACE_DNS, task["name"]).hex[:12]
+        jobs.append({
+            "id":           stable_id,
+            "name":         task["name"],
+            "prompt":       task["prompt"],
+            "schedule":     {"kind": "cron", "expr": task["cron"]},
+            "enabled":      True,
+            "state":        "scheduled",
+            "tags":         ["nix-managed"],
+            "created_at":   now,
+            "last_run_at":  None,
+            "run_count":    0,
+            "next_run_at":  None,
+        })
+
+    # Atomic write
+    tmp = JOBS_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(jobs, indent=2))
+    tmp.replace(JOBS_FILE)
+    print(f"hermes-cron-seed: {len([j for j in jobs if 'nix-managed' in j.get('tags',[])])} nix-managed jobs written")
+  '';
+
 in
 {
   options.modules.services.ai.hermes-agent = {
     enable = mkEnableOption "Hermes Agent (NousResearch)";
 
+    # ── Core ────────────────────────────────────────────────────────────────
+
     model = mkOption {
       type = types.str;
       default = "anthropic/claude-opus-4-8";
-      description = "Default LLM model for Hermes. Should be a LiteLLM-routed name or direct provider string.";
+      description = "Default LLM model. Should be a LiteLLM-routed name or direct provider string.";
     };
 
     inferenceUrl = mkOption {
       type = types.nullOr types.str;
       default = "http://127.0.0.1:${toString config.modules.services.ai.litellm.port}";
-      description = "Base URL for the LiteLLM proxy. Set null to use provider URLs directly.";
+      description = "Base URL for the LiteLLM proxy. Null uses provider URLs directly.";
     };
 
     environmentFile = mkOption {
       type = types.nullOr types.path;
       default = null;
-      description = "Agenix-decrypted environment file. Must contain ANTHROPIC_API_KEY (or provider key) and LITELLM_MASTER_KEY.";
+      description = "Agenix-decrypted environment file. Must contain ANTHROPIC_API_KEY and LITELLM_MASTER_KEY.";
     };
 
     containerMode = mkOption {
@@ -49,62 +189,229 @@ in
       description = "Additional volume mounts for the container.";
     };
 
+    # ── Identity ─────────────────────────────────────────────────────────────
+
     soul = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = "SOUL.md content (hermes system prompt / persona). Written to the working directory at activation via services.hermes-agent.documents. Null uses hermes's built-in default.";
+      description = "SOUL.md content (persona). Written to HERMES_HOME at activation via activation script. Null uses hermes's built-in default.";
     };
 
+    agentsMd = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "AGENTS.md content installed into the hermes working directory. Loaded as project context on every session.";
+    };
+
+    # ── Matrix ───────────────────────────────────────────────────────────────
+
+    matrixNotificationRoom = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Matrix room ID for proactive notifications (digests, alerts, cron output). Falls back to homeRoom if null.";
+    };
+
+    # ── Vault ────────────────────────────────────────────────────────────────
+
+    vaultGitRemote = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Git remote URL for the hermes vault. Written to vault/.git/config at activation. Enables the vault-git skill to push off-host.";
+    };
+
+    # ── Users ────────────────────────────────────────────────────────────────
+
+    hostUsers = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = "Users who get a ~/.hermes symlink to the service state dir (for host-CLI parity with the container).";
+    };
+
+    # ── Executor ─────────────────────────────────────────────────────────────
+
+    executorPackages = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = "Additional packages available to the hermes-executor user (and therefore to hermes via SSH).";
+    };
+
+    # ── Scheduled tasks ──────────────────────────────────────────────────────
+
+    scheduledTasks = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          name   = mkOption { type = types.str; description = "Unique name for this task (used as stable job ID)."; };
+          cron   = mkOption { type = types.str; description = "Cron expression, e.g. '0 8 * * *'."; };
+          prompt = mkOption { type = types.str; description = "Prompt hermes runs on schedule."; };
+        };
+      });
+      default = [];
+      description = "User-defined scheduled tasks written into hermes's cron scheduler at activation.";
+    };
+
+    digest = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Morning digest: service health, ZFS, disk usage. Posts to Matrix."; };
+      cron   = mkOption { type = types.str; default = "0 8 * * *";
+        description = "Cron schedule for the morning digest."; };
+    };
+
+    nixUpdateSummary = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Weekly nix flake update summary. Checks input staleness, posts to Matrix."; };
+      cron   = mkOption { type = types.str; default = "0 9 * * 1";
+        description = "Cron schedule (default: Monday 9am)."; };
+    };
+
+    nightlyAnomalyScan = {
+      enable    = mkOption { type = types.bool; default = true;
+        description = "Nightly silent anomaly scan. Posts to Matrix only when something is wrong."; };
+      cron      = mkOption { type = types.str; default = "0 2 * * *";
+        description = "Cron schedule (default: 2am daily)."; };
+      services  = mkOption { type = types.listOf types.str; default = [];
+        description = "Systemd services to check in the nightly scan."; };
+      pools     = mkOption { type = types.listOf types.str; default = [];
+        description = "ZFS pools to check in the nightly scan."; };
+    };
+
+    monthlyVaultMaintenance = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Monthly vault housekeeping: dedup memories, flag stale skills, push to remote."; };
+      cron   = mkOption { type = types.str; default = "0 10 1 * *";
+        description = "Cron schedule (default: 1st of month, 10am)."; };
+    };
+
+    vaultwardenAudit = {
+      enable  = mkOption { type = types.bool; default = false;
+        description = "Monthly Vaultwarden audit: stale passwords, HTTP URIs, empty entries."; };
+      cron    = mkOption { type = types.str; default = "0 10 1 * *";
+        description = "Cron schedule (default: 1st of month, 10am)."; };
+      apiUrl  = mkOption { type = types.str; default = "http://localhost:8222";
+        description = "Vaultwarden API base URL."; };
+    };
+
+    weeklyStorageReport = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Weekly storage report: df, ZFS dataset sizes, vault size. Posts to Matrix."; };
+      cron   = mkOption { type = types.str; default = "0 9 * * 6";
+        description = "Cron schedule (default: Saturday 9am)."; };
+    };
+
+    # ── Integrations ─────────────────────────────────────────────────────────
+
+    homelabMcp = {
+      enable  = mkOption { type = types.bool; default = true;
+        description = "Register the hermes-homelab-mcp server so hermes can query service health, ZFS, disk, and Tailscale status via structured tool calls."; };
+      port    = mkOption { type = types.port; default = 7830;
+        description = "Port the homelab MCP SSE server listens on (localhost only)."; };
+      allowRestarts = mkOption { type = types.bool; default = false;
+        description = "Expose a restart_service tool. Each call requires Matrix confirmation before executing (enforced by the skill, not the tool itself)."; };
+    };
+
+    immich = {
+      enable      = mkOption { type = types.bool; default = false;
+        description = "Wire IMMICH_API_URL and IMMICH_API_KEY_ENV into hermes environment for Immich API access."; };
+      apiUrl      = mkOption { type = types.str; default = "http://localhost:2283";
+        description = "Immich API base URL."; };
+      apiKeyEnvVar = mkOption { type = types.str; default = "IMMICH_API_KEY";
+        description = "Name of the env var holding the Immich API key (sourced from environmentFile)."; };
+    };
+
+    n8n = {
+      enable      = mkOption { type = types.bool; default = false;
+        description = "Wire N8N_BASE_URL into hermes environment so the executor can trigger n8n workflows via webhook."; };
+      baseUrl     = mkOption { type = types.str; default = "http://localhost:5678";
+        description = "n8n base URL."; };
+      apiKeyEnvVar = mkOption { type = types.str; default = "N8N_API_KEY";
+        description = "Name of the env var holding the n8n API key."; };
+    };
+
+    # ── Passthroughs ─────────────────────────────────────────────────────────
+
+    mcpServers = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "Additional MCP servers merged into services.hermes-agent.mcpServers.";
+    };
+
+    extraPlugins = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = "Extra plugins passed to services.hermes-agent.extraPlugins.";
+    };
+
+    extraSettings = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "Arbitrary settings merged into services.hermes-agent.settings.";
+    };
   };
 
   config = mkIf cfg.enable {
-    # olm is required by mautrix[encryption] for Matrix E2E. nixpkgs marks it
-    # insecure due to the upstream project being archived, but it's functional
-    # and there's no replacement for python-olm in the mautrix ecosystem yet.
     nixpkgs.config.permittedInsecurePackages = [ "olm-3.2.16" ];
 
+    # ── Upstream service ──────────────────────────────────────────────────────
+
     services.hermes-agent = {
-      enable = true;
+      enable            = true;
       addToSystemPackages = true;
 
-      # Use optionalAttrs (not mkIf) so all values are plain YAML strings.
-      # The upstream hermes module serializes mkIf into {_type: if, ...} dicts,
-      # and runtime_provider.py calls .strip() on those → AttributeError.
-      #
-      # provider=custom:litellm-proxy: hermes resolves this against the
-      # providers.litellm-proxy entry, reads LITELLM_MASTER_KEY from env,
-      # and sends it as the API key so LiteLLM auth succeeds.
+      # Use optionalAttrs (not mkIf) — upstream serializes mkIf into dicts and
+      # runtime_provider.py calls .strip() on those → AttributeError.
       settings = {
         model = { default = cfg.model; provider = "custom:litellm-proxy"; }
           // optionalAttrs (cfg.inferenceUrl != null) { base_url = cfg.inferenceUrl; };
       } // optionalAttrs (cfg.inferenceUrl != null) {
         providers.litellm-proxy = {
-          api = cfg.inferenceUrl;
+          api     = cfg.inferenceUrl;
           key_env = "LITELLM_MASTER_KEY";
         };
-      };
+      } // cfg.extraSettings;
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
 
-      environment = optionalAttrs (cfg.homeRoom != null) {
-        MATRIX_HOME_ROOM = cfg.homeRoom;
-      };
+      environment = {}
+        // optionalAttrs (cfg.homeRoom != null)               { MATRIX_HOME_ROOM         = cfg.homeRoom; }
+        // optionalAttrs (cfg.matrixNotificationRoom != null)  { MATRIX_NOTIFICATION_ROOM = cfg.matrixNotificationRoom; }
+        // optionalAttrs cfg.immich.enable {
+             IMMICH_API_URL     = cfg.immich.apiUrl;
+             IMMICH_API_KEY_ENV = cfg.immich.apiKeyEnvVar;
+           }
+        // optionalAttrs cfg.n8n.enable {
+             N8N_BASE_URL     = cfg.n8n.baseUrl;
+             N8N_API_KEY_ENV  = cfg.n8n.apiKeyEnvVar;
+           };
 
-      # Matrix platform dependencies — uses the upstream 'matrix' pyproject.toml
-      # optional-dependency group, which includes mautrix[encryption]==0.21.0,
-      # aiosqlite, asyncpg, and aiohttp-socks into the sealed uv venv.
+      documents = {}
+        // optionalAttrs (cfg.agentsMd != null) { "AGENTS.md" = cfg.agentsMd; };
+
       extraDependencyGroups = [ "matrix" ];
 
       container = mkIf cfg.containerMode {
-        enable = true;
-        backend = "docker";
+        enable       = true;
+        backend      = "docker";
         extraVolumes = cfg.extraVolumes;
+        hostUsers    = cfg.hostUsers;
       };
+
+      extraPlugins = cfg.extraPlugins;
+
+      mcpServers = cfg.mcpServers
+        // optionalAttrs (cfg.homelabMcp.enable
+            && config.modules.services.ai.hermes-homelab-mcp.enable) {
+          homelab.url = "http://localhost:${toString cfg.homelabMcp.port}/sse";
+        };
     };
 
-    # Write SOUL.md to HERMES_HOME (.hermes/), where load_soul_md() reads it.
-    # Cannot use services.hermes-agent.documents — that installs to workingDirectory
-    # (workspace), which hermes never checks for the persona slot.
+    # ── Executor packages ─────────────────────────────────────────────────────
+
+    users.users.hermes-executor.packages = mkIf (cfg.executorPackages != [])
+      cfg.executorPackages;
+
+    # ── SOUL.md → HERMES_HOME ─────────────────────────────────────────────────
+    # load_soul_md() reads from HERMES_HOME/SOUL.md, not workingDirectory.
+    # documents installs to workingDirectory — wrong path, silent no-op.
+
     system.activationScripts.hermesAgentSoul = mkIf (cfg.soul != null) {
       text = ''
         install -o hermes-agent -g hermes-agent -m 0660 \
@@ -112,6 +419,43 @@ in
           /var/lib/hermes-agent/.hermes/SOUL.md
       '';
       deps = [ "hermes-agent-setup" "users" "groups" ];
+    };
+
+    # ── Vault git remote ──────────────────────────────────────────────────────
+
+    system.activationScripts.hermesAgentVaultRemote = mkIf (cfg.vaultGitRemote != null) {
+      text = ''
+        VAULT=/var/lib/hermes-agent/.hermes
+        if [ -d "$VAULT/.git" ]; then
+          if ${pkgs.git}/bin/git -C "$VAULT" remote get-url origin >/dev/null 2>&1; then
+            ${pkgs.git}/bin/git -C "$VAULT" remote set-url origin ${escapeShellArg cfg.vaultGitRemote}
+          else
+            ${pkgs.git}/bin/git -C "$VAULT" remote add origin ${escapeShellArg cfg.vaultGitRemote}
+          fi
+        fi
+      '';
+      deps = [ "hermes-agent-setup" "users" "groups" ];
+    };
+
+    # ── Cron job seeding ──────────────────────────────────────────────────────
+
+    system.activationScripts.hermesAgentCronJobs = mkIf (allScheduledTasks != []) {
+      text = ''
+        HERMES_HOME=/var/lib/hermes-agent/.hermes \
+          ${pkgs.python3}/bin/python3 ${cronSeedScript} \
+          ${escapeShellArg (builtins.toJSON (map (t: {
+            inherit (t) name cron prompt;
+          }) allScheduledTasks))}
+      '';
+      deps = [ "hermes-agent-setup" "users" "groups" ];
+    };
+
+    # ── Homelab MCP: wire port when our module is enabled ────────────────────
+
+    modules.services.ai.hermes-homelab-mcp = mkIf cfg.homelabMcp.enable {
+      enable        = true;
+      port          = cfg.homelabMcp.port;
+      allowRestarts = cfg.homelabMcp.allowRestarts;
     };
   };
 }

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -86,8 +86,6 @@ in
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
 
-      documents = optionalAttrs (cfg.soul != null) { "SOUL.md" = cfg.soul; };
-
       environment = optionalAttrs (cfg.homeRoom != null) {
         MATRIX_HOME_ROOM = cfg.homeRoom;
       };

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -86,6 +86,8 @@ in
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
 
+      documents = optionalAttrs (cfg.soul != null) { "SOUL.md" = cfg.soul; };
+
       environment = optionalAttrs (cfg.homeRoom != null) {
         MATRIX_HOME_ROOM = cfg.homeRoom;
       };

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -5,148 +5,542 @@ let
   cfg = config.modules.services.ai.hermes-agent;
 
   # ---------------------------------------------------------------------------
-  # Cron job seed script
-  # Manages a "nix-managed" subset of ~/.hermes/cron/jobs.json.
-  # Idempotent: removes stale nix-managed entries, inserts current ones.
-  # Does not touch user-created jobs (no "nix-managed" tag).
+  # Vault skill definitions — seeded into HERMES_HOME/skills/ at activation.
+  # Written only once (existence check); the agent can improve them over time.
   # ---------------------------------------------------------------------------
+
+  skillRelationshipCrm = ''
+    ---
+    name: relationship-crm
+    description: Track and maintain relationships using vault memories — birthdays, last contact, follow-ups
+    version: 1.0.0
+    category: life
+    tags: [relationships, memory, crm]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    Keep a lightweight CRM in vault memories. No external service — everything
+    lives in `$HERMES_HOME/memories/people/`. Commit after every write (vault-git skill).
+
+    ## Memory file format
+
+    Path: `memories/people/<firstname-lastname>.md`
+
+    ```markdown
+    # Jane Smith
+
+    **Birthday:** 1990-03-15
+    **Last contact:** 2025-11-20
+    **How we know:** College friend
+    **Location:** Austin, TX
+
+    ## Notes
+    - Loves hiking, has two dogs
+    - Working on a startup in climate tech
+
+    ## Follow-ups
+    - [ ] Send her the Patagonia recommendation she asked about
+    ```
+
+    ## Triggers
+
+    - When you have a conversation that mentions a person by name and something worth remembering
+    - When the user says "remember that [person]..."
+    - After the weekly relationship nudge task fires
+
+    ## Weekly nudge (automated)
+
+    The `nix-relationship-nudge` cron job scans all people files and:
+    1. Flags anyone with `Last contact` older than 60 days
+    2. Flags birthdays in the next 14 days
+    3. Posts a compact list to Matrix — name, days since contact, any upcoming birthday
+
+    ## Commands for the agent
+
+    ```bash
+    # List all people files
+    ls $HERMES_HOME/memories/people/
+
+    # Find people not contacted recently
+    grep -l "Last contact:" $HERMES_HOME/memories/people/*.md | \
+      xargs grep "Last contact:" | sort -t: -k3
+
+    # Upcoming birthdays (next 14 days)
+    python3 -c "
+    import os, re
+    from datetime import date, timedelta
+    today = date.today()
+    window_end = today + timedelta(days=14)
+    people_dir = os.path.expandvars('\$HERMES_HOME/memories/people')
+    if not os.path.isdir(people_dir): exit()
+    for f in os.listdir(people_dir):
+        if not f.endswith('.md'): continue
+        text = open(os.path.join(people_dir, f)).read()
+        m = re.search(r'Birthday.*?(\d{4}-\d{2}-\d{2})', text)
+        if not m: continue
+        bd = date.fromisoformat(m.group(1))
+        this_year = bd.replace(year=today.year)
+        if this_year < today: this_year = bd.replace(year=today.year+1)
+        if this_year <= window_end:
+            days = (this_year - today).days
+            name = f.replace('-', ' ').replace('.md', '').title()
+            print(f'{days}d: {name} ({this_year})')
+    "
+    ```
+  '';
+
+  skillFocusMode = ''
+    ---
+    name: focus-mode
+    description: Enter a deep work session — block distractions, protect calendar time, set Matrix away status
+    version: 1.0.0
+    category: productivity
+    tags: [focus, calendar, productivity]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    When the user asks to "focus" or "deep work", run a structured focus session:
+    1. Post an away message to Matrix home room
+    2. Block time on calendar (via calendar MCP if available)
+    3. Set a timer
+    4. Check in when done
+
+    ## Trigger phrases
+
+    - "focus mode [N] minutes/hours"
+    - "deep work session"
+    - "I need to focus for..."
+    - "block off [time] for..."
+
+    ## Protocol
+
+    ```
+    1. Confirm duration (default: ${toString cfg.focusMode.defaultDuration} minutes)
+    2. Post to Matrix home room:
+       "🎯 Focus mode: [task description]. Back at [time]. DMs OK for urgent."
+    3. Create calendar block if calendar MCP available
+    4. Wait duration, then post:
+       "⏰ Focus session complete. How did it go?"
+    5. Save a brief note to vault: date, task, duration, outcome
+    ```
+
+    ## Calendar block
+
+    Only if the user has a calendar MCP connected. Use "Focus: [task]" as title,
+    set as busy, private.
+
+    ## Session log
+
+    Save to `$HERMES_HOME/memories/focus-sessions.md` after each session.
+    Review weekly to notice patterns (best times, common interruptions).
+  '';
+
+  skillWeeklyReview = ''
+    ---
+    name: weekly-review
+    description: Structured Friday review ritual — reflect on the week, set intentions for next
+    version: 1.0.0
+    category: productivity
+    tags: [review, planning, ritual]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    Run every Friday at ${cfg.weeklyReview.cron} via the nix-weekly-review cron job.
+    Aggregate data from across the week, reflect, plan ahead.
+
+    ## Review structure
+
+    Post to Matrix notification room with this format:
+
+    ```
+    📋 Week of [date] — Review
+
+    **This week:**
+    - [3-5 bullet points of notable events/completions from calendar + memory]
+
+    **Finances (week):**
+    - Total spent: $X  |  On track / At risk / Over
+    - Notable: [largest transaction or category spike]
+
+    **Infrastructure:**
+    - Any incidents? Services that needed attention?
+
+    **Focus sessions:** X this week, avg Y minutes
+
+    **Relationships:** [Anyone to reach out to?]
+
+    ---
+    What's one thing to carry into next week?
+    ```
+
+    ## Data sources
+
+    Pull from (use MCP tools as available):
+    - Calendar: events from Mon–Fri
+    - actual_spending_summary / actual_budget_status for the week
+    - Vault memories written this week: `git -C $HERMES_HOME log --since="7 days ago" --oneline`
+    - Focus session log
+    - Homelab anomaly scan results (nix-nightly-anomaly-scan output)
+
+    ## After the review
+
+    Wait for the user's reply (if any), then:
+    1. Save their answer as a vault memory entry
+    2. Commit to vault git
+  '';
+
+  skillImmichAlbums = ''
+    ---
+    name: immich-albums
+    description: Create and manage Immich photo albums via natural language
+    version: 1.0.0
+    category: media
+    tags: [immich, photos, albums]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    Create smart Immich albums from conversational requests using MCP tools.
+
+    ## Trigger phrases
+
+    - "make an album of..."
+    - "create a photo album..."
+    - "find photos of/from..."
+    - "put together pictures of..."
+
+    ## Workflow
+
+    1. Use `immich_search` to find matching assets (date range, city, smart query)
+    2. Show a preview: "Found X photos — [date range], [cities]. Create album '[name]'?"
+    3. On confirmation: call `immich_create_album` with collected asset IDs
+    4. Reply with the album link
+
+    ## Search strategies
+
+    - By date range: use `date_from` / `date_to`
+    - By location: use `city` parameter
+    - By content: use `query` for smart/semantic search
+    - Combine: search by date first, then filter by city
+
+    ## Album naming
+
+    Suggest a name based on the request:
+    - "Scotland trip August 2024" → dates + inferred location
+    - "Dogs" → descriptor only
+    Ask the user to confirm or rename before creating.
+  '';
+
+  skillBudgetReview = ''
+    ---
+    name: budget-review
+    description: Query and interpret Actual Budget data — spending trends, budget adherence, alerts
+    version: 1.0.0
+    category: finance
+    tags: [budget, finance, actual]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    Surface financial awareness without reading raw numbers at the user —
+    interpret the data and present it as useful insights.
+
+    ## MCP tools available
+
+    - `actual_spending_summary(month?)` — totals by category
+    - `actual_budget_status(month?)` — over/under per category
+    - `actual_recent_transactions(days?, limit?)` — recent transactions
+
+    ## Response style
+
+    - Lead with the headline: "On track", "One category over", "Three categories over"
+    - Show over-budget categories prominently
+    - Call out any single transaction > $${toString cfg.actualBudget.alertThreshold}
+    - Skip categories that are well under (< 50%) unless asked
+
+    ## Alert thresholds
+
+    - Any category > 100% of budget → immediate flag
+    - Any single transaction > $${toString cfg.actualBudget.alertThreshold} → mention in digest
+    - Month-to-date total spend > 90% of monthly income estimate → warning
+
+    ## Monthly report (automated)
+
+    The `nix-monthly-budget-report` cron job runs on the last day of each month
+    and posts a full breakdown to Matrix.
+  '';
+
+  skillNotionTasks = ''
+    ---
+    name: notion-tasks
+    description: Sync tasks with Notion — capture from conversation, update status, audit stale items
+    version: 1.0.0
+    category: productivity
+    tags: [notion, tasks, productivity]
+    always_active: false
+    ---
+
+    ## Purpose
+
+    Use the Notion MCP to keep tasks in sync without opening Notion manually.
+
+    ## Capture flow
+
+    When user says "add task: [thing]" or "remind me to..." or "put in Notion...":
+    1. Create a page in the designated tasks database
+    2. Set title, due date if mentioned, priority if mentioned
+    3. Confirm: "Added '[task]' to Notion."
+
+    ## Status queries
+
+    "What do I have due this week?" → query Notion tasks database,
+    filter by due date this week, sort by priority, post compact list.
+
+    ## Stale task audit (automated)
+
+    The `nix-notion-stale-audit` cron job runs weekly and:
+    1. Finds tasks open > 30 days with no update
+    2. Posts list to Matrix: "X stale tasks in Notion — worth a review?"
+    3. Does NOT close or modify them without explicit instruction
+
+    ## Important
+
+    Never mark tasks complete without explicit user confirmation.
+    Never delete Notion pages.
+  '';
+
+  # ---------------------------------------------------------------------------
+  # Skill seeding activation script
+  # ---------------------------------------------------------------------------
+  skillSeedScript = pkgs.writeText "hermes-skill-seed.py" ''
+    #!/usr/bin/env python3
+    """Seed life management skills into HERMES_HOME/skills/. Never overwrites."""
+    import json, os, sys
+    from pathlib import Path
+
+    home   = Path(os.environ["HERMES_HOME"])
+    skills = json.loads(sys.argv[1])
+
+    for skill in skills:
+        category = skill["category"]
+        name     = skill["name"]
+        content  = skill["content"]
+        dest     = home / "skills" / category / name / "SKILL.md"
+        if dest.exists():
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+        print(f"hermes-skill-seed: seeded {category}/{name}")
+  '';
+
+  # All skills to seed, only those whose feature flag is enabled
+  skillsToSeed = []
+    ++ optional cfg.relationshipCrm.enable {
+        category = "life"; name = "relationship-crm"; content = skillRelationshipCrm; }
+    ++ optional cfg.focusMode.enable {
+        category = "productivity"; name = "focus-mode"; content = skillFocusMode; }
+    ++ optional cfg.weeklyReview.enable {
+        category = "productivity"; name = "weekly-review"; content = skillWeeklyReview; }
+    ++ optional cfg.immich.enable {
+        category = "media"; name = "immich-albums"; content = skillImmichAlbums; }
+    ++ optional cfg.actualBudget.enable {
+        category = "finance"; name = "budget-review"; content = skillBudgetReview; }
+    ++ optional cfg.notionSync.enable {
+        category = "productivity"; name = "notion-tasks"; content = skillNotionTasks; }
+    ++ cfg.extraSkills;
+
+  # ---------------------------------------------------------------------------
+  # Scheduled tasks — built-in + user-defined, collapsed into one seed
+  # ---------------------------------------------------------------------------
+
   allScheduledTasks = cfg.scheduledTasks
+
     ++ optional cfg.digest.enable {
         name  = "nix-morning-digest";
         cron  = cfg.digest.cron;
         prompt = ''
-          Post a morning digest to the Matrix ${
-            if cfg.matrixNotificationRoom != null
-            then "notification room"
-            else "home room"
-          }. Include:
-          1. Any services that restarted or failed overnight (check journalctl -p err --since yesterday)
-          2. ZFS pool health summary (zpool status -x)
-          3. Disk usage on / and /data if above 80%
-          4. A one-line note if anything needs attention, otherwise just "All clear."
-          Keep it short — bullet points, no preamble.
+          Post a morning briefing to Matrix. Pull from every available source:
+
+          📅 CALENDAR (if calendar MCP available):
+          - Events today and tomorrow
+
+          ☀️ WEATHER:
+          - Use the homelab MCP weather tool
+
+          💰 FINANCES (if Actual Budget connected):
+          - Use actual_budget_status for current month — one line: on track / any over-budget categories
+
+          🖼️ ON THIS DAY:
+          - Use immich_on_this_day — list photos from this date in past years (max 3)
+
+          📺 MEDIA:
+          - Use jellyseerr_requests with status=available — any requests that just became available?
+
+          🖥️ INFRASTRUCTURE:
+          - Use zfs_pool_status — only mention if not "all pools healthy"
+          - Use disk_usage with warn_above=80 — only mention if triggered
+
+          Format: short, scannable. Skip any section where nothing notable is happening.
+          Total length: under 20 lines.
         '';
       }
+
     ++ optional cfg.nixUpdateSummary.enable {
         name  = "nix-weekly-update-summary";
         cron  = cfg.nixUpdateSummary.cron;
         prompt = ''
-          Check the nix-config repo for any pending flake input updates.
-          Run: cd /nix-config && git pull && nix flake metadata --json
-          Summarise which inputs are behind HEAD (if any), what major version
-          changes are implied, and whether anything looks risky. Post to Matrix.
+          Weekly nix flake staleness check. Steps:
+          1. Use nix_flake_info MCP tool to see current input revisions
+          2. SSH to executor and run: cd /nix-config && git pull && nix flake metadata --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); [print(k, v.get('lastModified','?')) for k,v in d.get('locks',{}).get('nodes',{}).items() if k!='root']"
+          3. Compare — flag any input more than 30 days stale
+          4. If anything is stale, post summary to Matrix with the input names
+          5. If all fresh, skip (no message)
         '';
       }
+
     ++ optional cfg.nightlyAnomalyScan.enable {
         name  = "nix-nightly-anomaly-scan";
         cron  = cfg.nightlyAnomalyScan.cron;
         prompt = ''
-          Silent anomaly scan — only post to Matrix if something is wrong.
-          Check:
-          - journalctl -p err --since "2 hours ago" (filter noise like avahi/systemd-resolved)
-          ${optionalString (cfg.nightlyAnomalyScan.services != [])
-            "- systemctl is-active ${concatStringsSep " " cfg.nightlyAnomalyScan.services}"}
+          Silent nightly scan — only post to Matrix if something is ACTUALLY wrong.
+
+          Check via homelab MCP:
+          - service_logs for each of: ${concatStringsSep ", " cfg.nightlyAnomalyScan.services} — errors in last 2 hours
           ${optionalString (cfg.nightlyAnomalyScan.pools != [])
-            "- zpool status ${concatStringsSep " " cfg.nightlyAnomalyScan.pools}"}
-          If everything is healthy, do nothing (no message). Only speak up
-          when there is a real problem.
+            "- zfs_pool_status for pools: ${concatStringsSep ", " cfg.nightlyAnomalyScan.pools}"}
+          - disk_usage with warn_above=85
+
+          If everything is healthy → do nothing, post nothing.
+          Only speak when there is a real problem worth waking someone up for.
+          One short Matrix message max. Skip systemd noise (avahi, resolved).
         '';
       }
+
+    ++ optional cfg.weeklyReview.enable {
+        name  = "nix-weekly-review";
+        cron  = cfg.weeklyReview.cron;
+        prompt = ''
+          Friday weekly review. Follow the weekly-review skill protocol.
+          Pull data from all available MCP tools and vault git log.
+          Post the structured review to Matrix, then ask the reflection question.
+          Save the user's response (if any within 1 hour) as a vault memory.
+        '';
+      }
+
     ++ optional cfg.monthlyVaultMaintenance.enable {
         name  = "nix-monthly-vault-maintenance";
         cron  = cfg.monthlyVaultMaintenance.cron;
         prompt = ''
-          Monthly vault maintenance pass:
-          1. Review memories/ — merge duplicates, mark stale entries for removal
-          2. Review skills/ — note any skills that haven't been used in 30 days
-          3. Commit any changes to the vault git repo
-          4. If vault has a remote, push.
-          Post a one-line summary to Matrix when done.
+          Monthly vault housekeeping:
+          1. Review memories/ — identify near-duplicate entries, merge them
+          2. Review skills/ — list skills not referenced in recent sessions
+          3. Compact the memories index (MEMORY.md) if it's grown stale
+          4. Commit all changes: git -C $HERMES_HOME add -A && git -C $HERMES_HOME commit -m "maintenance: monthly vault cleanup"
+          5. Push if remote configured
+          6. Post one-line summary to Matrix
         '';
       }
+
+    ++ optional (cfg.actualBudget.enable && cfg.actualBudget.monthlyReport) {
+        name  = "nix-monthly-budget-report";
+        cron  = cfg.actualBudget.monthlyReportCron;
+        prompt = ''
+          End-of-month budget report. Use the budget-review skill and:
+          1. actual_spending_summary for the month just ended
+          2. actual_budget_status — call out any over-budget categories
+          3. actual_recent_transactions for last 7 days — any large items?
+          Post a structured breakdown to Matrix.
+          Save a summary to vault: memories/finances/YYYY-MM.md
+        '';
+      }
+
+    ++ optional (cfg.actualBudget.enable && cfg.actualBudget.weeklyReport) {
+        name  = "nix-weekly-budget-pulse";
+        cron  = cfg.actualBudget.weeklyReportCron;
+        prompt = ''
+          Weekly budget pulse check. Use actual_budget_status for current month.
+          If all categories are under 80% of budget with more than a week left → skip, post nothing.
+          If any category is over budget or approaching → post a brief warning to Matrix.
+          Keep it to 3 lines max.
+        '';
+      }
+
+    ++ optional cfg.immichOnThisDay.enable {
+        name  = "nix-immich-on-this-day";
+        cron  = cfg.immichOnThisDay.cron;
+        prompt = ''
+          Daily memory prompt. Use immich_on_this_day MCP tool.
+          If photos found: post to Matrix with dates and thumbnail links.
+            Format: "📸 On this day: [year] — [city if available]"
+            List up to 4 photos with year and location.
+          If no photos: skip, post nothing.
+        '';
+      }
+
+    ++ optional (cfg.relationshipCrm.enable && cfg.relationshipCrm.weeklyNudge) {
+        name  = "nix-relationship-nudge";
+        cron  = cfg.relationshipCrm.nudgeCron;
+        prompt = ''
+          Weekly relationship check. Follow the relationship-crm skill protocol:
+          1. Scan memories/people/ for anyone not contacted in >60 days
+          2. Check for birthdays in the next 14 days
+          3. If anything found: post a compact list to Matrix
+             Format: "👋 [Name] — [X] days since contact" or "🎂 [Name] — birthday in [N] days"
+          4. If nothing: skip, post nothing.
+        '';
+      }
+
+    ++ optional (cfg.notionSync.enable && cfg.notionSync.weeklyTaskAudit) {
+        name  = "nix-notion-stale-audit";
+        cron  = cfg.notionSync.auditCron;
+        prompt = ''
+          Weekly Notion task audit. Follow the notion-tasks skill protocol:
+          Use the Notion MCP to find tasks open longer than 30 days with no recent update.
+          If stale tasks found: post count + titles to Matrix.
+          If none: skip.
+        '';
+      }
+
     ++ optional (cfg.vaultwardenAudit.enable) {
         name  = "nix-monthly-password-audit";
         cron  = cfg.vaultwardenAudit.cron;
         prompt = ''
-          Vaultwarden audit pass. Using the Vaultwarden API at ${cfg.vaultwardenAudit.apiUrl}:
-          1. List items and flag any with passwords older than 180 days
-          2. Flag any HTTP (non-HTTPS) URIs
-          3. Flag any entries with no password (username-only)
-          Do NOT read or expose any passwords. Post a summary count to Matrix
-          (e.g. "3 stale, 1 HTTP URI, 0 empty"). If nothing to flag, skip.
+          Monthly Vaultwarden hygiene check. Use the vaultwarden_health MCP tool.
+          Also use executor SSH to run Bitwarden CLI if available:
+            bw list items --session $BW_SESSION 2>/dev/null | python3 -c "..."
+          Report to Matrix:
+          - Count of passwords older than 180 days (do NOT show the passwords)
+          - Count of items with HTTP (non-HTTPS) URIs
+          - Count of items with no password
+          - Overall: "X items need attention" or "All clear"
         '';
       }
+
     ++ optional cfg.weeklyStorageReport.enable {
         name  = "nix-weekly-storage-report";
         cron  = cfg.weeklyStorageReport.cron;
         prompt = ''
-          Weekly storage report. Run:
-          - df -h (highlight anything above 75%)
-          - zfs list -o name,used,avail,refer -s used | head -20
-          - du -sh /data/tristonyoder/home/vaults/hermes-brain (vault size)
-          Post a compact table to Matrix. Warn if any dataset is above 80%.
+          Weekly storage report. Use MCP tools:
+          - disk_usage — show filesystems above 60%
+          - zfs_list with sort=used and limit=15
+          Post a compact table to Matrix. Highlight anything above 80% in bold.
         '';
       };
-
-  # Python script that seeds/reconciles nix-managed cron jobs in jobs.json
-  cronSeedScript = pkgs.writeText "hermes-cron-seed.py" ''
-    #!/usr/bin/env python3
-    """
-    Seed nix-declared cron jobs into ~/.hermes/cron/jobs.json.
-    Idempotent: tagged entries are replaced on every activation.
-    User-created jobs (no "nix-managed" tag) are never touched.
-    """
-    import json, os, sys, uuid, tempfile
-    from pathlib import Path
-    from datetime import datetime, timezone
-
-    CRON_DIR = Path(os.environ["HERMES_HOME"]) / "cron"
-    JOBS_FILE = CRON_DIR / "jobs.json"
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-
-    declared = json.loads(sys.argv[1])
-
-    # Load existing jobs (may not exist yet)
-    try:
-        jobs = json.loads(JOBS_FILE.read_text())
-    except (FileNotFoundError, json.JSONDecodeError):
-        jobs = []
-
-    # Remove stale nix-managed entries
-    jobs = [j for j in jobs if "nix-managed" not in j.get("tags", [])]
-
-    # Add current nix-managed entries
-    now = datetime.now(timezone.utc).isoformat()
-    for task in declared:
-        # Stable ID derived from name so activation is truly idempotent
-        stable_id = "nix-" + uuid.uuid5(uuid.NAMESPACE_DNS, task["name"]).hex[:12]
-        jobs.append({
-            "id":           stable_id,
-            "name":         task["name"],
-            "prompt":       task["prompt"],
-            "schedule":     {"kind": "cron", "expr": task["cron"]},
-            "enabled":      True,
-            "state":        "scheduled",
-            "tags":         ["nix-managed"],
-            "created_at":   now,
-            "last_run_at":  None,
-            "run_count":    0,
-            "next_run_at":  None,
-        })
-
-    # Atomic write
-    tmp = JOBS_FILE.with_suffix(".tmp")
-    tmp.write_text(json.dumps(jobs, indent=2))
-    tmp.replace(JOBS_FILE)
-    print(f"hermes-cron-seed: {len([j for j in jobs if 'nix-managed' in j.get('tags',[])])} nix-managed jobs written")
-  '';
 
 in
 {
   options.modules.services.ai.hermes-agent = {
     enable = mkEnableOption "Hermes Agent (NousResearch)";
 
-    # ── Core ────────────────────────────────────────────────────────────────
+    # ── Core ─────────────────────────────────────────────────────────────────
 
     model = mkOption {
       type = types.str;
@@ -157,19 +551,19 @@ in
     inferenceUrl = mkOption {
       type = types.nullOr types.str;
       default = "http://127.0.0.1:${toString config.modules.services.ai.litellm.port}";
-      description = "Base URL for the LiteLLM proxy. Null uses provider URLs directly.";
+      description = "LiteLLM proxy base URL. Null uses provider URLs directly.";
     };
 
     environmentFile = mkOption {
       type = types.nullOr types.path;
       default = null;
-      description = "Agenix-decrypted environment file. Must contain ANTHROPIC_API_KEY and LITELLM_MASTER_KEY.";
+      description = "Agenix-decrypted env file. Must contain ANTHROPIC_API_KEY and LITELLM_MASTER_KEY.";
     };
 
     containerMode = mkOption {
       type = types.bool;
       default = true;
-      description = "Run Hermes in a Docker container (supports apt/pip/npm for agent-installed tools).";
+      description = "Run Hermes in a Docker container.";
     };
 
     homeRoom = mkOption {
@@ -189,21 +583,21 @@ in
       description = "Additional volume mounts for the container.";
     };
 
-    # ── Identity ─────────────────────────────────────────────────────────────
+    # ── Identity ──────────────────────────────────────────────────────────────
 
     soul = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = "SOUL.md content (persona). Written to HERMES_HOME at activation via activation script. Null uses hermes's built-in default.";
+      description = "SOUL.md content. Written to HERMES_HOME at activation. Null uses hermes's built-in default.";
     };
 
     agentsMd = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = "AGENTS.md content installed into the hermes working directory. Loaded as project context on every session.";
+      description = "AGENTS.md content installed into the hermes working directory (project context, loaded every session).";
     };
 
-    # ── Matrix ───────────────────────────────────────────────────────────────
+    # ── Matrix ────────────────────────────────────────────────────────────────
 
     matrixNotificationRoom = mkOption {
       type = types.nullOr types.str;
@@ -211,139 +605,189 @@ in
       description = "Matrix room ID for proactive notifications (digests, alerts, cron output). Falls back to homeRoom if null.";
     };
 
-    # ── Vault ────────────────────────────────────────────────────────────────
+    # ── Vault ─────────────────────────────────────────────────────────────────
 
     vaultGitRemote = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = "Git remote URL for the hermes vault. Written to vault/.git/config at activation. Enables the vault-git skill to push off-host.";
+      description = "Git remote URL for the hermes vault. Written at activation.";
     };
 
-    # ── Users ────────────────────────────────────────────────────────────────
+    # ── Users / executor ──────────────────────────────────────────────────────
 
     hostUsers = mkOption {
       type = types.listOf types.str;
       default = [];
-      description = "Users who get a ~/.hermes symlink to the service state dir (for host-CLI parity with the container).";
+      description = "Users who get a ~/.hermes symlink to the service state dir.";
     };
-
-    # ── Executor ─────────────────────────────────────────────────────────────
 
     executorPackages = mkOption {
       type = types.listOf types.package;
       default = [];
-      description = "Additional packages available to the hermes-executor user (and therefore to hermes via SSH).";
+      description = "Extra packages available to hermes-executor user.";
     };
 
-    # ── Scheduled tasks ──────────────────────────────────────────────────────
+    # ── Built-in scheduled behaviors ──────────────────────────────────────────
 
     scheduledTasks = mkOption {
       type = types.listOf (types.submodule {
         options = {
-          name   = mkOption { type = types.str; description = "Unique name for this task (used as stable job ID)."; };
-          cron   = mkOption { type = types.str; description = "Cron expression, e.g. '0 8 * * *'."; };
-          prompt = mkOption { type = types.str; description = "Prompt hermes runs on schedule."; };
+          name   = mkOption { type = types.str; };
+          cron   = mkOption { type = types.str; };
+          prompt = mkOption { type = types.str; };
         };
       });
       default = [];
-      description = "User-defined scheduled tasks written into hermes's cron scheduler at activation.";
+      description = "User-defined scheduled tasks added to hermes cron.";
     };
 
     digest = {
       enable = mkOption { type = types.bool; default = true;
-        description = "Morning digest: service health, ZFS, disk usage. Posts to Matrix."; };
-      cron   = mkOption { type = types.str; default = "0 8 * * *";
-        description = "Cron schedule for the morning digest."; };
+        description = "Morning briefing: calendar, weather, finances, On This Day, media, infra."; };
+      cron   = mkOption { type = types.str; default = "0 8 * * *"; };
     };
 
     nixUpdateSummary = {
       enable = mkOption { type = types.bool; default = true;
-        description = "Weekly nix flake update summary. Checks input staleness, posts to Matrix."; };
-      cron   = mkOption { type = types.str; default = "0 9 * * 1";
-        description = "Cron schedule (default: Monday 9am)."; };
+        description = "Weekly nix flake input staleness report."; };
+      cron   = mkOption { type = types.str; default = "0 9 * * 1"; };
     };
 
     nightlyAnomalyScan = {
-      enable    = mkOption { type = types.bool; default = true;
-        description = "Nightly silent anomaly scan. Posts to Matrix only when something is wrong."; };
-      cron      = mkOption { type = types.str; default = "0 2 * * *";
-        description = "Cron schedule (default: 2am daily)."; };
-      services  = mkOption { type = types.listOf types.str; default = [];
-        description = "Systemd services to check in the nightly scan."; };
-      pools     = mkOption { type = types.listOf types.str; default = [];
-        description = "ZFS pools to check in the nightly scan."; };
+      enable   = mkOption { type = types.bool; default = true;
+        description = "Nightly silent scan — posts to Matrix only on anomalies."; };
+      cron     = mkOption { type = types.str; default = "0 2 * * *"; };
+      services = mkOption { type = types.listOf types.str; default = []; };
+      pools    = mkOption { type = types.listOf types.str; default = []; };
+    };
+
+    weeklyReview = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Friday weekly review ritual posted to Matrix."; };
+      cron   = mkOption { type = types.str; default = "0 16 * * 5"; };
     };
 
     monthlyVaultMaintenance = {
       enable = mkOption { type = types.bool; default = true;
-        description = "Monthly vault housekeeping: dedup memories, flag stale skills, push to remote."; };
-      cron   = mkOption { type = types.str; default = "0 10 1 * *";
-        description = "Cron schedule (default: 1st of month, 10am)."; };
-    };
-
-    vaultwardenAudit = {
-      enable  = mkOption { type = types.bool; default = false;
-        description = "Monthly Vaultwarden audit: stale passwords, HTTP URIs, empty entries."; };
-      cron    = mkOption { type = types.str; default = "0 10 1 * *";
-        description = "Cron schedule (default: 1st of month, 10am)."; };
-      apiUrl  = mkOption { type = types.str; default = "http://localhost:8222";
-        description = "Vaultwarden API base URL."; };
+        description = "Monthly vault dedup, stale skill flagging, push to remote."; };
+      cron   = mkOption { type = types.str; default = "0 10 1 * *"; };
     };
 
     weeklyStorageReport = {
       enable = mkOption { type = types.bool; default = true;
-        description = "Weekly storage report: df, ZFS dataset sizes, vault size. Posts to Matrix."; };
-      cron   = mkOption { type = types.str; default = "0 9 * * 6";
-        description = "Cron schedule (default: Saturday 9am)."; };
+        description = "Weekly storage report: df + ZFS dataset sizes."; };
+      cron   = mkOption { type = types.str; default = "0 9 * * 6"; };
     };
 
-    # ── Integrations ─────────────────────────────────────────────────────────
+    vaultwardenAudit = {
+      enable = mkOption { type = types.bool; default = false;
+        description = "Monthly Vaultwarden password hygiene report."; };
+      cron   = mkOption { type = types.str; default = "0 10 1 * *"; };
+      apiUrl = mkOption { type = types.str; default = "http://localhost:8222"; };
+    };
 
-    homelabMcp = {
-      enable  = mkOption { type = types.bool; default = true;
-        description = "Register the hermes-homelab-mcp server so hermes can query service health, ZFS, disk, and Tailscale status via structured tool calls."; };
-      port    = mkOption { type = types.port; default = 7830;
-        description = "Port the homelab MCP SSE server listens on (localhost only)."; };
-      allowRestarts = mkOption { type = types.bool; default = false;
-        description = "Expose a restart_service tool. Each call requires Matrix confirmation before executing (enforced by the skill, not the tool itself)."; };
+    # ── Life management integrations ──────────────────────────────────────────
+
+    actualBudget = {
+      enable          = mkOption { type = types.bool; default = false;
+        description = "Wire Actual Budget API into hermes environment and enable budget skills/tasks."; };
+      apiUrl          = mkOption { type = types.str; default = "http://localhost:5007";
+        description = "Actual HTTP API base URL."; };
+      apiKeyEnvVar    = mkOption { type = types.str; default = "ACTUAL_HTTP_API_KEY";
+        description = "Env var name for the Actual HTTP API key."; };
+      weeklyReport    = mkOption { type = types.bool; default = true;
+        description = "Weekly budget pulse check — warns only when a category is over/approaching."; };
+      weeklyReportCron = mkOption { type = types.str; default = "0 9 * * 5";
+        description = "Schedule for weekly budget pulse (default: Friday 9am)."; };
+      monthlyReport   = mkOption { type = types.bool; default = true;
+        description = "End-of-month full budget breakdown posted to Matrix."; };
+      monthlyReportCron = mkOption { type = types.str; default = "0 8 28 * *";
+        description = "Schedule for monthly report (default: 28th of month 8am)."; };
+      alertThreshold  = mkOption { type = types.int; default = 200;
+        description = "Flag any single transaction above this amount (dollars)."; };
     };
 
     immich = {
-      enable      = mkOption { type = types.bool; default = false;
-        description = "Wire IMMICH_API_URL and IMMICH_API_KEY_ENV into hermes environment for Immich API access."; };
-      apiUrl      = mkOption { type = types.str; default = "http://localhost:2283";
-        description = "Immich API base URL."; };
-      apiKeyEnvVar = mkOption { type = types.str; default = "IMMICH_API_KEY";
-        description = "Name of the env var holding the Immich API key (sourced from environmentFile)."; };
+      enable       = mkOption { type = types.bool; default = false;
+        description = "Wire Immich API into hermes and enable photo skills/tasks."; };
+      apiUrl       = mkOption { type = types.str; default = "http://localhost:2283"; };
+      apiKeyEnvVar = mkOption { type = types.str; default = "IMMICH_API_KEY"; };
+    };
+
+    immichOnThisDay = {
+      enable = mkOption { type = types.bool; default = true;
+        description = "Daily 'On This Day' photo memory from Immich. Requires immich.enable."; };
+      cron   = mkOption { type = types.str; default = "30 7 * * *"; };
     };
 
     n8n = {
-      enable      = mkOption { type = types.bool; default = false;
-        description = "Wire N8N_BASE_URL into hermes environment so the executor can trigger n8n workflows via webhook."; };
-      baseUrl     = mkOption { type = types.str; default = "http://localhost:5678";
-        description = "n8n base URL."; };
-      apiKeyEnvVar = mkOption { type = types.str; default = "N8N_API_KEY";
-        description = "Name of the env var holding the n8n API key."; };
+      enable       = mkOption { type = types.bool; default = false;
+        description = "Wire n8n API into hermes environment."; };
+      baseUrl      = mkOption { type = types.str; default = "http://localhost:5678"; };
+      apiKeyEnvVar = mkOption { type = types.str; default = "N8N_API_KEY"; };
     };
 
-    # ── Passthroughs ─────────────────────────────────────────────────────────
+    notionSync = {
+      enable          = mkOption { type = types.bool; default = false;
+        description = "Enable Notion task integration skills and weekly stale-task audit."; };
+      weeklyTaskAudit = mkOption { type = types.bool; default = true;
+        description = "Weekly Notion task audit — flags tasks open >30 days."; };
+      auditCron       = mkOption { type = types.str; default = "0 10 * * 1";
+        description = "Schedule for stale task audit (default: Monday 10am)."; };
+    };
+
+    relationshipCrm = {
+      enable      = mkOption { type = types.bool; default = true;
+        description = "Seed relationship CRM skill and enable weekly nudge."; };
+      weeklyNudge = mkOption { type = types.bool; default = true;
+        description = "Sunday nudge: flag people not contacted in >60 days and upcoming birthdays."; };
+      nudgeCron   = mkOption { type = types.str; default = "0 10 * * 0"; };
+    };
+
+    focusMode = {
+      enable          = mkOption { type = types.bool; default = true;
+        description = "Seed focus mode skill (no scheduled task — triggered by conversation)."; };
+      defaultDuration = mkOption { type = types.int; default = 90;
+        description = "Default focus session length in minutes."; };
+    };
+
+    # ── Homelab MCP ───────────────────────────────────────────────────────────
+
+    homelabMcp = {
+      enable        = mkOption { type = types.bool; default = true;
+        description = "Enable hermes-homelab-mcp service and register it as an MCP server."; };
+      port          = mkOption { type = types.port; default = 7830; };
+      allowRestarts = mkOption { type = types.bool; default = false;
+        description = "Expose restart_service MCP tool (requires confirmed_by on each call)."; };
+    };
+
+    # ── Passthroughs ──────────────────────────────────────────────────────────
 
     mcpServers = mkOption {
-      type = types.attrs;
-      default = {};
+      type = types.attrs; default = {};
       description = "Additional MCP servers merged into services.hermes-agent.mcpServers.";
     };
 
     extraPlugins = mkOption {
-      type = types.listOf types.package;
-      default = [];
+      type = types.listOf types.package; default = [];
       description = "Extra plugins passed to services.hermes-agent.extraPlugins.";
     };
 
     extraSettings = mkOption {
-      type = types.attrs;
-      default = {};
+      type = types.attrs; default = {};
       description = "Arbitrary settings merged into services.hermes-agent.settings.";
+    };
+
+    extraSkills = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          category = mkOption { type = types.str; };
+          name     = mkOption { type = types.str; };
+          content  = mkOption { type = types.str; };
+        };
+      });
+      default = [];
+      description = "Additional vault skills to seed at activation. Each becomes HERMES_HOME/skills/<category>/<name>/SKILL.md.";
     };
   };
 
@@ -356,8 +800,6 @@ in
       enable            = true;
       addToSystemPackages = true;
 
-      # Use optionalAttrs (not mkIf) — upstream serializes mkIf into dicts and
-      # runtime_provider.py calls .strip() on those → AttributeError.
       settings = {
         model = { default = cfg.model; provider = "custom:litellm-proxy"; }
           // optionalAttrs (cfg.inferenceUrl != null) { base_url = cfg.inferenceUrl; };
@@ -376,6 +818,10 @@ in
         // optionalAttrs cfg.immich.enable {
              IMMICH_API_URL     = cfg.immich.apiUrl;
              IMMICH_API_KEY_ENV = cfg.immich.apiKeyEnvVar;
+           }
+        // optionalAttrs cfg.actualBudget.enable {
+             ACTUAL_API_URL     = cfg.actualBudget.apiUrl;
+             ACTUAL_API_KEY_ENV = cfg.actualBudget.apiKeyEnvVar;
            }
         // optionalAttrs cfg.n8n.enable {
              N8N_BASE_URL     = cfg.n8n.baseUrl;
@@ -409,8 +855,7 @@ in
       cfg.executorPackages;
 
     # ── SOUL.md → HERMES_HOME ─────────────────────────────────────────────────
-    # load_soul_md() reads from HERMES_HOME/SOUL.md, not workingDirectory.
-    # documents installs to workingDirectory — wrong path, silent no-op.
+    # load_soul_md() reads HERMES_HOME/SOUL.md, not workingDirectory.
 
     system.activationScripts.hermesAgentSoul = mkIf (cfg.soul != null) {
       text = ''
@@ -437,10 +882,66 @@ in
       deps = [ "hermes-agent-setup" "users" "groups" ];
     };
 
+    # ── Skill seeding ─────────────────────────────────────────────────────────
+
+    system.activationScripts.hermesAgentSkills = mkIf (skillsToSeed != []) {
+      text = ''
+        HERMES_HOME=/var/lib/hermes-agent/.hermes \
+          ${pkgs.python3}/bin/python3 ${skillSeedScript} \
+          ${escapeShellArg (builtins.toJSON skillsToSeed)}
+      '';
+      deps = [ "hermes-agent-setup" "users" "groups" ];
+    };
+
     # ── Cron job seeding ──────────────────────────────────────────────────────
 
     system.activationScripts.hermesAgentCronJobs = mkIf (allScheduledTasks != []) {
-      text = ''
+      text = let
+        cronSeedScript = pkgs.writeText "hermes-cron-seed.py" ''
+          #!/usr/bin/env python3
+          """Seed nix-declared cron jobs into HERMES_HOME/cron/jobs.json. Idempotent."""
+          import json, os, sys, uuid
+          from pathlib import Path
+          from datetime import datetime, timezone
+
+          CRON_DIR = Path(os.environ["HERMES_HOME"]) / "cron"
+          JOBS_FILE = CRON_DIR / "jobs.json"
+          CRON_DIR.mkdir(parents=True, exist_ok=True)
+
+          declared = json.loads(sys.argv[1])
+
+          try:
+              jobs = json.loads(JOBS_FILE.read_text())
+          except (FileNotFoundError, json.JSONDecodeError):
+              jobs = []
+
+          # Remove stale nix-managed entries, keep user-created ones
+          jobs = [j for j in jobs if "nix-managed" not in j.get("tags", [])]
+
+          now = datetime.now(timezone.utc).isoformat()
+          for task in declared:
+              stable_id = "nix-" + uuid.uuid5(uuid.NAMESPACE_DNS, task["name"]).hex[:12]
+              jobs.append({
+                  "id":          stable_id,
+                  "name":        task["name"],
+                  "prompt":      task["prompt"],
+                  "schedule":    {"kind": "cron", "expr": task["cron"]},
+                  "enabled":     True,
+                  "state":       "scheduled",
+                  "tags":        ["nix-managed"],
+                  "created_at":  now,
+                  "last_run_at": None,
+                  "run_count":   0,
+                  "next_run_at": None,
+              })
+
+          tmp = JOBS_FILE.with_suffix(".tmp")
+          tmp.write_text(json.dumps(jobs, indent=2))
+          tmp.replace(JOBS_FILE)
+          managed = [j for j in jobs if "nix-managed" in j.get("tags", [])]
+          print(f"hermes-cron-seed: {len(managed)} nix-managed jobs written")
+        '';
+      in ''
         HERMES_HOME=/var/lib/hermes-agent/.hermes \
           ${pkgs.python3}/bin/python3 ${cronSeedScript} \
           ${escapeShellArg (builtins.toJSON (map (t: {
@@ -450,12 +951,15 @@ in
       deps = [ "hermes-agent-setup" "users" "groups" ];
     };
 
-    # ── Homelab MCP: wire port when our module is enabled ────────────────────
+    # ── Homelab MCP wiring ────────────────────────────────────────────────────
 
     modules.services.ai.hermes-homelab-mcp = mkIf cfg.homelabMcp.enable {
-      enable        = true;
-      port          = cfg.homelabMcp.port;
-      allowRestarts = cfg.homelabMcp.allowRestarts;
+      enable              = true;
+      port                = cfg.homelabMcp.port;
+      allowRestarts       = cfg.homelabMcp.allowRestarts;
+      environmentFile     = cfg.environmentFile;
+      immichApiKeyEnvVar  = cfg.immich.apiKeyEnvVar;
+      actualApiKeyEnvVar  = cfg.actualBudget.apiKeyEnvVar;
     };
   };
 }

--- a/modules/services/ai/hermes-homelab-mcp.nix
+++ b/modules/services/ai/hermes-homelab-mcp.nix
@@ -382,7 +382,8 @@ let
         for a in assets[:limit]:
             city_str = a.get("exifInfo",{}).get("city","")
             loc = f" — {city_str}" if city_str else ""
-            lines.append(f"  {a.get('localDateTime','')[:10]}{loc}  id={a.get('id')}  {IMMICH_API_URL}/api/assets/{a.get('id')}/thumbnail")
+            dt = (a.get("localDateTime") or "")[:10]
+            lines.append(f"  {dt}{loc}  id={a.get('id')}  {IMMICH_API_URL}/api/assets/{a.get('id')}/thumbnail")
         return f"Found {len(assets)} photo(s):\n" + "\n".join(lines)
 
     def tool_immich_create_album(args):

--- a/modules/services/ai/hermes-homelab-mcp.nix
+++ b/modules/services/ai/hermes-homelab-mcp.nix
@@ -2,11 +2,10 @@
 
 # Homelab MCP server for Hermes.
 #
-# Exposes structured tools for querying the local NixOS host over SSE transport:
-#   service_status / list_services / service_logs / restart_service (gated)
-#   zfs_pool_status / zfs_list
-#   disk_usage / system_info
-#   tailscale_status / tailscale_peers
+# Exposes structured tools over SSE on localhost so Hermes can query:
+#   Infrastructure  — systemd, journald, ZFS, disk, Tailscale, nix flake
+#   Life / media    — Immich, Jellyseerr, Actual Budget, Vaultwarden stats
+#   Environment     — weather, network stats
 #
 # Hermes reaches it at http://localhost:<port>/sse via --network=host.
 # Enabled automatically when modules.services.ai.hermes-agent.homelabMcp.enable = true.
@@ -15,281 +14,522 @@ with lib;
 let
   cfg = config.modules.services.ai.hermes-homelab-mcp;
 
-  # Minimal SSE MCP server — stdlib only, no mcp/fastmcp dependency.
-  # Implements: initialize, tools/list, tools/call.
-  # SSE transport: GET /sse opens event stream; POST /message sends requests.
   mcpServer = pkgs.writeText "hermes-homelab-mcp.py" ''
     #!/usr/bin/env python3
-    """
-    Homelab MCP SSE server for Hermes.
-    Exposes systemd, ZFS, disk, and Tailscale status as MCP tools.
-    """
-    import json, os, subprocess, threading, queue, time, traceback, uuid
+    """Homelab MCP SSE server for Hermes. Stdlib only — no mcp/fastmcp dependency."""
+    import json, os, subprocess, threading, queue, time, traceback, uuid, urllib.request
     from http.server import HTTPServer, BaseHTTPRequestHandler
     from urllib.parse import urlparse, parse_qs
+    from datetime import date, datetime, timezone, timedelta
 
     ALLOW_RESTARTS = os.environ.get("HOMELAB_MCP_ALLOW_RESTARTS", "0") == "1"
-    PORT = int(os.environ.get("HOMELAB_MCP_PORT", "7830"))
+    PORT           = int(os.environ.get("HOMELAB_MCP_PORT", "7830"))
 
-    # ---------------------------------------------------------------------------
-    # Tool definitions
-    # ---------------------------------------------------------------------------
+    ACTUAL_API_URL    = os.environ.get("ACTUAL_API_URL",    "http://localhost:5007")
+    ACTUAL_API_KEY    = os.environ.get("ACTUAL_API_KEY",    "")
+    IMMICH_API_URL    = os.environ.get("IMMICH_API_URL",    "http://localhost:2283")
+    IMMICH_API_KEY    = os.environ.get("IMMICH_API_KEY",    "")
+    JELLYSEERR_URL    = os.environ.get("JELLYSEERR_URL",    "http://localhost:5055")
+    JELLYSEERR_KEY    = os.environ.get("JELLYSEERR_API_KEY","")
+    VAULTWARDEN_URL   = os.environ.get("VAULTWARDEN_URL",   "http://localhost:8222")
+    WEATHER_LOCATION  = os.environ.get("WEATHER_LOCATION",  "")
 
-    TOOLS = [
-      {
-        "name": "service_status",
-        "description": "Get the status of a systemd service.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name": {"type": "string", "description": "Service name (e.g. 'jellyfin')"}
-          },
-          "required": ["name"]
-        }
-      },
-      {
-        "name": "list_services",
-        "description": "List systemd services, optionally filtered by state or name fragment.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "state":  {"type": "string", "description": "Filter by state: running, failed, inactive, etc."},
-            "filter": {"type": "string", "description": "Name fragment to match (substring)."}
-          }
-        }
-      },
-      {
-        "name": "service_logs",
-        "description": "Fetch recent journal log lines for a systemd service.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name":  {"type": "string", "description": "Service name."},
-            "lines": {"type": "integer", "description": "Number of lines to return (default 50)."},
-            "since": {"type": "string", "description": "Relative time filter, e.g. '1 hour ago'."}
-          },
-          "required": ["name"]
-        }
-      },
-      {
-        "name": "zfs_pool_status",
-        "description": "Get ZFS pool health status (equivalent to zpool status -x or full status).",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "pool": {"type": "string", "description": "Pool name. Omit for all pools."},
-            "verbose": {"type": "boolean", "description": "Include per-vdev detail (default false)."}
-          }
-        }
-      },
-      {
-        "name": "zfs_list",
-        "description": "List ZFS datasets or volumes with usage statistics.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "type":   {"type": "string", "description": "filesystem, volume, snapshot (default: filesystem)."},
-            "pool":   {"type": "string", "description": "Restrict to datasets under this pool."},
-            "sort":   {"type": "string", "description": "Sort by property (default: used)."},
-            "limit":  {"type": "integer", "description": "Maximum rows (default 20)."}
-          }
-        }
-      },
-      {
-        "name": "disk_usage",
-        "description": "Report filesystem disk usage (df -h), optionally for a specific path.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "path":      {"type": "string",  "description": "Path to report (default: all mounted filesystems)."},
-            "warn_above": {"type": "integer", "description": "Only show filesystems above this % used (0-100)."}
-          }
-        }
-      },
-      {
-        "name": "system_info",
-        "description": "Get host system information: hostname, uptime, load, memory.",
-        "inputSchema": {"type": "object", "properties": {}}
-      },
-      {
-        "name": "tailscale_status",
-        "description": "Get Tailscale node status and connected peer list.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "peers_only": {"type": "boolean", "description": "Only list peers, not self (default false)."}
-          }
-        }
-      },
-      {
-        "name": "nix_flake_info",
-        "description": "Show current flake inputs and their last-modified dates from the system flake lock.",
-        "inputSchema": {"type": "object", "properties": {}}
-      },
-    ] + ([{
-        "name": "restart_service",
-        "description": "Restart a systemd service. REQUIRES explicit human confirmation in Matrix before calling — include the confirmation message ID in the call.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name":           {"type": "string", "description": "Service name to restart."},
-            "confirmed_by":   {"type": "string", "description": "Matrix message ID of the human confirmation."}
-          },
-          "required": ["name", "confirmed_by"]
-        }
-      }] if ALLOW_RESTARTS else [])
+    # ── Helpers ────────────────────────────────────────────────────────────────
 
-    # ---------------------------------------------------------------------------
-    # Tool implementations
-    # ---------------------------------------------------------------------------
-
-    def run(cmd, timeout=10):
+    def run(cmd, timeout=15):
         try:
             r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
             return (r.stdout + r.stderr).strip()
         except subprocess.TimeoutExpired:
             return f"[timeout after {timeout}s]"
         except FileNotFoundError:
-            return f"[command not found: {cmd[0]}]"
+            return f"[not found: {cmd[0]}]"
+
+    def http_get(url, headers=None, timeout=10):
+        req = urllib.request.Request(url, headers=headers or {})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read().decode())
+        except Exception as e:
+            return {"error": str(e)}
+
+    def http_post(url, data, headers=None, timeout=10):
+        body = json.dumps(data).encode()
+        h = {"Content-Type": "application/json", **(headers or {})}
+        req = urllib.request.Request(url, data=body, headers=h, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read().decode())
+        except Exception as e:
+            return {"error": str(e)}
+
+    def actual_headers():
+        h = {"Content-Type": "application/json"}
+        if ACTUAL_API_KEY:
+            h["x-api-key"] = ACTUAL_API_KEY
+        return h
+
+    def immich_headers():
+        h = {"Accept": "application/json"}
+        if IMMICH_API_KEY:
+            h["x-api-key"] = IMMICH_API_KEY
+        return h
+
+    def jellyseerr_headers():
+        h = {"Accept": "application/json"}
+        if JELLYSEERR_KEY:
+            h["X-Api-Key"] = JELLYSEERR_KEY
+        return h
+
+    # ── Tool definitions ───────────────────────────────────────────────────────
+
+    TOOLS = [
+      # ── Infrastructure ───────────────────────────────────────────────────
+      {
+        "name": "service_status",
+        "description": "Get the current status of a systemd service.",
+        "inputSchema": {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
+      },
+      {
+        "name": "list_services",
+        "description": "List systemd services, optionally filtered by state or name fragment.",
+        "inputSchema": {"type":"object","properties":{
+          "state":{"type":"string","description":"running, failed, inactive, etc."},
+          "filter":{"type":"string","description":"Name substring to match."}
+        }}
+      },
+      {
+        "name": "service_logs",
+        "description": "Fetch recent journal log lines for a systemd service.",
+        "inputSchema": {"type":"object","properties":{
+          "name":{"type":"string"},"lines":{"type":"integer"},"since":{"type":"string"}
+        },"required":["name"]}
+      },
+      {
+        "name": "zfs_pool_status",
+        "description": "ZFS pool health. Omit pool for all pools.",
+        "inputSchema": {"type":"object","properties":{
+          "pool":{"type":"string"},"verbose":{"type":"boolean"}
+        }}
+      },
+      {
+        "name": "zfs_list",
+        "description": "List ZFS datasets with usage statistics.",
+        "inputSchema": {"type":"object","properties":{
+          "type":{"type":"string"},"pool":{"type":"string"},
+          "sort":{"type":"string"},"limit":{"type":"integer"}
+        }}
+      },
+      {
+        "name": "disk_usage",
+        "description": "Filesystem disk usage (df -h). Optionally filter to filesystems above a threshold.",
+        "inputSchema": {"type":"object","properties":{
+          "path":{"type":"string"},"warn_above":{"type":"integer"}
+        }}
+      },
+      {
+        "name": "system_info",
+        "description": "Hostname, uptime, load, memory summary.",
+        "inputSchema": {"type":"object","properties":{}}
+      },
+      {
+        "name": "tailscale_status",
+        "description": "Tailscale mesh status and peer list.",
+        "inputSchema": {"type":"object","properties":{
+          "peers_only":{"type":"boolean"}
+        }}
+      },
+      {
+        "name": "nix_flake_info",
+        "description": "Current flake inputs and last-modified dates from the system flake lock.",
+        "inputSchema": {"type":"object","properties":{}}
+      },
+      # ── Life / media ─────────────────────────────────────────────────────
+      {
+        "name": "weather",
+        "description": "Current weather and 3-day forecast for the configured location.",
+        "inputSchema": {"type":"object","properties":{
+          "location":{"type":"string","description":"Override location (city name or lat,lon)."}
+        }}
+      },
+      {
+        "name": "immich_on_this_day",
+        "description": "Photos taken on this calendar date in prior years, from Immich.",
+        "inputSchema": {"type":"object","properties":{
+          "date":{"type":"string","description":"ISO date (YYYY-MM-DD). Defaults to today."},
+          "limit":{"type":"integer","description":"Max photos to return (default 5)."}
+        }}
+      },
+      {
+        "name": "immich_search",
+        "description": "Search Immich photos by date range, city, or description.",
+        "inputSchema": {"type":"object","properties":{
+          "query":{"type":"string","description":"Smart search query."},
+          "date_from":{"type":"string","description":"ISO date YYYY-MM-DD."},
+          "date_to":{"type":"string","description":"ISO date YYYY-MM-DD."},
+          "city":{"type":"string"},
+          "limit":{"type":"integer","default":10}
+        }}
+      },
+      {
+        "name": "immich_create_album",
+        "description": "Create an Immich album from a list of asset IDs.",
+        "inputSchema": {"type":"object","properties":{
+          "name":{"type":"string"},"asset_ids":{"type":"array","items":{"type":"string"}}
+        },"required":["name","asset_ids"]}
+      },
+      {
+        "name": "jellyseerr_requests",
+        "description": "List Jellyseerr media requests, optionally filtered by status.",
+        "inputSchema": {"type":"object","properties":{
+          "status":{"type":"string","description":"pending, approved, available, unavailable. Omit for all."},
+          "limit":{"type":"integer","default":20}
+        }}
+      },
+      {
+        "name": "actual_spending_summary",
+        "description": "Monthly spending totals by category from Actual Budget.",
+        "inputSchema": {"type":"object","properties":{
+          "month":{"type":"string","description":"YYYY-MM (defaults to current month)."}
+        }}
+      },
+      {
+        "name": "actual_budget_status",
+        "description": "Per-category budget vs spent for a month — shows over/under at a glance.",
+        "inputSchema": {"type":"object","properties":{
+          "month":{"type":"string","description":"YYYY-MM (defaults to current month)."}
+        }}
+      },
+      {
+        "name": "actual_recent_transactions",
+        "description": "Recent transactions across all accounts from Actual Budget.",
+        "inputSchema": {"type":"object","properties":{
+          "days":{"type":"integer","description":"Lookback window in days (default 7)."},
+          "limit":{"type":"integer","default":30}
+        }}
+      },
+      {
+        "name": "vaultwarden_health",
+        "description": "Vaultwarden admin stats: user count, active sessions, 2FA adoption.",
+        "inputSchema": {"type":"object","properties":{}}
+      },
+    ] + ([{
+        "name": "restart_service",
+        "description": "Restart a systemd service. Requires confirmed_by (Matrix message ID of explicit human approval).",
+        "inputSchema": {"type":"object","properties":{
+          "name":{"type":"string"},"confirmed_by":{"type":"string"}
+        },"required":["name","confirmed_by"]}
+      }] if ALLOW_RESTARTS else [])
+
+    # ── Tool implementations ───────────────────────────────────────────────────
+
+    def _safe_name(s):
+        return s.replace("-","").replace("_","").replace(".","").replace("/","").isalnum()
 
     def tool_service_status(args):
-        name = args["name"]
-        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
-            return "Invalid service name."
-        return run(["systemctl", "status", "--no-pager", "-l", name])
+        n = args["name"]
+        return run(["systemctl","status","--no-pager","-l", n])
 
     def tool_list_services(args):
-        state  = args.get("state", "")
-        filt   = args.get("filter", "")
-        cmd = ["systemctl", "list-units", "--no-pager", "--no-legend", "--type=service"]
-        if state:
-            cmd += ["--state", state]
+        state = args.get("state","")
+        filt  = args.get("filter","")
+        cmd   = ["systemctl","list-units","--no-pager","--no-legend","--type=service"]
+        if state: cmd += ["--state", state]
         out = run(cmd)
         if filt:
             out = "\n".join(l for l in out.splitlines() if filt.lower() in l.lower())
         return out or "(none)"
 
     def tool_service_logs(args):
-        name  = args["name"]
+        n     = args["name"]
         lines = str(args.get("lines", 50))
-        since = args.get("since", "")
-        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
-            return "Invalid service name."
-        cmd = ["journalctl", "-u", name, "--no-pager", "-n", lines]
-        if since:
-            cmd += ["--since", since]
-        return run(cmd, timeout=15)
+        since = args.get("since","")
+        cmd = ["journalctl","-u",n,"--no-pager","-n",lines]
+        if since: cmd += ["--since", since]
+        return run(cmd, timeout=20)
 
     def tool_zfs_pool_status(args):
-        pool    = args.get("pool", "")
+        pool    = args.get("pool","")
         verbose = args.get("verbose", False)
-        cmd = ["zpool", "status"] + (["-v"] if verbose else ["-x"])
-        if pool:
-            cmd.append(pool)
+        cmd = ["zpool","status"] + (["-v"] if verbose else ["-x"])
+        if pool: cmd.append(pool)
         return run(cmd)
 
     def tool_zfs_list(args):
-        kind  = args.get("type", "filesystem")
-        pool  = args.get("pool", "")
-        sort  = args.get("sort", "used")
-        limit = int(args.get("limit", 20))
-        cmd = ["zfs", "list", "-t", kind, "-o", "name,used,avail,refer,mountpoint",
-               "-s", sort, "-H"]
-        if pool:
-            cmd += ["-r", pool]
-        out = run(cmd)
+        kind  = args.get("type","filesystem")
+        pool  = args.get("pool","")
+        sort  = args.get("sort","used")
+        limit = int(args.get("limit",20))
+        cmd = ["zfs","list","-t",kind,"-o","name,used,avail,refer,mountpoint","-s",sort,"-H"]
+        if pool: cmd += ["-r", pool]
+        out   = run(cmd)
         lines = out.splitlines()
         if len(lines) > limit:
-            lines = lines[:limit] + [f"... ({len(lines) - limit} more)"]
+            lines = lines[:limit] + [f"... ({len(lines)-limit} more)"]
         return "\n".join(lines) or "(none)"
 
     def tool_disk_usage(args):
-        path       = args.get("path", "")
-        warn_above = args.get("warn_above", 0)
-        cmd = ["df", "-h", "--output=source,size,used,avail,pcent,target"]
-        if path:
-            cmd.append(path)
+        path  = args.get("path","")
+        above = args.get("warn_above", 0)
+        cmd   = ["df","-h","--output=source,size,used,avail,pcent,target"]
+        if path: cmd.append(path)
         out = run(cmd)
-        if warn_above:
-            header, *rows = out.splitlines()
-            rows = [r for r in rows if _pct(r) >= warn_above]
-            out = "\n".join([header] + rows) if rows else f"(all filesystems below {warn_above}%)"
+        if above:
+            hdr, *rows = out.splitlines()
+            rows = [r for r in rows if _pct(r) >= above]
+            out = ("\n".join([hdr]+rows)) if rows else f"(all below {above}%)"
         return out
 
     def _pct(row):
-        try:
-            return int(row.split()[-2].rstrip("%"))
-        except (IndexError, ValueError):
-            return 0
+        try: return int(row.split()[-2].rstrip("%"))
+        except: return 0
 
     def tool_system_info(args):
-        parts = [
-            run(["uname", "-a"]),
-            run(["uptime"]),
-            run(["free", "-h"]),
-        ]
-        return "\n\n".join(p for p in parts if p)
+        return "\n\n".join(filter(None,[run(["uname","-a"]),run(["uptime"]),run(["free","-h"])]))
 
     def tool_tailscale_status(args):
-        peers_only = args.get("peers_only", False)
-        out = run(["tailscale", "status"])
-        if peers_only:
+        out = run(["tailscale","status"])
+        if args.get("peers_only"):
             lines = out.splitlines()
-            # First line is self; skip it
-            out = "\n".join(lines[1:]) if len(lines) > 1 else "(no peers)"
+            out = "\n".join(lines[1:]) if len(lines)>1 else "(no peers)"
         return out
 
     def tool_nix_flake_info(args):
-        lock = "/etc/nixos/flake.lock"
-        if not os.path.exists(lock):
-            lock = "/run/current-system/flake.lock"
-        if not os.path.exists(lock):
-            return "flake.lock not found at /etc/nixos/flake.lock or /run/current-system/flake.lock"
+        for path in ["/etc/nixos/flake.lock","/run/current-system/flake.lock"]:
+            if os.path.exists(path):
+                try:
+                    data  = json.loads(open(path).read())
+                    nodes = data.get("nodes",{})
+                    lines = []
+                    for name,node in sorted(nodes.items()):
+                        if name == "root": continue
+                        locked = node.get("locked",{})
+                        rev    = locked.get("rev","")[:8]
+                        lm     = locked.get("lastModified","")
+                        lines.append(f"{name:30s}  rev={rev}  lastModified={lm}")
+                    return "\n".join(lines) or "(empty)"
+                except Exception as e:
+                    return f"Error: {e}"
+        return "flake.lock not found"
+
+    def tool_weather(args):
+        loc = args.get("location","") or WEATHER_LOCATION or "auto"
+        url = f"https://wttr.in/{urllib.parse.quote(loc)}?format=4&M"
         try:
-            data = json.loads(open(lock).read())
-            nodes = data.get("nodes", {})
-            lines = []
-            for name, node in sorted(nodes.items()):
-                if name == "root":
-                    continue
-                locked = node.get("locked", {})
-                rev    = locked.get("rev", "")[:8]
-                lm     = locked.get("lastModified", "")
-                lines.append(f"{name:30s}  rev={rev}  lastModified={lm}")
-            return "\n".join(lines) or "(empty lock)"
+            req = urllib.request.Request(url, headers={"User-Agent":"curl/7.0"})
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.read().decode().strip()
         except Exception as e:
-            return f"Error reading flake.lock: {e}"
+            return f"Weather unavailable: {e}"
+
+    def tool_immich_on_this_day(args):
+        today     = args.get("date") or date.today().isoformat()
+        limit     = int(args.get("limit", 5))
+        d         = date.fromisoformat(today)
+        results   = []
+        base_url  = IMMICH_API_URL.rstrip("/")
+        for year_offset in range(1, 10):
+            year = d.year - year_offset
+            if year < 2000: break
+            day_start = date(year, d.month, d.day)
+            day_end   = day_start + timedelta(days=1)
+            url = (f"{base_url}/api/search/metadata"
+                   f"?takenAfter={day_start.isoformat()}T00:00:00.000Z"
+                   f"&takenBefore={day_end.isoformat()}T00:00:00.000Z"
+                   f"&withExif=true&size={limit}")
+            data = http_get(url, immich_headers())
+            assets = data.get("assets", {}).get("items", [])
+            for a in assets:
+                city = a.get("exifInfo", {}).get("city","")
+                results.append({
+                    "id":    a.get("id"),
+                    "date":  a.get("localDateTime","")[:10],
+                    "city":  city,
+                    "type":  a.get("type",""),
+                    "thumb": f"{base_url}/api/assets/{a.get('id')}/thumbnail",
+                })
+            if len(results) >= limit: break
+        if not results:
+            return f"No photos found on {d.month}/{d.day} in previous years."
+        lines = [f"Photos from {d.strftime('%B %-d')} in past years:"]
+        for r in results[:limit]:
+            loc = f" — {r['city']}" if r['city'] else ""
+            lines.append(f"  [{r['date']}]{loc}  {r['thumb']}")
+        return "\n".join(lines)
+
+    def tool_immich_search(args):
+        query     = args.get("query","")
+        date_from = args.get("date_from","")
+        date_to   = args.get("date_to","")
+        city      = args.get("city","")
+        limit     = int(args.get("limit", 10))
+        base_url  = IMMICH_API_URL.rstrip("/")
+        params = {"withExif":"true", "size": str(limit)}
+        if date_from: params["takenAfter"]  = f"{date_from}T00:00:00.000Z"
+        if date_to:   params["takenBefore"] = f"{date_to}T23:59:59.999Z"
+        if city:      params["city"]        = city
+        qs  = "&".join(f"{k}={urllib.parse.quote(str(v))}" for k,v in params.items())
+        url = f"{base_url}/api/search/metadata?{qs}"
+        if query:
+            data = http_post(f"{base_url}/api/search/smart", {"query":query,"size":limit}, immich_headers())
+            assets = data.get("assets",{}).get("items",[])
+        else:
+            data   = http_get(url, immich_headers())
+            assets = data.get("assets",{}).get("items",[])
+        if not assets:
+            return "No photos found."
+        lines = []
+        for a in assets[:limit]:
+            city_str = a.get("exifInfo",{}).get("city","")
+            loc = f" — {city_str}" if city_str else ""
+            lines.append(f"  {a.get('localDateTime','')[:10]}{loc}  id={a.get('id')}  {IMMICH_API_URL}/api/assets/{a.get('id')}/thumbnail")
+        return f"Found {len(assets)} photo(s):\n" + "\n".join(lines)
+
+    def tool_immich_create_album(args):
+        name      = args["name"]
+        asset_ids = args["asset_ids"]
+        base_url  = IMMICH_API_URL.rstrip("/")
+        result = http_post(f"{base_url}/api/albums",
+                           {"albumName": name, "assetIds": asset_ids},
+                           immich_headers())
+        if "error" in result:
+            return f"Failed: {result['error']}"
+        album_id = result.get("id","")
+        return f"Album '{name}' created with {len(asset_ids)} photos. ID: {album_id}"
+
+    def tool_jellyseerr_requests(args):
+        status = args.get("status","")
+        limit  = int(args.get("limit", 20))
+        url    = f"{JELLYSEERR_URL}/api/v1/request?take={limit}"
+        if status: url += f"&filter={status}"
+        data   = http_get(url, jellyseerr_headers())
+        if "error" in data:
+            return f"Jellyseerr error: {data['error']}"
+        items = data.get("results", [])
+        if not items:
+            return "No requests found."
+        lines = []
+        for r in items:
+            media     = r.get("media",{})
+            title     = media.get("originalTitle","") or media.get("name","unknown")
+            req_status= r.get("status", "?")
+            typ       = r.get("type","")
+            requested_by = r.get("requestedBy",{}).get("displayName","?")
+            lines.append(f"  [{req_status}] {title} ({typ}) — requested by {requested_by}")
+        return f"{len(items)} request(s):\n" + "\n".join(lines)
+
+    def tool_actual_spending_summary(args):
+        month = args.get("month") or date.today().strftime("%Y-%m")
+        url   = f"{ACTUAL_API_URL}/api/budget-months/{month}/categories"
+        data  = http_get(url, actual_headers())
+        if "error" in data:
+            return f"Actual Budget error: {data['error']}"
+        cats  = data if isinstance(data, list) else data.get("categories", [])
+        if not cats:
+            return f"No category data for {month}."
+        lines = [f"Spending summary for {month}:"]
+        total = 0
+        for c in sorted(cats, key=lambda x: abs(x.get("spent",0)), reverse=True):
+            name    = c.get("name","?")
+            spent   = abs(c.get("spent",0)) / 100
+            budget  = abs(c.get("budgeted",0)) / 100
+            total  += spent
+            lines.append(f"  {name:30s}  spent=${spent:.2f}  budget=${budget:.2f}")
+        lines.append(f"\n  Total spent: ${total:.2f}")
+        return "\n".join(lines)
+
+    def tool_actual_budget_status(args):
+        month = args.get("month") or date.today().strftime("%Y-%m")
+        url   = f"{ACTUAL_API_URL}/api/budget-months/{month}/categories"
+        data  = http_get(url, actual_headers())
+        if "error" in data:
+            return f"Actual Budget error: {data['error']}"
+        cats  = data if isinstance(data, list) else data.get("categories", [])
+        over  = []
+        under = []
+        for c in cats:
+            name    = c.get("name","?")
+            spent   = abs(c.get("spent",0)) / 100
+            budget  = abs(c.get("budgeted",0)) / 100
+            if budget <= 0: continue
+            pct = spent / budget * 100
+            if pct > 100:
+                over.append(f"  OVER  {name:28s} ${spent:.0f} / ${budget:.0f} ({pct:.0f}%)")
+            elif pct > 80:
+                under.append(f"  WARN  {name:28s} ${spent:.0f} / ${budget:.0f} ({pct:.0f}%)")
+            else:
+                under.append(f"  OK    {name:28s} ${spent:.0f} / ${budget:.0f} ({pct:.0f}%)")
+        lines = [f"Budget status for {month}:"] + over + under
+        return "\n".join(lines) if len(lines)>1 else f"No budgeted categories for {month}."
+
+    def tool_actual_recent_transactions(args):
+        days  = int(args.get("days", 7))
+        limit = int(args.get("limit", 30))
+        since = (date.today() - timedelta(days=days)).isoformat()
+        url   = f"{ACTUAL_API_URL}/api/transactions?since_date={since}&limit={limit}"
+        data  = http_get(url, actual_headers())
+        if "error" in data:
+            return f"Actual Budget error: {data['error']}"
+        txns  = data if isinstance(data, list) else data.get("transactions", [])
+        if not txns:
+            return f"No transactions in the last {days} days."
+        lines = [f"Recent transactions (last {days} days):"]
+        for t in txns[:limit]:
+            amt   = t.get("amount",0) / 100
+            name  = t.get("payee_name","") or t.get("imported_payee","?")
+            dt    = t.get("date","?")
+            acct  = t.get("account_name","")
+            lines.append(f"  {dt}  {name:30s}  ${amt:8.2f}  [{acct}]")
+        return "\n".join(lines)
+
+    def tool_vaultwarden_health(args):
+        # Vaultwarden admin API — requires VAULTWARDEN_ADMIN_TOKEN in env
+        token = os.environ.get("VAULTWARDEN_ADMIN_TOKEN","")
+        if not token:
+            return "VAULTWARDEN_ADMIN_TOKEN not set — admin API unavailable."
+        url  = f"{VAULTWARDEN_URL}/admin/diagnostics"
+        req  = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                data = json.loads(r.read().decode())
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Vaultwarden admin error: {e}"
 
     def tool_restart_service(args):
         if not ALLOW_RESTARTS:
-            return "restart_service is disabled on this host."
-        name         = args.get("name", "")
-        confirmed_by = args.get("confirmed_by", "")
+            return "restart_service is disabled."
+        name         = args.get("name","")
+        confirmed_by = args.get("confirmed_by","")
         if not confirmed_by:
-            return "ERROR: confirmed_by is required. Get explicit human confirmation in Matrix first."
-        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
-            return "Invalid service name."
-        result = run(["systemctl", "restart", name], timeout=30)
-        return f"Restarted {name} (confirmed by {confirmed_by}).\n{result}"
+            return "ERROR: confirmed_by required — get explicit Matrix confirmation first."
+        result = run(["systemctl","restart",name], timeout=30)
+        return f"Restarted {name} (confirmed: {confirmed_by}).\n{result}"
 
     TOOL_IMPLS = {
-        "service_status":   tool_service_status,
-        "list_services":    tool_list_services,
-        "service_logs":     tool_service_logs,
-        "zfs_pool_status":  tool_zfs_pool_status,
-        "zfs_list":         tool_zfs_list,
-        "disk_usage":       tool_disk_usage,
-        "system_info":      tool_system_info,
-        "tailscale_status": tool_tailscale_status,
-        "nix_flake_info":   tool_nix_flake_info,
-        "restart_service":  tool_restart_service,
+        "service_status":            tool_service_status,
+        "list_services":             tool_list_services,
+        "service_logs":              tool_service_logs,
+        "zfs_pool_status":           tool_zfs_pool_status,
+        "zfs_list":                  tool_zfs_list,
+        "disk_usage":                tool_disk_usage,
+        "system_info":               tool_system_info,
+        "tailscale_status":          tool_tailscale_status,
+        "nix_flake_info":            tool_nix_flake_info,
+        "weather":                   tool_weather,
+        "immich_on_this_day":        tool_immich_on_this_day,
+        "immich_search":             tool_immich_search,
+        "immich_create_album":       tool_immich_create_album,
+        "jellyseerr_requests":       tool_jellyseerr_requests,
+        "actual_spending_summary":   tool_actual_spending_summary,
+        "actual_budget_status":      tool_actual_budget_status,
+        "actual_recent_transactions":tool_actual_recent_transactions,
+        "vaultwarden_health":        tool_vaultwarden_health,
+        "restart_service":           tool_restart_service,
     }
 
-    # ---------------------------------------------------------------------------
-    # Minimal SSE MCP server
-    # ---------------------------------------------------------------------------
+    # ── SSE MCP transport ──────────────────────────────────────────────────────
 
-    # session_id → queue of outbound SSE strings
     _sessions = {}
     _sessions_lock = threading.Lock()
 
@@ -297,74 +537,58 @@ let
         msg = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
         with _sessions_lock:
             q = _sessions.get(session_id)
-        if q:
-            q.put(msg)
+        if q: q.put(msg)
 
     def _handle_jsonrpc(session_id, body):
-        try:
-            req = json.loads(body)
-        except Exception:
-            return
-        method = req.get("method", "")
+        try: req = json.loads(body)
+        except Exception: return
+        method = req.get("method","")
         rid    = req.get("id")
-        params = req.get("params", {})
+        params = req.get("params",{})
 
         def respond(result=None, error=None):
-            r = {"jsonrpc": "2.0", "id": rid}
-            if error:
-                r["error"] = error
-            else:
-                r["result"] = result
+            r = {"jsonrpc":"2.0","id":rid}
+            if error: r["error"] = error
+            else:     r["result"] = result
             _send(session_id, "message", r)
 
         if method == "initialize":
-            respond({
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"tools": {}},
-                "serverInfo": {"name": "hermes-homelab-mcp", "version": "1.0.0"}
-            })
+            respond({"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"hermes-homelab-mcp","version":"2.0.0"}})
         elif method == "tools/list":
             respond({"tools": TOOLS})
         elif method == "tools/call":
-            name = params.get("name", "")
-            args = params.get("arguments", {})
+            name = params.get("name","")
+            args = params.get("arguments",{})
             impl = TOOL_IMPLS.get(name)
             if not impl:
-                respond(error={"code": -32601, "message": f"Unknown tool: {name}"})
+                respond(error={"code":-32601,"message":f"Unknown tool: {name}"})
                 return
             try:
                 result = impl(args)
-                respond({"content": [{"type": "text", "text": str(result)}]})
+                respond({"content":[{"type":"text","text":str(result)}]})
             except Exception as e:
-                respond(error={"code": -32000, "message": str(e),
-                               "data": traceback.format_exc()})
+                respond(error={"code":-32000,"message":str(e),"data":traceback.format_exc()})
         elif method == "notifications/initialized":
-            pass  # no response needed
-        else:
-            if rid is not None:
-                respond(error={"code": -32601, "message": f"Method not found: {method}"})
+            pass
+        elif rid is not None:
+            respond(error={"code":-32601,"message":f"Unknown: {method}"})
 
     class Handler(BaseHTTPRequestHandler):
-        def log_message(self, fmt, *args):
-            pass  # suppress access log noise
+        def log_message(self, fmt, *args): pass
 
         def do_GET(self):
             if not self.path.startswith("/sse"):
-                self.send_error(404)
-                return
-            session_id = str(uuid.uuid4())
-            q = queue.Queue()
-            with _sessions_lock:
-                _sessions[session_id] = q
+                self.send_error(404); return
+            sid = str(uuid.uuid4())
+            q   = queue.Queue()
+            with _sessions_lock: _sessions[sid] = q
             self.send_response(200)
-            self.send_header("Content-Type", "text/event-stream")
-            self.send_header("Cache-Control", "no-cache")
-            self.send_header("Connection", "keep-alive")
+            self.send_header("Content-Type","text/event-stream")
+            self.send_header("Cache-Control","no-cache")
+            self.send_header("Connection","keep-alive")
             self.end_headers()
-            # Send endpoint event so client knows where to POST
-            endpoint_event = f"event: endpoint\ndata: \"/message?session_id={session_id}\"\n\n"
             try:
-                self.wfile.write(endpoint_event.encode())
+                self.wfile.write(f'event: endpoint\ndata: "/message?session_id={sid}"\n\n'.encode())
                 self.wfile.flush()
                 while True:
                     try:
@@ -372,32 +596,27 @@ let
                         self.wfile.write(msg.encode())
                         self.wfile.flush()
                     except queue.Empty:
-                        # keep-alive ping
                         self.wfile.write(b": ping\n\n")
                         self.wfile.flush()
-            except (BrokenPipeError, ConnectionResetError):
-                pass
+            except (BrokenPipeError, ConnectionResetError): pass
             finally:
-                with _sessions_lock:
-                    _sessions.pop(session_id, None)
+                with _sessions_lock: _sessions.pop(sid, None)
 
         def do_POST(self):
             if not self.path.startswith("/message"):
-                self.send_error(404)
-                return
-            qs = parse_qs(urlparse(self.path).query)
-            session_id = (qs.get("session_id", [None])[0])
-            length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(length)
-            threading.Thread(
-                target=_handle_jsonrpc, args=(session_id, body), daemon=True
-            ).start()
+                self.send_error(404); return
+            qs  = parse_qs(urlparse(self.path).query)
+            sid = (qs.get("session_id",[None])[0])
+            n   = int(self.headers.get("Content-Length",0))
+            body = self.rfile.read(n)
+            threading.Thread(target=_handle_jsonrpc, args=(sid,body), daemon=True).start()
             self.send_response(202)
             self.end_headers()
 
     if __name__ == "__main__":
+        import urllib.parse
         server = HTTPServer(("127.0.0.1", PORT), Handler)
-        print(f"hermes-homelab-mcp listening on 127.0.0.1:{PORT}", flush=True)
+        print(f"hermes-homelab-mcp v2 listening on 127.0.0.1:{PORT}", flush=True)
         server.serve_forever()
   '';
 
@@ -411,15 +630,69 @@ in
     enable = mkEnableOption "Hermes homelab MCP server";
 
     port = mkOption {
-      type = types.port;
+      type    = types.port;
       default = 7830;
       description = "Port the MCP SSE server listens on (127.0.0.1 only).";
     };
 
     allowRestarts = mkOption {
-      type = types.bool;
+      type    = types.bool;
       default = false;
-      description = "Expose the restart_service tool. Each call requires explicit Matrix confirmation (enforced by the calling skill).";
+      description = "Expose restart_service tool. Requires confirmed_by (Matrix confirmation message ID).";
+    };
+
+    weatherLocation = mkOption {
+      type    = types.str;
+      default = "";
+      description = "Default location for weather tool (city name or lat,lon). Empty = wttr.in auto-detect.";
+    };
+
+    actualApiUrl = mkOption {
+      type    = types.str;
+      default = "http://localhost:${toString config.modules.services.productivity.actualHttpApi.port}";
+      description = "Actual Budget HTTP API base URL.";
+    };
+
+    actualApiKeyEnvVar = mkOption {
+      type    = types.str;
+      default = "ACTUAL_HTTP_API_KEY";
+      description = "Env var name holding the Actual HTTP API key.";
+    };
+
+    immichApiUrl = mkOption {
+      type    = types.str;
+      default = "http://localhost:${toString config.modules.services.media.immich.port}";
+      description = "Immich API base URL.";
+    };
+
+    immichApiKeyEnvVar = mkOption {
+      type    = types.str;
+      default = "IMMICH_API_KEY";
+      description = "Env var name holding the Immich API key.";
+    };
+
+    jellyseerrUrl = mkOption {
+      type    = types.str;
+      default = "http://localhost:${toString config.modules.services.media.jellyseerr.port}";
+      description = "Jellyseerr base URL.";
+    };
+
+    jellyseerrApiKeyEnvVar = mkOption {
+      type    = types.str;
+      default = "JELLYSEERR_API_KEY";
+      description = "Env var name holding the Jellyseerr API key.";
+    };
+
+    vaultwardenUrl = mkOption {
+      type    = types.str;
+      default = "http://localhost:${toString config.modules.services.productivity.vaultwarden.port}";
+      description = "Vaultwarden base URL.";
+    };
+
+    environmentFile = mkOption {
+      type    = types.nullOr types.path;
+      default = null;
+      description = "Agenix-decrypted env file supplying API keys referenced by *ApiKeyEnvVar options.";
     };
   };
 
@@ -434,20 +707,26 @@ in
       environment = {
         HOMELAB_MCP_PORT           = toString cfg.port;
         HOMELAB_MCP_ALLOW_RESTARTS = if cfg.allowRestarts then "1" else "0";
+        ACTUAL_API_URL             = cfg.actualApiUrl;
+        ACTUAL_API_KEY_ENV         = cfg.actualApiKeyEnvVar;
+        IMMICH_API_URL             = cfg.immichApiUrl;
+        IMMICH_API_KEY_ENV         = cfg.immichApiKeyEnvVar;
+        JELLYSEERR_URL             = cfg.jellyseerrUrl;
+        JELLYSEERR_API_KEY_ENV     = cfg.jellyseerrApiKeyEnvVar;
+        VAULTWARDEN_URL            = cfg.vaultwardenUrl;
+        WEATHER_LOCATION           = cfg.weatherLocation;
       };
 
       serviceConfig = {
-        ExecStart     = "${mcpBin}/bin/hermes-homelab-mcp";
-        Restart       = "on-failure";
-        RestartSec    = "5s";
-        # Run as root so systemctl, journalctl, zpool, df all work without sudo.
-        # The server only binds 127.0.0.1 — not exposed externally.
-        User          = "root";
-        # Harden what we can while preserving host visibility
-        PrivateTmp    = true;
-        ProtectHome   = "read-only";
-        ProtectSystem = "strict";
-        ReadWritePaths = [ "/run" "/tmp" ];
+        ExecStart       = "${mcpBin}/bin/hermes-homelab-mcp";
+        EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        Restart         = "on-failure";
+        RestartSec      = "5s";
+        User            = "root";
+        PrivateTmp      = true;
+        ProtectHome     = "read-only";
+        ProtectSystem   = "strict";
+        ReadWritePaths  = [ "/run" "/tmp" ];
       };
     };
   };

--- a/modules/services/ai/hermes-homelab-mcp.nix
+++ b/modules/services/ai/hermes-homelab-mcp.nix
@@ -1,0 +1,454 @@
+{ config, lib, pkgs, ... }:
+
+# Homelab MCP server for Hermes.
+#
+# Exposes structured tools for querying the local NixOS host over SSE transport:
+#   service_status / list_services / service_logs / restart_service (gated)
+#   zfs_pool_status / zfs_list
+#   disk_usage / system_info
+#   tailscale_status / tailscale_peers
+#
+# Hermes reaches it at http://localhost:<port>/sse via --network=host.
+# Enabled automatically when modules.services.ai.hermes-agent.homelabMcp.enable = true.
+
+with lib;
+let
+  cfg = config.modules.services.ai.hermes-homelab-mcp;
+
+  # Minimal SSE MCP server — stdlib only, no mcp/fastmcp dependency.
+  # Implements: initialize, tools/list, tools/call.
+  # SSE transport: GET /sse opens event stream; POST /message sends requests.
+  mcpServer = pkgs.writeText "hermes-homelab-mcp.py" ''
+    #!/usr/bin/env python3
+    """
+    Homelab MCP SSE server for Hermes.
+    Exposes systemd, ZFS, disk, and Tailscale status as MCP tools.
+    """
+    import json, os, subprocess, threading, queue, time, traceback, uuid
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    from urllib.parse import urlparse, parse_qs
+
+    ALLOW_RESTARTS = os.environ.get("HOMELAB_MCP_ALLOW_RESTARTS", "0") == "1"
+    PORT = int(os.environ.get("HOMELAB_MCP_PORT", "7830"))
+
+    # ---------------------------------------------------------------------------
+    # Tool definitions
+    # ---------------------------------------------------------------------------
+
+    TOOLS = [
+      {
+        "name": "service_status",
+        "description": "Get the status of a systemd service.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string", "description": "Service name (e.g. 'jellyfin')"}
+          },
+          "required": ["name"]
+        }
+      },
+      {
+        "name": "list_services",
+        "description": "List systemd services, optionally filtered by state or name fragment.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "state":  {"type": "string", "description": "Filter by state: running, failed, inactive, etc."},
+            "filter": {"type": "string", "description": "Name fragment to match (substring)."}
+          }
+        }
+      },
+      {
+        "name": "service_logs",
+        "description": "Fetch recent journal log lines for a systemd service.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "name":  {"type": "string", "description": "Service name."},
+            "lines": {"type": "integer", "description": "Number of lines to return (default 50)."},
+            "since": {"type": "string", "description": "Relative time filter, e.g. '1 hour ago'."}
+          },
+          "required": ["name"]
+        }
+      },
+      {
+        "name": "zfs_pool_status",
+        "description": "Get ZFS pool health status (equivalent to zpool status -x or full status).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "pool": {"type": "string", "description": "Pool name. Omit for all pools."},
+            "verbose": {"type": "boolean", "description": "Include per-vdev detail (default false)."}
+          }
+        }
+      },
+      {
+        "name": "zfs_list",
+        "description": "List ZFS datasets or volumes with usage statistics.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "type":   {"type": "string", "description": "filesystem, volume, snapshot (default: filesystem)."},
+            "pool":   {"type": "string", "description": "Restrict to datasets under this pool."},
+            "sort":   {"type": "string", "description": "Sort by property (default: used)."},
+            "limit":  {"type": "integer", "description": "Maximum rows (default 20)."}
+          }
+        }
+      },
+      {
+        "name": "disk_usage",
+        "description": "Report filesystem disk usage (df -h), optionally for a specific path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "path":      {"type": "string",  "description": "Path to report (default: all mounted filesystems)."},
+            "warn_above": {"type": "integer", "description": "Only show filesystems above this % used (0-100)."}
+          }
+        }
+      },
+      {
+        "name": "system_info",
+        "description": "Get host system information: hostname, uptime, load, memory.",
+        "inputSchema": {"type": "object", "properties": {}}
+      },
+      {
+        "name": "tailscale_status",
+        "description": "Get Tailscale node status and connected peer list.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "peers_only": {"type": "boolean", "description": "Only list peers, not self (default false)."}
+          }
+        }
+      },
+      {
+        "name": "nix_flake_info",
+        "description": "Show current flake inputs and their last-modified dates from the system flake lock.",
+        "inputSchema": {"type": "object", "properties": {}}
+      },
+    ] + ([{
+        "name": "restart_service",
+        "description": "Restart a systemd service. REQUIRES explicit human confirmation in Matrix before calling — include the confirmation message ID in the call.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "name":           {"type": "string", "description": "Service name to restart."},
+            "confirmed_by":   {"type": "string", "description": "Matrix message ID of the human confirmation."}
+          },
+          "required": ["name", "confirmed_by"]
+        }
+      }] if ALLOW_RESTARTS else [])
+
+    # ---------------------------------------------------------------------------
+    # Tool implementations
+    # ---------------------------------------------------------------------------
+
+    def run(cmd, timeout=10):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            return (r.stdout + r.stderr).strip()
+        except subprocess.TimeoutExpired:
+            return f"[timeout after {timeout}s]"
+        except FileNotFoundError:
+            return f"[command not found: {cmd[0]}]"
+
+    def tool_service_status(args):
+        name = args["name"]
+        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
+            return "Invalid service name."
+        return run(["systemctl", "status", "--no-pager", "-l", name])
+
+    def tool_list_services(args):
+        state  = args.get("state", "")
+        filt   = args.get("filter", "")
+        cmd = ["systemctl", "list-units", "--no-pager", "--no-legend", "--type=service"]
+        if state:
+            cmd += ["--state", state]
+        out = run(cmd)
+        if filt:
+            out = "\n".join(l for l in out.splitlines() if filt.lower() in l.lower())
+        return out or "(none)"
+
+    def tool_service_logs(args):
+        name  = args["name"]
+        lines = str(args.get("lines", 50))
+        since = args.get("since", "")
+        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
+            return "Invalid service name."
+        cmd = ["journalctl", "-u", name, "--no-pager", "-n", lines]
+        if since:
+            cmd += ["--since", since]
+        return run(cmd, timeout=15)
+
+    def tool_zfs_pool_status(args):
+        pool    = args.get("pool", "")
+        verbose = args.get("verbose", False)
+        cmd = ["zpool", "status"] + (["-v"] if verbose else ["-x"])
+        if pool:
+            cmd.append(pool)
+        return run(cmd)
+
+    def tool_zfs_list(args):
+        kind  = args.get("type", "filesystem")
+        pool  = args.get("pool", "")
+        sort  = args.get("sort", "used")
+        limit = int(args.get("limit", 20))
+        cmd = ["zfs", "list", "-t", kind, "-o", "name,used,avail,refer,mountpoint",
+               "-s", sort, "-H"]
+        if pool:
+            cmd += ["-r", pool]
+        out = run(cmd)
+        lines = out.splitlines()
+        if len(lines) > limit:
+            lines = lines[:limit] + [f"... ({len(lines) - limit} more)"]
+        return "\n".join(lines) or "(none)"
+
+    def tool_disk_usage(args):
+        path       = args.get("path", "")
+        warn_above = args.get("warn_above", 0)
+        cmd = ["df", "-h", "--output=source,size,used,avail,pcent,target"]
+        if path:
+            cmd.append(path)
+        out = run(cmd)
+        if warn_above:
+            header, *rows = out.splitlines()
+            rows = [r for r in rows if _pct(r) >= warn_above]
+            out = "\n".join([header] + rows) if rows else f"(all filesystems below {warn_above}%)"
+        return out
+
+    def _pct(row):
+        try:
+            return int(row.split()[-2].rstrip("%"))
+        except (IndexError, ValueError):
+            return 0
+
+    def tool_system_info(args):
+        parts = [
+            run(["uname", "-a"]),
+            run(["uptime"]),
+            run(["free", "-h"]),
+        ]
+        return "\n\n".join(p for p in parts if p)
+
+    def tool_tailscale_status(args):
+        peers_only = args.get("peers_only", False)
+        out = run(["tailscale", "status"])
+        if peers_only:
+            lines = out.splitlines()
+            # First line is self; skip it
+            out = "\n".join(lines[1:]) if len(lines) > 1 else "(no peers)"
+        return out
+
+    def tool_nix_flake_info(args):
+        lock = "/etc/nixos/flake.lock"
+        if not os.path.exists(lock):
+            lock = "/run/current-system/flake.lock"
+        if not os.path.exists(lock):
+            return "flake.lock not found at /etc/nixos/flake.lock or /run/current-system/flake.lock"
+        try:
+            data = json.loads(open(lock).read())
+            nodes = data.get("nodes", {})
+            lines = []
+            for name, node in sorted(nodes.items()):
+                if name == "root":
+                    continue
+                locked = node.get("locked", {})
+                rev    = locked.get("rev", "")[:8]
+                lm     = locked.get("lastModified", "")
+                lines.append(f"{name:30s}  rev={rev}  lastModified={lm}")
+            return "\n".join(lines) or "(empty lock)"
+        except Exception as e:
+            return f"Error reading flake.lock: {e}"
+
+    def tool_restart_service(args):
+        if not ALLOW_RESTARTS:
+            return "restart_service is disabled on this host."
+        name         = args.get("name", "")
+        confirmed_by = args.get("confirmed_by", "")
+        if not confirmed_by:
+            return "ERROR: confirmed_by is required. Get explicit human confirmation in Matrix first."
+        if not name.replace("-", "").replace("_", "").replace(".", "").isalnum():
+            return "Invalid service name."
+        result = run(["systemctl", "restart", name], timeout=30)
+        return f"Restarted {name} (confirmed by {confirmed_by}).\n{result}"
+
+    TOOL_IMPLS = {
+        "service_status":   tool_service_status,
+        "list_services":    tool_list_services,
+        "service_logs":     tool_service_logs,
+        "zfs_pool_status":  tool_zfs_pool_status,
+        "zfs_list":         tool_zfs_list,
+        "disk_usage":       tool_disk_usage,
+        "system_info":      tool_system_info,
+        "tailscale_status": tool_tailscale_status,
+        "nix_flake_info":   tool_nix_flake_info,
+        "restart_service":  tool_restart_service,
+    }
+
+    # ---------------------------------------------------------------------------
+    # Minimal SSE MCP server
+    # ---------------------------------------------------------------------------
+
+    # session_id → queue of outbound SSE strings
+    _sessions = {}
+    _sessions_lock = threading.Lock()
+
+    def _send(session_id, event_type, data):
+        msg = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+        with _sessions_lock:
+            q = _sessions.get(session_id)
+        if q:
+            q.put(msg)
+
+    def _handle_jsonrpc(session_id, body):
+        try:
+            req = json.loads(body)
+        except Exception:
+            return
+        method = req.get("method", "")
+        rid    = req.get("id")
+        params = req.get("params", {})
+
+        def respond(result=None, error=None):
+            r = {"jsonrpc": "2.0", "id": rid}
+            if error:
+                r["error"] = error
+            else:
+                r["result"] = result
+            _send(session_id, "message", r)
+
+        if method == "initialize":
+            respond({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "hermes-homelab-mcp", "version": "1.0.0"}
+            })
+        elif method == "tools/list":
+            respond({"tools": TOOLS})
+        elif method == "tools/call":
+            name = params.get("name", "")
+            args = params.get("arguments", {})
+            impl = TOOL_IMPLS.get(name)
+            if not impl:
+                respond(error={"code": -32601, "message": f"Unknown tool: {name}"})
+                return
+            try:
+                result = impl(args)
+                respond({"content": [{"type": "text", "text": str(result)}]})
+            except Exception as e:
+                respond(error={"code": -32000, "message": str(e),
+                               "data": traceback.format_exc()})
+        elif method == "notifications/initialized":
+            pass  # no response needed
+        else:
+            if rid is not None:
+                respond(error={"code": -32601, "message": f"Method not found: {method}"})
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass  # suppress access log noise
+
+        def do_GET(self):
+            if not self.path.startswith("/sse"):
+                self.send_error(404)
+                return
+            session_id = str(uuid.uuid4())
+            q = queue.Queue()
+            with _sessions_lock:
+                _sessions[session_id] = q
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            # Send endpoint event so client knows where to POST
+            endpoint_event = f"event: endpoint\ndata: \"/message?session_id={session_id}\"\n\n"
+            try:
+                self.wfile.write(endpoint_event.encode())
+                self.wfile.flush()
+                while True:
+                    try:
+                        msg = q.get(timeout=30)
+                        self.wfile.write(msg.encode())
+                        self.wfile.flush()
+                    except queue.Empty:
+                        # keep-alive ping
+                        self.wfile.write(b": ping\n\n")
+                        self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                with _sessions_lock:
+                    _sessions.pop(session_id, None)
+
+        def do_POST(self):
+            if not self.path.startswith("/message"):
+                self.send_error(404)
+                return
+            qs = parse_qs(urlparse(self.path).query)
+            session_id = (qs.get("session_id", [None])[0])
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            threading.Thread(
+                target=_handle_jsonrpc, args=(session_id, body), daemon=True
+            ).start()
+            self.send_response(202)
+            self.end_headers()
+
+    if __name__ == "__main__":
+        server = HTTPServer(("127.0.0.1", PORT), Handler)
+        print(f"hermes-homelab-mcp listening on 127.0.0.1:{PORT}", flush=True)
+        server.serve_forever()
+  '';
+
+  mcpBin = pkgs.writeShellScriptBin "hermes-homelab-mcp" ''
+    exec ${pkgs.python3}/bin/python3 ${mcpServer} "$@"
+  '';
+
+in
+{
+  options.modules.services.ai.hermes-homelab-mcp = {
+    enable = mkEnableOption "Hermes homelab MCP server";
+
+    port = mkOption {
+      type = types.port;
+      default = 7830;
+      description = "Port the MCP SSE server listens on (127.0.0.1 only).";
+    };
+
+    allowRestarts = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Expose the restart_service tool. Each call requires explicit Matrix confirmation (enforced by the calling skill).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ mcpBin ];
+
+    systemd.services.hermes-homelab-mcp = {
+      description = "Hermes homelab MCP SSE server";
+      wantedBy    = [ "multi-user.target" ];
+      after       = [ "network.target" ];
+
+      environment = {
+        HOMELAB_MCP_PORT           = toString cfg.port;
+        HOMELAB_MCP_ALLOW_RESTARTS = if cfg.allowRestarts then "1" else "0";
+      };
+
+      serviceConfig = {
+        ExecStart     = "${mcpBin}/bin/hermes-homelab-mcp";
+        Restart       = "on-failure";
+        RestartSec    = "5s";
+        # Run as root so systemctl, journalctl, zpool, df all work without sudo.
+        # The server only binds 127.0.0.1 — not exposed externally.
+        User          = "root";
+        # Harden what we can while preserving host visibility
+        PrivateTmp    = true;
+        ProtectHome   = "read-only";
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/run" "/tmp" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Depends on #213 (merge first — this branch includes those commits).

## What this adds

### Scheduling — hermes runs itself

Seven built-in scheduled behaviors, each with an `enable` flag (all on by default except `vaultwardenAudit`):

| Option | Schedule | What it does |
|--------|----------|--------------|
| `digest` | Daily 8am | Service health, ZFS status, disk pressure → Matrix |
| `nixUpdateSummary` | Mon 9am | Flake input staleness report → Matrix |
| `nightlyAnomalyScan` | 2am | Silent scan; posts only on real anomalies |
| `monthlyVaultMaintenance` | 1st of month | Dedup memories, flag stale skills, push remote |
| `weeklyStorageReport` | Sat 9am | df + ZFS dataset sizes → Matrix |
| `vaultwardenAudit` | 1st of month | Password hygiene (off by default) |
| `scheduledTasks` | user-defined | Arbitrary prompt + cron, same mechanism |

Jobs write into `~/.hermes/cron/jobs.json` via a Python activation script. Nix-managed jobs are tagged and replaced idempotently on every rebuild; user-created jobs are never touched.

### Homelab MCP server — hermes can see the host

New module `hermes-homelab-mcp.nix`: a stdlib-only Python SSE MCP server on `127.0.0.1:7830`. No `mcp`/`fastmcp` package dependency. Tools:

- `service_status` / `list_services` / `service_logs`
- `zfs_pool_status` / `zfs_list`
- `disk_usage` / `system_info`
- `tailscale_status`
- `nix_flake_info` (reads flake.lock)
- `restart_service` (opt-in via `allowRestarts = true`, requires `confirmed_by` arg)

Hermes reaches it via SSE at `http://localhost:7830/sse` (container uses `--network=host`). Enabled automatically when `homelabMcp.enable = true`.

### New typed options

- `matrixNotificationRoom` — separate room for proactive output vs interactive sessions
- `vaultGitRemote` — git remote written to vault at activation
- `agentsMd` — `AGENTS.md` in working directory (project context loaded every session)
- `hostUsers` — `~/.hermes` symlink for listed users
- `executorPackages` — extra packages on the executor user
- `immich` / `n8n` — wire API URLs into hermes environment
- `mcpServers` / `extraPlugins` / `extraSettings` passthroughs

### david wiring

`nightlyAnomalyScan` now watches the core service stack (jellyfin, immich, vaultwarden, postgresql, caddy, matrix-synapse, litellm, hermes-agent) and the `tank` ZFS pool.