### PR TITLE
refactor(ai): four maintainability fixes across AI modules

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -2,6 +2,12 @@
 # Hosts all services including infrastructure, media, productivity, and storage
 
 { config, pkgs, lib, nixpkgs, nixpkgs-unstable, nix-bitcoin, ... }:
+let
+  # Tailscale IP for tristons-workstation. LiteLLM uses aiodns which bypasses
+  # /etc/hosts, so we must use the raw IP rather than the hostname everywhere
+  # LiteLLM resolves endpoints. Update this if the device re-registers on Tailscale.
+  workstationIp = "100.110.37.61";
+in
 {
   imports = [
     ../../modules/services/tailscale-router.nix
@@ -25,7 +31,7 @@
 
   # tristons-workstation is reachable via Tailscale but not via VLAN from david's br0.
   # Pin it to the Tailscale IP so internal service lookups (LiteLLM → Ollama) work.
-  networking.hosts."100.110.37.61" = [ "tristons-workstation.theyoder.family" "tristons-workstation" ];
+  networking.hosts.${workstationIp} = [ "tristons-workstation.theyoder.family" "tristons-workstation" ];
   system.autoUpgrade.channel = "https://nixos.org/channels/nixos-23.11/";
 
   # ZFS encryption key is loaded via postDeviceCommands (key file, not interactive).
@@ -155,14 +161,14 @@
     port = 4100;
     models = [
       # ── Embeddings ────────────────────────────────────────────────────────────
-      { name = "embed";            model = "ollama/nomic-embed-text";      apiBase = "http://100.110.37.61:11434"; }
+      { name = "embed";            model = "ollama/nomic-embed-text";      apiBase = "http://${workstationIp}:11434"; }
 
       # ── Local inference (tristons-workstation RTX 4080) ──────────────────────
-      { name = "local";            model = "ollama/hermes3";               apiBase = "http://100.110.37.61:11434"; }
-      { name = "local-fast";       model = "ollama/llama3.2:3b";           apiBase = "http://100.110.37.61:11434"; }
-      { name = "local-tool";       model = "ollama/qwen2.5:14b";           apiBase = "http://100.110.37.61:11434"; }
-      { name = "local-code";       model = "ollama/qwen2.5-coder:14b";     apiBase = "http://100.110.37.61:11434"; }
-      { name = "local-general";    model = "ollama/phi4:14b";              apiBase = "http://100.110.37.61:11434"; }
+      { name = "local";            model = "ollama/hermes3";               apiBase = "http://${workstationIp}:11434"; }
+      { name = "local-fast";       model = "ollama/llama3.2:3b";           apiBase = "http://${workstationIp}:11434"; }
+      { name = "local-tool";       model = "ollama/qwen2.5:14b";           apiBase = "http://${workstationIp}:11434"; }
+      { name = "local-code";       model = "ollama/qwen2.5-coder:14b";     apiBase = "http://${workstationIp}:11434"; }
+      { name = "local-general";    model = "ollama/phi4:14b";              apiBase = "http://${workstationIp}:11434"; }
 
       # ── API models (Anthropic) ────────────────────────────────────────────────
       # fast: general tasking, routing, summarization
@@ -175,14 +181,12 @@
     environmentFile = config.age.secrets.hermes-env.path;
   };
 
-  # Set the Matrix home room so /sethome is not needed after each restart.
-  # HERMES_MANAGED=true blocks the /sethome command; env var is the only path.
-  services.hermes-agent.environment.MATRIX_HOME_ROOM = "!evHgyPMGVZyKzGopQo:theyoder.family";
-
   modules.services.ai.hermes-agent = {
     enable = true;
     model = "local-general";  # LiteLLM route: phi4:14b on tristons-workstation RTX 4080
     environmentFile = config.age.secrets.hermes-env.path;
+    # HERMES_MANAGED=true (in environmentFile) blocks /sethome; homeRoom is the only path.
+    homeRoom = "!evHgyPMGVZyKzGopQo:theyoder.family";
     extraVolumes = [
       "/data/tristonyoder/home/Projects/nix-config:/nix-config:ro"
     ];

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -32,6 +32,17 @@ in
       description = "Run Hermes in a Docker container (supports apt/pip/npm for agent-installed tools).";
     };
 
+    homeRoom = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Matrix room ID to use as Hermes's persistent home room (sets MATRIX_HOME_ROOM).
+        When set, Hermes re-joins this room on startup without requiring /sethome.
+        Must be set alongside HERMES_MANAGED=true in the environment file to block
+        the /sethome command (prevents accidental home-room override).
+      '';
+    };
+
     extraVolumes = mkOption {
       type = types.listOf types.str;
       default = [];
@@ -67,6 +78,10 @@ in
       };
 
       environmentFiles = optional (cfg.environmentFile != null) cfg.environmentFile;
+
+      environment = optionalAttrs (cfg.homeRoom != null) {
+        MATRIX_HOME_ROOM = cfg.homeRoom;
+      };
 
       # Matrix platform dependencies — uses the upstream 'matrix' pyproject.toml
       # optional-dependency group, which includes mautrix[encryption]==0.21.0,

--- a/modules/services/ai/litellm.nix
+++ b/modules/services/ai/litellm.nix
@@ -90,7 +90,7 @@ in
           drop_params = true;
         };
 
-        general_settings = mkIf cfg.requireAuth {
+        general_settings = optionalAttrs cfg.requireAuth {
           master_key = "os.environ/LITELLM_MASTER_KEY";
         };
       };

--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -20,8 +20,8 @@ in
 
     ollamaHost = mkOption {
       type = types.str;
-      default = "http://tristons-workstation:11434";
-      description = "Ollama API endpoint for local models.";
+      default = "http://localhost:${toString config.modules.services.ai.ollama.port}";
+      description = "Ollama API endpoint for local models. Override when Ollama runs on a remote host.";
     };
 
     # Path to an EnvironmentFile with secrets. Loaded by the systemd unit so


### PR DESCRIPTION
## Summary

- **litellm**: Replace `mkIf` with `optionalAttrs` in `general_settings` — same `_type:if` YAML serialization hazard that broke hermes-agent's `base_url` config
- **hermes-agent**: Add `homeRoom` option so callers set `MATRIX_HOME_ROOM` through the module interface instead of poking `services.hermes-agent.environment` directly
- **david**: Centralize Tailscale IP (`100.110.37.61`) as a `let workstationIp` binding — was duplicated across 5 `apiBase` entries and `networking.hosts`; comment explains why raw IP is required (LiteLLM aiodns bypasses `/etc/hosts`)
- **open-webui**: Replace hardcoded `tristons-workstation:11434` default for `ollamaHost` with `localhost:${ollama.port}` so the module is reusable on any host

## Test plan

- [ ] Dry-run build on david: `sudo nixos-rebuild dry-run --flake .#david`
- [ ] Confirm LiteLLM still starts and routes to workstation Ollama models
- [ ] Confirm hermes-agent picks up `MATRIX_HOME_ROOM` from the new `homeRoom` option (check `systemctl status hermes-agent` — should not require `/sethome` after restart)