### PR TITLE
fix: use dedicated dir for nix build out-links in CI

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -131,21 +131,25 @@ jobs:
         ssh ${{ secrets.NIXOS_SERVER_USER }}@david.vpn.theyoder.family << 'EOF'
           set -e
 
+          NIX_CLOSURE_DIR="/var/lib/nix-ci-closures"
+          sudo mkdir -p "$NIX_CLOSURE_DIR"
+
           build_and_cache() {
             local host="$1"
             shift
             echo "--- Building $host ---"
+            local out_link="$NIX_CLOSURE_DIR/$host"
             sudo nix build \
               "github:TristonYoder/nix-config#nixosConfigurations.$host.config.system.build.toplevel" \
               --refresh \
-              --out-link "/tmp/nix-closure-$host" \
+              --out-link "$out_link" \
               "$@"
-            STORE_PATH=$(readlink -f "/tmp/nix-closure-$host")
+            STORE_PATH=$(readlink -f "$out_link")
             echo "Signing and caching: $STORE_PATH"
             sudo nix copy \
               --to "file:///data/nix-builds/cache?secret-key=/run/agenix/nix-cache-signing-key" \
               "$STORE_PATH"
-            rm -f "/tmp/nix-closure-$host"
+            sudo rm -f "$out_link"
             echo "✅ $host cached"
           }
 


### PR DESCRIPTION
## Summary

- Moves nix build `--out-link` symlinks from `/tmp/nix-closure-$host` to `/var/lib/nix-ci-closures/$host`
- The directory is root-owned (`sudo mkdir -p`), so all operations on it are consistently sudo
- `sudo rm -f` on cleanup (was missing sudo — caused `Operation not permitted` failure)

## Why

`sudo nix build --out-link /tmp/nix-closure-$host` creates a root-owned symlink in the shared `/tmp` directory. The subsequent `rm -f` ran without sudo and failed. The CI job aborted before the deploy step, so david was never rebuilt after the feat/serviceMagic merge.

Using `/var/lib/nix-ci-closures/` makes the location explicit, predictable, and fully under root — no ambiguity about who owns what.