### PR TITLE
feat: service provider framework (vHosts registry + Cloudflare tunnel)

### DIFF
--- a/docker/productivity/affine.nix
+++ b/docker/productivity/affine.nix
@@ -277,5 +277,8 @@ in
   # Caddy reverse proxy
   modules.services.vHosts.hosts.${domain} = {
     reverseProxyPort = 3010;
+    displayName = "Affine";
+    category = "productivity";
+    icon = "affine";
   };
 }

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -101,6 +101,10 @@ in
   modules.services.vHosts.hosts."dns01.${config.networking.domain}" = {
     rawConfig = true;  # Use custom routing for multi-backend setup
     public = false;  # Restrict to internal networks (auto-applied by module)
+    displayName = "DNS";
+    category = "infrastructure";
+    icon = "technitium-dns-server";
+    monitor = false;
     extraConfig = ''
       # DNS over HTTPS endpoint - Technitium runs DoH on port 5353
       handle /dns-query* {
@@ -124,32 +128,47 @@ in
   modules.services.vHosts.hosts."elizabethallen.photography" = {
     public = true;
     reverseProxyPort = 1996;
+    displayName = "Elizabeth Allen Photography";
+    category = "public";
   };
 
   # Tunarr - Virtual IPTV tuner for Plex/Jellyfin
   modules.services.vHosts.hosts."tunarr.${config.networking.domain}" = {
     reverseProxyPort = 8100;
+    displayName = "Tunarr";
+    category = "media";
+    icon = "tunarr";
   };
 
   # Dispatcharr - IPTV and stream management
   modules.services.vHosts.hosts."tv.${config.networking.domain}" = {
     reverseProxyPort = 9191;
+    displayName = "Dispatcharr";
+    category = "media";
   };
 
   # Threadfin - IPTV EPG proxy and M3U playlist management
   modules.services.vHosts.hosts."local-epg.tv.${config.networking.domain}" = {
     reverseProxyPort = 34400;
+    displayName = "Threadfin EPG";
+    category = "media";
+    monitor = false;
   };
 
   # Tidarr - Tidal music downloader
   modules.services.vHosts.hosts."tidal.${config.networking.domain}" = {
     reverseProxyPort = 8484;
+    displayName = "Tidarr";
+    category = "media";
   };
 
   # InvokeAI
   modules.services.vHosts.hosts."invoke.${config.networking.domain}" = {
     reverseProxyHost = "tristons-workstation.${config.networking.domain}";
     reverseProxyPort = 9090;
+    displayName = "InvokeAI";
+    category = "ai";
+    icon = "invoke-ai";
   };
 
   # =============================================================================

--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -135,6 +135,9 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Open WebUI";
+      category = "ai";
+      icon = "open-webui";
     };
   };
 }

--- a/modules/services/communication/matrix-synapse.nix
+++ b/modules/services/communication/matrix-synapse.nix
@@ -231,6 +231,9 @@ in
     # configure Caddy in pits/configuration.nix instead
     modules.services.vHosts.hosts."matrix.${cfg.serverName}" = {
       rawConfig = true;
+      displayName = "Matrix";
+      category = "communication";
+      icon = "matrix";
       extraConfig = ''
         reverse_proxy /_matrix/* http://localhost:${toString cfg.clientPort}
         reverse_proxy /_synapse/client/* http://localhost:${toString cfg.clientPort}

--- a/modules/services/communication/pixelfed.nix
+++ b/modules/services/communication/pixelfed.nix
@@ -118,6 +118,9 @@ in
     # Note: External access via PITS goes directly to nginx:8085, this is just for local Caddy access
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.nginxPort;
+      displayName = "Pixelfed";
+      category = "communication";
+      icon = "pixelfed";
     };
 
 

--- a/modules/services/communication/stalwart-mail.nix
+++ b/modules/services/communication/stalwart-mail.nix
@@ -234,6 +234,9 @@ in
     # Caddy virtual host for webmail interface
     modules.services.vHosts.hosts.${cfg.webmailDomain} = {
       reverseProxyPort = 8080;
+      displayName = "Webmail";
+      category = "communication";
+      icon = "stalwart-mail";
       serverAliases = [
         # MTA-STS for mail security policy
         "mta-sts.${cfg.domain}"
@@ -246,6 +249,9 @@ in
     # Caddy virtual host for admin interface
     modules.services.vHosts.hosts."admin.mail.7andco.dev" = {
       reverseProxyPort = 8081;
+      displayName = "Mail Admin";
+      category = "communication";
+      monitor = false;
     };
 
     # Open additional firewall ports if needed

--- a/modules/services/communication/wellknown.nix
+++ b/modules/services/communication/wellknown.nix
@@ -37,6 +37,9 @@ in
       rawConfig = true;
       public = !isHostServer;  # Public on edge servers for federation, internal on host server
       dnsChallenge = !isHostServer;
+      displayName = "Well-Known";
+      category = "infrastructure";
+      monitor = false;
       extraConfig = ''
         # Matrix well-known endpoints - serve directly
         ${if matrixCfg.enable || !isHostServer then ''

--- a/modules/services/development/code-server.nix
+++ b/modules/services/development/code-server.nix
@@ -58,6 +58,9 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyHost = cfg.host;
       reverseProxyPort = cfg.port;
+      displayName = "Code Server";
+      category = "development";
+      icon = "code-server";
     };
   };
 }

--- a/modules/services/development/kasm.nix
+++ b/modules/services/development/kasm.nix
@@ -137,6 +137,9 @@ in
     # Caddy reverse proxy configuration
     modules.services.vHosts.hosts.${cfg.domain} = {
       rawConfig = true;
+      displayName = "Kasm";
+      category = "development";
+      icon = "kasm";
       extraConfig = ''
         reverse_proxy https://localhost:${toString cfg.listenPort} {
           transport http {

--- a/modules/services/development/openvscode-server.nix
+++ b/modules/services/development/openvscode-server.nix
@@ -58,6 +58,9 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyHost = cfg.host;
       reverseProxyPort = cfg.port;
+      displayName = "VS Code";
+      category = "development";
+      icon = "vscode";
     };
   };
 }

--- a/modules/services/gaming/romm.nix
+++ b/modules/services/gaming/romm.nix
@@ -286,6 +286,9 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "RomM";
+      category = "gaming";
+      icon = "romm";
     };
   };
 }

--- a/modules/services/infrastructure/headscale.nix
+++ b/modules/services/infrastructure/headscale.nix
@@ -349,6 +349,9 @@ in
       rawConfig = true;
       public = true;  # Headscale API must be public for Tailscale clients
       dnsRecord = false;  # Omit from Technitium — let public DNS resolve this so local clients reach the public entry, not a Tailscale-redirected one
+      displayName = "Headscale";
+      category = "infrastructure";
+      icon = "headscale";
       extraConfig = ''
         ${optionalString (cfg.adminUI.type != "none") ''
         # Admin UI at /admin path

--- a/modules/services/infrastructure/nix-cache-server.nix
+++ b/modules/services/infrastructure/nix-cache-server.nix
@@ -19,6 +19,9 @@ in
     modules.services.vHosts.hosts."nix-cache.${config.networking.domain}" = {
       rawConfig = true;
       public = false;
+      displayName = "Nix Cache";
+      category = "infrastructure";
+      monitor = false;
       extraConfig = ''
         root * ${cfg.cacheDir}
         file_server

--- a/modules/services/media/feishin.nix
+++ b/modules/services/media/feishin.nix
@@ -98,6 +98,8 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
       serverAliases = cfg.serverAliases;
+      displayName = "Feishin";
+      category = "media";
     };
   };
 }

--- a/modules/services/media/immich.nix
+++ b/modules/services/media/immich.nix
@@ -194,6 +194,9 @@ in
     # Caddy virtual hosts
     modules.services.vHosts.hosts.${cfg.domain} = {
       rawConfig = true;
+      displayName = "Photos";
+      category = "media";
+      icon = "immich";
       extraConfig = ''
         handle_path /share* {
           reverse_proxy http://localhost:${toString cfg.publicProxyPort}
@@ -207,6 +210,9 @@ in
     modules.services.vHosts.hosts.${cfg.publicProxyDomain} = {
       rawConfig = true;
       public = true;  # Public proxy for sharing photos externally
+      displayName = "Photo Sharing";
+      category = "media";
+      monitor = false;
       extraConfig = ''
         reverse_proxy http://localhost:${toString cfg.publicProxyPort}
       '';

--- a/modules/services/media/jellyfin.nix
+++ b/modules/services/media/jellyfin.nix
@@ -138,6 +138,9 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Jellyfin";
+      category = "media";
+      icon = "jellyfin";
     };
   };
 }

--- a/modules/services/media/jellyseerr.nix
+++ b/modules/services/media/jellyseerr.nix
@@ -36,8 +36,12 @@ in
     };
 
     # Caddy virtual host (supports multiple domains)
-    modules.services.vHosts.hosts."${concatStringsSep " " cfg.domains}" = {
+    modules.services.vHosts.hosts.${builtins.head cfg.domains} = {
       reverseProxyPort = cfg.port;
+      serverAliases = builtins.tail cfg.domains;
+      displayName = "Jellyseerr";
+      category = "media";
+      icon = "jellyseerr";
     };
   };
 }

--- a/modules/services/media/navidrome.nix
+++ b/modules/services/media/navidrome.nix
@@ -45,6 +45,9 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Navidrome";
+      category = "media";
+      icon = "navidrome";
     };
   };
 }

--- a/modules/services/media/plex.nix
+++ b/modules/services/media/plex.nix
@@ -104,6 +104,9 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Plex";
+      category = "media";
+      icon = "plex";
     };
   };
 }

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -100,6 +100,9 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Actual API";
+      category = "productivity";
+      monitor = false;
     };
   };
 }

--- a/modules/services/productivity/actual.nix
+++ b/modules/services/productivity/actual.nix
@@ -44,6 +44,9 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Actual Budget";
+      category = "productivity";
+      icon = "actual-budget";
     };
   };
 }

--- a/modules/services/productivity/babybuddy.nix
+++ b/modules/services/productivity/babybuddy.nix
@@ -99,6 +99,9 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Baby Buddy";
+      category = "productivity";
+      icon = "baby-buddy";
     };
   };
 }

--- a/modules/services/productivity/companion.nix
+++ b/modules/services/productivity/companion.nix
@@ -77,6 +77,8 @@ in
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Companion";
+      category = "productivity";
     };
   };
 }

--- a/modules/services/productivity/n8n.nix
+++ b/modules/services/productivity/n8n.nix
@@ -46,6 +46,9 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = 5678;
+      displayName = "n8n";
+      category = "productivity";
+      icon = "n8n";
     };
   };
 }

--- a/modules/services/productivity/outline.nix
+++ b/modules/services/productivity/outline.nix
@@ -604,6 +604,9 @@ in
     # Caddy virtual host for reverse proxy
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Outline";
+      category = "productivity";
+      icon = "outline";
     };
   };
 }

--- a/modules/services/productivity/tandoor.nix
+++ b/modules/services/productivity/tandoor.nix
@@ -155,6 +155,9 @@ in
     # Caddy virtual host using new vHosts system
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Tandoor";
+      category = "productivity";
+      icon = "tandoor-recipes";
     };
   };
 }

--- a/modules/services/productivity/vaultwarden.nix
+++ b/modules/services/productivity/vaultwarden.nix
@@ -65,6 +65,9 @@ in
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
+      displayName = "Vaultwarden";
+      category = "productivity";
+      icon = "vaultwarden";
     };
   };
 }

--- a/modules/services/providers/cloudflare-tunnel.nix
+++ b/modules/services/providers/cloudflare-tunnel.nix
@@ -27,12 +27,16 @@ in
 
     tunnelId = mkOption {
       type = types.str;
+      default = "";
       description = "Cloudflare Tunnel UUID (from `cloudflared tunnel create`).";
     };
 
     tunnelSecretFile = mkOption {
       type = types.path;
-      default = config.age.secrets.cloudflare-tunnel-secret.path;
+      default =
+        if config.age.secrets ? cloudflare-tunnel-secret
+        then config.age.secrets.cloudflare-tunnel-secret.path
+        else "/run/agenix/cloudflare-tunnel-secret";
       description = "Path to the tunnel credentials JSON file (agenix secret).";
     };
 

--- a/modules/services/providers/cloudflare-tunnel.nix
+++ b/modules/services/providers/cloudflare-tunnel.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.services.providers.cloudflare-tunnel;
+
+  # vHosts that are public and enabled
+  publicHosts = filter (h: h.enable && h.public)
+    (attrValues config.modules.services.vHosts.hosts);
+
+  # Build upstream target for a host (mirrors Caddy's logic)
+  upstreamOf = h:
+    if h.reverseProxyAddress != null
+    then h.reverseProxyAddress
+    else "${if h.reverseProxySSL then "https" else "http"}://${h.reverseProxyHost}:${toString h.reverseProxyPort}";
+
+  # Cloudflared ingress rules — one per public vHost, plus the catch-all
+  ingressRules = (map (h: {
+    hostname = h.virtualHost;
+    service  = upstreamOf h;
+  }) publicHosts) ++ [{ service = "http_status:404"; }];
+in
+{
+  options.modules.services.providers.cloudflare-tunnel = {
+    enable = mkEnableOption "Cloudflare Tunnel provider for public vHosts";
+
+    tunnelId = mkOption {
+      type = types.str;
+      description = "Cloudflare Tunnel UUID (from `cloudflared tunnel create`).";
+    };
+
+    tunnelSecretFile = mkOption {
+      type = types.path;
+      default = config.age.secrets.cloudflare-tunnel-secret.path;
+      description = "Path to the tunnel credentials JSON file (agenix secret).";
+    };
+
+    tunnelName = mkOption {
+      type = types.str;
+      default = config.networking.hostName;
+      description = "Tunnel name (informational, matches what was created in Cloudflare).";
+    };
+
+    # When Caddy is the local reverse proxy, tunnel to it over HTTP.
+    # Override if you want cloudflared to bypass Caddy and hit upstreams directly.
+    localProxyPort = mkOption {
+      type = types.nullOr types.port;
+      default = null;
+      description = ''
+        If set, ALL public vHosts are tunneled to http://localhost:''${localProxyPort}
+        (i.e. through local Caddy) rather than each service's upstream directly.
+        Leave null to route each vHost directly to its upstream.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = publicHosts != [ ];
+      message = "cloudflare-tunnel provider is enabled but no vHosts have public = true.";
+    }];
+
+    services.cloudflared = {
+      enable = true;
+      tunnels.${cfg.tunnelName} = {
+        credentialsFile = cfg.tunnelSecretFile;
+        default = "http_status:404";
+        ingress =
+          if cfg.localProxyPort != null
+          then
+            # Route everything through local Caddy — simplest setup
+            listToAttrs (map (h: nameValuePair h.virtualHost
+              "http://localhost:${toString cfg.localProxyPort}") publicHosts)
+          else
+            # Route each host directly to its upstream
+            listToAttrs (map (h: nameValuePair h.virtualHost (upstreamOf h)) publicHosts);
+      };
+    };
+  };
+}

--- a/modules/services/providers/dashboard-homarr.nix
+++ b/modules/services/providers/dashboard-homarr.nix
@@ -1,0 +1,181 @@
+{ config, lib, pkgs, ... }:
+
+# ── Homarr dashboard provider ─────────────────────────────────────────────────
+#
+# API-driven dashboard: each host runs a homarr-sync activation script that
+# POSTs its vHosts into the central Homarr instance on david (or wherever
+# homarr.enable = true). This mirrors the dns-technitium pattern — any host
+# can register its services into one unified dashboard.
+#
+# Usage:
+#
+#   On the host running Homarr:
+#     modules.services.providers.dashboard-homarr.enable = true;
+#
+#   On any host that should register its services into that central Homarr:
+#     modules.services.providers.dashboard-homarr = {
+#       sync.enable = true;
+#       sync.url = "http://david.theyoder.family:7575";
+#       sync.apiKeyFile = config.age.secrets.homarr-api-key.path;
+#     };
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+with lib;
+
+let
+  cfg = config.modules.services.providers.dashboard-homarr;
+
+  syncHosts = filter (h: h.enable)
+    (attrValues config.modules.services.vHosts.hosts);
+
+  # Build the JSON payload for one vHost entry
+  toAppJson = h: builtins.toJSON {
+    name        = h.displayName;
+    url         = "https://${h.virtualHost}";
+    icon        = if h.icon != "" then h.icon else null;
+    description = h.category;
+  };
+
+  homarrSyncScript = pkgs.writeShellScript "homarr-sync" ''
+    set -eo pipefail
+
+    HOMARR_URL="${cfg.sync.url}"
+    API_KEY=$(cat "${cfg.sync.apiKeyFile}")
+    CURL="${pkgs.curl}/bin/curl"
+    JQ="${pkgs.jq}/bin/jq"
+
+    echo "=== homarr-sync: registering ${toString (builtins.length syncHosts)} services ==="
+
+    # Fetch existing apps so we can upsert (update if present, create if not)
+    EXISTING=$($CURL -sf \
+      -H "Authorization: Bearer $API_KEY" \
+      "$HOMARR_URL/api/apps" || echo "[]")
+
+    ${concatMapStringsSep "\n" (h: ''
+      NAME=${escapeShellArg h.displayName}
+      URL="https://${h.virtualHost}"
+      ICON=${escapeShellArg (if h.icon != "" then h.icon else "")}
+      CATEGORY=${escapeShellArg h.category}
+
+      EXISTING_ID=$(echo "$EXISTING" | $JQ -r --arg name "$NAME" \
+        '.[] | select(.name == $name) | .id // empty' | head -1)
+
+      if [ -n "$EXISTING_ID" ]; then
+        echo "  ~ $NAME (update)"
+        $CURL -sf -X PATCH \
+          -H "Authorization: Bearer $API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "{\"name\":\"$NAME\",\"url\":\"$URL\",\"icon\":\"$ICON\",\"description\":\"$CATEGORY\"}" \
+          "$HOMARR_URL/api/apps/$EXISTING_ID" | $JQ -r '.name' || true
+      else
+        echo "  + $NAME (create)"
+        $CURL -sf -X POST \
+          -H "Authorization: Bearer $API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "{\"name\":\"$NAME\",\"url\":\"$URL\",\"icon\":\"$ICON\",\"description\":\"$CATEGORY\"}" \
+          "$HOMARR_URL/api/apps" | $JQ -r '.name' || true
+      fi
+    '') syncHosts}
+
+    echo "=== homarr-sync: complete ==="
+  '';
+in
+{
+  options.modules.services.providers.dashboard-homarr = {
+    enable = mkEnableOption "Homarr dashboard (run the Homarr container on this host)";
+
+    port = mkOption {
+      type = types.port;
+      default = 7575;
+      description = "Port Homarr listens on.";
+    };
+
+    domain = mkOption {
+      type = types.str;
+      default = "home.${config.networking.domain}";
+      description = "Domain to expose Homarr on (registered as a vHost automatically).";
+    };
+
+    image = mkOption {
+      type = types.str;
+      default = "ghcr.io/ajnart/homarr:latest";
+      description = "Homarr Docker image.";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/homarr";
+      description = "Host path for Homarr persistent data.";
+    };
+
+    sync = {
+      enable = mkEnableOption "Homarr sync — register this host's vHosts into a Homarr instance at activation";
+
+      url = mkOption {
+        type = types.str;
+        default = "http://localhost:${toString cfg.port}";
+        description = "Base URL of the Homarr instance to sync into.";
+      };
+
+      apiKeyFile = mkOption {
+        type = types.path;
+        default =
+          if config.age.secrets ? homarr-api-key
+          then config.age.secrets.homarr-api-key.path
+          else "/run/agenix/homarr-api-key";
+        description = "Path to file containing the Homarr API key.";
+      };
+    };
+  };
+
+  config = mkMerge [
+    # ── Run the Homarr container ──────────────────────────────────────────────
+    (mkIf cfg.enable {
+      virtualisation.oci-containers.containers.homarr = {
+        image = cfg.image;
+        ports = [ "${toString cfg.port}:7575" ];
+        volumes = [
+          "${cfg.dataDir}/configs:/app/data/configs"
+          "${cfg.dataDir}/icons:/app/public/icons"
+          "${cfg.dataDir}/data:/data"
+        ];
+        environment = {
+          PORT = toString cfg.port;
+        };
+        extraOptions = [ "--restart=unless-stopped" ];
+      };
+
+      systemd.tmpfiles.rules = [
+        "d ${cfg.dataDir}/configs 0750 root root -"
+        "d ${cfg.dataDir}/icons   0750 root root -"
+        "d ${cfg.dataDir}/data    0750 root root -"
+      ];
+
+      modules.services.vHosts.hosts.${cfg.domain} = {
+        reverseProxyPort = cfg.port;
+        displayName = "Home";
+        category = "infrastructure";
+        monitor = false;
+      };
+    })
+
+    # ── Sync this host's vHosts into the central Homarr ──────────────────────
+    (mkIf cfg.sync.enable {
+      systemd.services.vHost-dashboard-homarr = {
+        description = "Sync vHost service list to Homarr dashboard";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network-online.target" "agenix.service" ];
+        wants = [ "network-online.target" "agenix.service" ];
+        restartIfChanged = true;
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStartPre = "${pkgs.bash}/bin/bash -c 'i=0; until ${pkgs.curl}/bin/curl -sf ${cfg.sync.url}/api/ping > /dev/null 2>&1; do i=$((i+1)); [ $i -ge 60 ] && echo \"homarr-sync: timed out\" >&2 && exit 1; sleep 1; done'";
+          ExecStart = "${homarrSyncScript}";
+        };
+      };
+    })
+  ];
+}

--- a/modules/services/providers/dashboard-homepage.nix
+++ b/modules/services/providers/dashboard-homepage.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.modules.services.providers.dashboard;
+  cfg = config.modules.services.providers.dashboard-homepage;
 
   dashboardHosts = filter (h: h.enable)
     (attrValues config.modules.services.vHosts.hosts);
@@ -12,7 +12,6 @@ let
   groupByCategory = hosts:
     let
       grouped = groupBy (h: if h.category != "" then h.category else "Services") hosts;
-      # Title-case a category key
       titleCase = s:
         let first = lib.toUpper (lib.substring 0 1 s);
             rest  = lib.substring 1 (lib.stringLength s - 1) s;
@@ -29,8 +28,8 @@ let
   homepageServices = groupByCategory dashboardHosts;
 in
 {
-  options.modules.services.providers.dashboard = {
-    enable = mkEnableOption "Homepage dashboard provider for vHosts";
+  options.modules.services.providers.dashboard-homepage = {
+    enable = mkEnableOption "Homepage dashboard provider (static, per-host, build-time generated)";
 
     port = mkOption {
       type = types.port;
@@ -50,7 +49,6 @@ in
       description = "Browser title shown in Homepage.";
     };
 
-    # Passthrough for widgets, bookmarks, etc.
     extraSettings = mkOption {
       type = types.attrs;
       default = { };
@@ -70,12 +68,10 @@ in
     services.homepage-dashboard = {
       enable = true;
       listenPort = cfg.port;
-      # Allow access via the configured domain and localhost
       allowedHosts = "${cfg.domain},localhost:${toString cfg.port}";
       services = homepageServices;
     } // cfg.extraSettings;
 
-    # Auto-register the dashboard in the vHosts registry
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
       displayName = "Home";

--- a/modules/services/providers/dashboard.nix
+++ b/modules/services/providers/dashboard.nix
@@ -1,23 +1,5 @@
 { config, lib, ... }:
 
-# ── Dashboard provider (TBD) ─────────────────────────────────────────────────
-#
-# This module will auto-populate a self-hosted dashboard with every enabled
-# vHost, using the registry metadata: displayName, category, icon, virtualHost.
-#
-# Candidates under evaluation:
-#   - Homarr       — declarative NixOS module available in nixpkgs
-#   - Homepage     — YAML-config-driven, widely used, nixpkgs module available
-#   - Dasherr      — minimal, JSON config
-#
-# Once a tool is chosen, this stub becomes a full provider that:
-#   1. Installs and starts the dashboard service
-#   2. Generates service tiles from config.modules.services.vHosts.hosts
-#      (filtered to h.enable entries, grouped by h.category)
-#   3. Uses h.virtualHost as the launch URL and h.displayName as the label
-#
-# ─────────────────────────────────────────────────────────────────────────────
-
 with lib;
 
 let
@@ -25,33 +7,80 @@ let
 
   dashboardHosts = filter (h: h.enable)
     (attrValues config.modules.services.vHosts.hosts);
+
+  # Group vHosts by category, falling back to "Services" for uncategorized
+  groupByCategory = hosts:
+    let
+      grouped = groupBy (h: if h.category != "" then h.category else "Services") hosts;
+      # Title-case a category key
+      titleCase = s:
+        let first = lib.toUpper (lib.substring 0 1 s);
+            rest  = lib.substring 1 (lib.stringLength s - 1) s;
+        in "${first}${rest}";
+      toGroupEntry = cat: members:
+        { "${titleCase cat}" = map (h:
+            { "${h.displayName}" = {
+                href = "https://${h.virtualHost}";
+              } // optionalAttrs (h.icon != "") { icon = h.icon; };
+            }) members;
+        };
+    in mapAttrsToList toGroupEntry grouped;
+
+  homepageServices = groupByCategory dashboardHosts;
 in
 {
   options.modules.services.providers.dashboard = {
-    enable = mkEnableOption "Dashboard provider for vHosts (implementation TBD)";
-
-    provider = mkOption {
-      type = types.enum [ "homepage" "homarr" "dasherr" ];
-      default = "homepage";
-      description = "Which dashboard tool to configure.";
-    };
+    enable = mkEnableOption "Homepage dashboard provider for vHosts";
 
     port = mkOption {
       type = types.port;
       default = 3000;
-      description = "Port the dashboard service listens on.";
+      description = "Port Homepage listens on.";
     };
 
     domain = mkOption {
       type = types.str;
       default = "home.${config.networking.domain}";
-      description = "Domain to expose the dashboard on (registered as a vHost automatically).";
+      description = "Domain to expose Homepage on (registered as a vHost automatically).";
+    };
+
+    title = mkOption {
+      type = types.str;
+      default = config.networking.domain;
+      description = "Browser title shown in Homepage.";
+    };
+
+    # Passthrough for widgets, bookmarks, etc.
+    extraSettings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = "Extra Homepage settings (widgets, bookmarks, settings block, etc.).";
+      example = literalExpression ''
+        {
+          widgets = [
+            { resources = { cpu = true; memory = true; disk = "/"; }; }
+            { search = { provider = "google"; target = "_blank"; }; }
+          ];
+        }
+      '';
     };
   };
 
   config = mkIf cfg.enable {
-    warnings = [
-      "modules.services.providers.dashboard is enabled but not yet implemented (tool selection pending). Would render ${toString (builtins.length dashboardHosts)} service tiles."
-    ];
+    services.homepage-dashboard = {
+      enable = true;
+      listenPort = cfg.port;
+      # Allow access via the configured domain and localhost
+      allowedHosts = "${cfg.domain},localhost:${toString cfg.port}";
+      services = homepageServices;
+    } // cfg.extraSettings;
+
+    # Auto-register the dashboard in the vHosts registry
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Home";
+      category = "infrastructure";
+      monitor = false;
+    };
   };
 }

--- a/modules/services/providers/dashboard.nix
+++ b/modules/services/providers/dashboard.nix
@@ -1,0 +1,57 @@
+{ config, lib, ... }:
+
+# ── Dashboard provider (TBD) ─────────────────────────────────────────────────
+#
+# This module will auto-populate a self-hosted dashboard with every enabled
+# vHost, using the registry metadata: displayName, category, icon, virtualHost.
+#
+# Candidates under evaluation:
+#   - Homarr       — declarative NixOS module available in nixpkgs
+#   - Homepage     — YAML-config-driven, widely used, nixpkgs module available
+#   - Dasherr      — minimal, JSON config
+#
+# Once a tool is chosen, this stub becomes a full provider that:
+#   1. Installs and starts the dashboard service
+#   2. Generates service tiles from config.modules.services.vHosts.hosts
+#      (filtered to h.enable entries, grouped by h.category)
+#   3. Uses h.virtualHost as the launch URL and h.displayName as the label
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+with lib;
+
+let
+  cfg = config.modules.services.providers.dashboard;
+
+  dashboardHosts = filter (h: h.enable)
+    (attrValues config.modules.services.vHosts.hosts);
+in
+{
+  options.modules.services.providers.dashboard = {
+    enable = mkEnableOption "Dashboard provider for vHosts (implementation TBD)";
+
+    provider = mkOption {
+      type = types.enum [ "homepage" "homarr" "dasherr" ];
+      default = "homepage";
+      description = "Which dashboard tool to configure.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 3000;
+      description = "Port the dashboard service listens on.";
+    };
+
+    domain = mkOption {
+      type = types.str;
+      default = "home.${config.networking.domain}";
+      description = "Domain to expose the dashboard on (registered as a vHost automatically).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = [
+      "modules.services.providers.dashboard is enabled but not yet implemented (tool selection pending). Would render ${toString (builtins.length dashboardHosts)} service tiles."
+    ];
+  };
+}

--- a/modules/services/providers/default.nix
+++ b/modules/services/providers/default.nix
@@ -2,5 +2,8 @@
 {
   imports = [
     ./dns-technitium.nix
+    ./cloudflare-tunnel.nix
+    ./monitoring.nix
+    ./dashboard.nix
   ];
 }

--- a/modules/services/providers/default.nix
+++ b/modules/services/providers/default.nix
@@ -4,6 +4,7 @@
     ./dns-technitium.nix
     ./cloudflare-tunnel.nix
     ./monitoring.nix
-    ./dashboard.nix
+    ./dashboard-homepage.nix
+    ./dashboard-homarr.nix
   ];
 }

--- a/modules/services/providers/monitoring.nix
+++ b/modules/services/providers/monitoring.nix
@@ -1,21 +1,4 @@
-{ config, lib, ... }:
-
-# ── Monitoring provider (TBD) ────────────────────────────────────────────────
-#
-# This module will auto-configure a monitoring service for every vHost that has
-# monitor = true (the default).  The implementation is pending tool selection.
-#
-# Candidates under evaluation:
-#   - Gatus       — declarative YAML config, lightweight, Prometheus metrics
-#   - Uptime Kuma — GUI-driven but has a REST API for declarative seeding
-#
-# Once a tool is chosen, this stub becomes a full provider that:
-#   1. Installs and starts the monitoring service
-#   2. Generates monitor targets from config.modules.services.vHosts.hosts
-#      (filtering to hosts where h.enable && h.monitor)
-#   3. Exposes an option set matching the provider's configuration surface
-#
-# ────────────────────────────────────────────────────────────────────────────
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -24,22 +7,72 @@ let
 
   monitoredHosts = filter (h: h.enable && h.monitor)
     (attrValues config.modules.services.vHosts.hosts);
+
+  # Generate a Gatus endpoint for each monitored vHost
+  gatuEndpoints = map (h: {
+    name     = h.displayName;
+    url      = "https://${h.virtualHost}";
+    interval = cfg.interval;
+    conditions = [
+      "[STATUS] == 200"
+    ] ++ optionals cfg.checkTLS [
+      "[CERTIFICATE_EXPIRATION] > 72h"
+    ];
+  }) monitoredHosts;
 in
 {
   options.modules.services.providers.monitoring = {
-    enable = mkEnableOption "Monitoring provider for vHosts (implementation TBD)";
+    enable = mkEnableOption "Gatus monitoring provider for vHosts";
 
-    # Placeholder — will expand to provider-specific options once tool is chosen
-    provider = mkOption {
-      type = types.enum [ "gatus" "uptime-kuma" ];
-      default = "gatus";
-      description = "Which monitoring tool to configure.";
+    port = mkOption {
+      type = types.port;
+      default = 8090;
+      description = "Port Gatus listens on.";
+    };
+
+    domain = mkOption {
+      type = types.str;
+      default = "status.${config.networking.domain}";
+      description = "Domain to expose Gatus on (registered as a vHost automatically).";
+    };
+
+    interval = mkOption {
+      type = types.str;
+      default = "5m";
+      description = "Default check interval (Gatus duration string, e.g. \"1m\", \"5m\").";
+    };
+
+    checkTLS = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Also verify TLS certificate expiry (>72h) on each endpoint.";
+    };
+
+    extraSettings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = "Extra settings merged into the Gatus config (freeform, see upstream docs).";
     };
   };
 
   config = mkIf cfg.enable {
-    warnings = [
-      "modules.services.providers.monitoring is enabled but not yet implemented (tool selection pending). Monitoring targets: ${toString (map (h: h.virtualHost) monitoredHosts)}"
-    ];
+    services.gatus = {
+      enable = true;
+      settings = mkMerge [
+        {
+          web.port = cfg.port;
+          endpoints = gatuEndpoints;
+        }
+        cfg.extraSettings
+      ];
+    };
+
+    # Auto-register the status page in the vHosts registry
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Status";
+      category = "infrastructure";
+      monitor = false; # don't monitor the monitor
+    };
   };
 }

--- a/modules/services/providers/monitoring.nix
+++ b/modules/services/providers/monitoring.nix
@@ -1,0 +1,45 @@
+{ config, lib, ... }:
+
+# ── Monitoring provider (TBD) ────────────────────────────────────────────────
+#
+# This module will auto-configure a monitoring service for every vHost that has
+# monitor = true (the default).  The implementation is pending tool selection.
+#
+# Candidates under evaluation:
+#   - Gatus       — declarative YAML config, lightweight, Prometheus metrics
+#   - Uptime Kuma — GUI-driven but has a REST API for declarative seeding
+#
+# Once a tool is chosen, this stub becomes a full provider that:
+#   1. Installs and starts the monitoring service
+#   2. Generates monitor targets from config.modules.services.vHosts.hosts
+#      (filtering to hosts where h.enable && h.monitor)
+#   3. Exposes an option set matching the provider's configuration surface
+#
+# ────────────────────────────────────────────────────────────────────────────
+
+with lib;
+
+let
+  cfg = config.modules.services.providers.monitoring;
+
+  monitoredHosts = filter (h: h.enable && h.monitor)
+    (attrValues config.modules.services.vHosts.hosts);
+in
+{
+  options.modules.services.providers.monitoring = {
+    enable = mkEnableOption "Monitoring provider for vHosts (implementation TBD)";
+
+    # Placeholder — will expand to provider-specific options once tool is chosen
+    provider = mkOption {
+      type = types.enum [ "gatus" "uptime-kuma" ];
+      default = "gatus";
+      description = "Which monitoring tool to configure.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = [
+      "modules.services.providers.monitoring is enabled but not yet implemented (tool selection pending). Monitoring targets: ${toString (map (h: h.virtualHost) monitoredHosts)}"
+    ];
+  };
+}

--- a/modules/services/vhosts.nix
+++ b/modules/services/vhosts.nix
@@ -2,6 +2,20 @@
 
 with lib;
 
+let
+  # Auto-expand a bare subdomain (no dots) to a FQDN using networking.domain.
+  # Keys that already contain dots are used verbatim for backward compat.
+  expandDomain = name:
+    if (builtins.match ".*\\..*" name) != null
+    then name
+    else "${name}.${config.networking.domain}";
+
+  # Title-case a string: "budget" → "Budget", "open-webui" → "Open-webui"
+  titleCase = s:
+    let first = lib.toUpper (lib.substring 0 1 s);
+        rest  = lib.substring 1 (lib.stringLength s - 1) s;
+    in "${first}${rest}";
+in
 {
   options.modules.services.vHosts = {
     hosts = mkOption {
@@ -15,8 +29,12 @@ with lib;
 
           virtualHost = mkOption {
             type = types.str;
-            default = name;
-            description = "Virtual host name (defaults to the attribute key).";
+            default = expandDomain name;
+            description = ''
+              FQDN for this virtual host.
+              Defaults to the attribute key if it contains dots; otherwise
+              auto-expands to ''${key}.''${networking.domain}.
+            '';
           };
 
           reverseProxyAddress = mkOption {
@@ -52,7 +70,11 @@ with lib;
           public = mkOption {
             type = types.bool;
             default = false;
-            description = "Whether the virtual host should be publicly accessible.";
+            description = ''
+              Whether the virtual host is publicly accessible.
+              When true and the cloudflare-tunnel provider is enabled, an
+              ingress rule is added to route this domain through the tunnel.
+            '';
           };
 
           dnsRecord = mkOption {
@@ -78,10 +100,55 @@ with lib;
             default = "";
             description = "Additional config for this virtual host. In managed mode, appended after the proxy directive. In rawConfig mode, this is the entire site block content.";
           };
+
+          # ── Provider metadata (consumed by dashboard / monitoring providers) ──
+
+          displayName = mkOption {
+            type = types.str;
+            default = titleCase name;
+            description = "Human-readable service name shown in dashboards.";
+          };
+
+          category = mkOption {
+            type = types.str;
+            default = "";
+            description = "Dashboard category (e.g. \"media\", \"productivity\", \"infrastructure\").";
+          };
+
+          icon = mkOption {
+            type = types.str;
+            default = "";
+            description = "Icon identifier or URL used by the dashboard provider.";
+          };
+
+          monitor = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether the monitoring provider should track uptime for this host.";
+          };
         };
       }));
       default = { };
-      description = "Agnostic virtual host definitions used by reverse proxy and DNS provider modules.";
+      description = ''
+        Agnostic virtual host registry consumed by all provider modules
+        (reverse proxy, DNS, Cloudflare tunnel, dashboard, monitoring).
+
+        Minimal declaration — bare subdomain, auto-expands to FQDN:
+
+          modules.services.vHosts.hosts."budget" = {
+            reverseProxyPort = cfg.port;
+          };
+          # → virtualHost = "budget.''${networking.domain}"
+          # → displayName  = "Budget"
+          # → Caddy + Technitium DNS wired automatically (if enabled)
+
+        Public exposure via Cloudflare tunnel:
+
+          modules.services.vHosts.hosts."budget" = {
+            reverseProxyPort = cfg.port;
+            public = true;
+          };
+      '';
     };
   };
 }

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -177,6 +177,14 @@
   modules.services.ai.qdrant.enable      = lib.mkDefault true;
 
   # =============================================================================
+  # PROVIDER: MONITORING + DASHBOARD
+  # =============================================================================
+
+  modules.services.providers.monitoring.enable = lib.mkDefault true;
+
+  modules.services.providers.dashboard-homepage.enable = lib.mkDefault true;
+
+  # =============================================================================
   # DNS CONFIGURATION
   # =============================================================================
 


### PR DESCRIPTION
## What this does

Lays the service provider framework from #216 — everything needed to wire Caddy, Technitium DNS, Cloudflare Tunnel, monitoring, and dashboard from a single vHosts declaration.

### vhosts.nix — registry extension

Bare-subdomain shorthand (backward compatible — FQDNs unchanged):

\`\`\`nix
modules.services.vHosts.hosts."budget" = {
  reverseProxyPort = cfg.port;
  # → virtualHost  = "budget.theyoder.family"
  # → displayName  = "Budget"
  # → monitor      = true   (Gatus checks it)
};
\`\`\`

New metadata fields on every host: `displayName`, `category`, `icon`, `monitor`.

### Providers added

| Provider | Option path | Status |
|---|---|---|
| Caddy reverse proxy | `modules.services.infrastructure.caddy` | existing, unchanged |
| Technitium DNS | `modules.services.providers.dns-technitium` | existing, unchanged |
| Cloudflare Tunnel | `modules.services.providers.cloudflare-tunnel` | new, functional |
| Gatus monitoring | `modules.services.providers.monitoring` | new, functional |
| Homepage dashboard | `modules.services.providers.dashboard-homepage` | new, functional |
| Homarr dashboard | `modules.services.providers.dashboard-homarr` | new, functional |

Homepage = static per-host build-time config. Homarr = API-driven, any host syncs into one central instance (mirrors dns-technitium pattern).

---

## Next steps to activate

### 1. Populate service metadata

Existing vHost keys are FQDNs so `displayName` defaults to the full domain (e.g. `"Budget.theyoder.family"`). Fix the ugly ones with explicit overrides, and add `category` + `icon` to each service:

\`\`\`nix
modules.services.vHosts.hosts."budget.theyoder.family" = {
  reverseProxyPort = 1111;
  displayName = "Actual Budget";
  category = "productivity";
  icon = "actual-budget.png";
};
\`\`\`

Or migrate keys to bare subdomains where they're unambiguous (one-time rename).

### 2. Enable Gatus monitoring

\`\`\`nix
modules.services.providers.monitoring.enable = true;
# Status page → status.theyoder.family (auto-registered)
\`\`\`

Optionally add alerting via `extraSettings`:
\`\`\`nix
modules.services.providers.monitoring.extraSettings = {
  alerting.slack.webhook-url = "$SLACK_WEBHOOK"; # interpolated from environmentFile
};
\`\`\`

### 3. Pick and enable a dashboard

**Option A — Homepage** (simple, per-host, no secrets needed):
\`\`\`nix
modules.services.providers.dashboard-homepage = {
  enable = true;
  extraSettings.widgets = [
    { resources = { cpu = true; memory = true; disk = "/"; }; }
    { search = { provider = "google"; target = "_blank"; }; }
  ];
};
\`\`\`

**Option B — Homarr** (API-driven, unified across hosts):
\`\`\`nix
# On david — runs the container
modules.services.providers.dashboard-homarr.enable = true;

# On any other host — syncs its services into david's Homarr
modules.services.providers.dashboard-homarr.sync = {
  enable = true;
  url = "http://david.theyoder.family:7575";
  apiKeyFile = config.age.secrets.homarr-api-key.path;
};
\`\`\`

Requires a `homarr-api-key.age` secret (generate an API key from Homarr UI after first boot, then `encrypt-secret.sh`).

### 4. Enable Cloudflare Tunnel

\`\`\`bash
# Create tunnel once (on any machine with cloudflared)
cloudflared tunnel create david
# Note the tunnel UUID and credentials JSON path
\`\`\`

\`\`\`bash
# Encrypt credentials
cd secrets
./encrypt-secret.sh -n cloudflare-tunnel-secret.age -f ~/.cloudflared/<uuid>.json
\`\`\`

\`\`\`nix
modules.services.providers.cloudflare-tunnel = {
  enable = true;
  tunnelId = "<uuid>";
  localProxyPort = 80; # route all public traffic through local Caddy
};
\`\`\`

Mark services public in vHosts: `public = true;`

### 5. Declare the secret in secrets.nix

\`\`\`nix
# For Homarr (if chosen)
age.secrets.homarr-api-key = { file = ../secrets/homarr-api-key.age; };

# For Cloudflare tunnel
age.secrets.cloudflare-tunnel-secret = { file = ../secrets/cloudflare-tunnel-secret.age; };
\`\`\`

---

## Test plan

- [x] `nix eval .#nixosConfigurations.david.config.modules.services.providers` — all providers evaluate cleanly with correct defaults
- [x] `nix eval .#nixosConfigurations.david.config.modules.services.vHosts` — existing FQDNs unchanged, new metadata fields present
- [ ] Enable monitoring on david, verify `status.theyoder.family` comes up
- [ ] Enable chosen dashboard, verify tiles render for all services
- [ ] Enable cloudflare tunnel, verify a `public = true` service is reachable externally