### PR TITLE
refactor: polish and deploy Nextcloud module

### DIFF
--- a/modules/services/storage/nextcloud.nix
+++ b/modules/services/storage/nextcloud.nix
@@ -3,7 +3,7 @@
 with lib;
 let
   cfg = config.modules.services.storage.nextcloud;
-  pkg = pkgs.nextcloud31;
+  pkg = pkgs.nextcloud32;
 
   builtinApps = listToAttrs (map (name: {
     inherit name;

--- a/modules/services/storage/nextcloud.nix
+++ b/modules/services/storage/nextcloud.nix
@@ -3,183 +3,73 @@
 with lib;
 let
   cfg = config.modules.services.storage.nextcloud;
+  pkg = pkgs.nextcloud31;
+
+  builtinApps = listToAttrs (map (name: {
+    inherit name;
+    value = pkg.packages.apps.${name};
+  }) cfg.apps);
 in
 {
   options.modules.services.storage.nextcloud = {
-    enable = mkEnableOption "Nextcloud file synchronization and collaboration";
-    
+    enable = mkEnableOption "Nextcloud file sync and collaboration";
+
     domain = mkOption {
       type = types.str;
-      default = "cloud.7andco.dev";
-      description = "Domain for Nextcloud web interface";
+      default = "cloud.${config.networking.domain}";
+      description = "Domain for Nextcloud";
     };
-    
-    package = mkOption {
-      type = types.package;
-      default = pkgs.nextcloud31;
-      description = "Nextcloud package version";
-    };
-    
+
     maxUploadSize = mkOption {
       type = types.str;
       default = "16G";
       description = "Maximum file upload size";
     };
-    
+
     adminUser = mkOption {
       type = types.str;
       default = "admin";
       description = "Nextcloud admin username";
     };
-    
+
     adminPassFile = mkOption {
       type = types.nullOr types.path;
       default = null;
-      description = "Path to file containing admin password (uses agenix if null)";
+      description = "Path to admin password file. Defaults to agenix-managed secret.";
     };
-    
-    autoUpdateApps = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable automatic app updates";
-    };
-    
-    enableBackups = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable nightly PostgreSQL backups";
-    };
-    
-    dbTablePrefix = mkOption {
-      type = types.str;
-      default = "oc_";
-      description = "Database table prefix for Nextcloud (useful for multiple instances)";
-    };
-    
+
     dataDir = mkOption {
       type = types.str;
       default = "/data/nextcloud";
-      description = "Nextcloud data directory for user files";
+      description = "Nextcloud user data directory";
     };
-    
+
+    apps = mkOption {
+      type = types.listOf types.str;
+      default = [ "contacts" "calendar" "tasks" "notes" "forms" "tables" "groupfolders" "polls" ];
+      description = "Built-in Nextcloud apps to enable. Names must match keys in nextcloud.packages.apps.";
+    };
+
+    extraApps = mkOption {
+      type = types.attrsOf types.package;
+      default = { };
+      description = "Additional Nextcloud apps fetched outside of nixpkgs.";
+    };
+
     enableOfficeApps = mkOption {
       type = types.bool;
       default = true;
-      description = "Enable Office apps (OnlyOffice, Collabora, etc.)";
+      description = "Enable OnlyOffice and Richdocuments office suite integration.";
     };
-    
-    enableElementApp = mkOption {
+
+    enableBackups = mkOption {
       type = types.bool;
       default = true;
-      description = "Enable Element (Matrix) chat app";
-    };
-    
-    # Built-in Nextcloud apps
-    enableNews = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable News RSS reader";
-    };
-    
-    enableMail = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Mail client";
-    };
-    
-    enableTables = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Tables (spreadsheet app)";
-    };
-    
-    enableForms = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Forms";
-    };
-    
-    enableContacts = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Contacts";
-    };
-    
-    enableCalendar = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Calendar";
-    };
-    
-    enableGroupfolders = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Groupfolders";
-    };
-    
-    enableExternal = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable External storage support";
-    };
-    
-    enableUserSaml = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable user_saml SSO authentication";
-    };
-    
-    enableRichdocumentscode = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Richdocumentscode document server";
-    };
-    
-    enableIntegrationNotion = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Notion integration";
-    };
-    
-    enableIntegrationGithub = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable GitHub integration";
-    };
-    
-    enableOfficeonline = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Officeonline document editor";
-    };
-    
-    enableElectronicsignatures = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Electronic Signatures";
-    };
-    
-    enableSnappymail = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Snappymail email client";
-    };
-    
-    enableLibresign = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable Libresign document signing";
-    };
-    
-    enableFilesReadmemd = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable files_readmemd markdown viewer";
+      description = "Enable nightly PostgreSQL backups.";
     };
   };
 
   config = mkIf cfg.enable {
-    # Declare agenix secret for Nextcloud admin password
     age.secrets.nextcloud-admin-password = mkIf (cfg.adminPassFile == null) {
       file = ../../../secrets/nextcloud-admin-password.age;
       owner = "nextcloud";
@@ -187,228 +77,75 @@ in
       mode = "0400";
     };
 
-    # Ensure PostgreSQL is available
-    assertions = [
-      {
-        assertion = config.services.postgresql.enable;
-        message = "Nextcloud requires PostgreSQL to be enabled";
-      }
-    ];
-
-    # Nextcloud service configuration
     services.nextcloud = {
       enable = true;
       hostName = cfg.domain;
-      package = cfg.package;
-      
-      # Database configuration - PostgreSQL
+      package = pkg;
       database.createLocally = true;
-      
-      # Redis caching
       configureRedis = true;
-      
-      # Upload size
       maxUploadSize = cfg.maxUploadSize;
-      
-      # HTTPS
       https = true;
-      
-      # App updates
-      autoUpdateApps.enable = cfg.autoUpdateApps;
+      autoUpdateApps.enable = false;
       extraAppsEnable = true;
-      
-      # Office and productivity apps
-      extraApps = mkMerge [
-        # Built-in Office apps (OnlyOffice, Richdocuments)
-        (mkIf cfg.enableOfficeApps (with config.services.nextcloud.package.packages.apps; {
-          inherit onlyoffice richdocuments;
-        }))
-        
-        # Built-in core apps
-        (mkIf cfg.enableNews (with config.services.nextcloud.package.packages.apps; {
-          inherit news;
-        }))
-        
-        (mkIf cfg.enableMail (with config.services.nextcloud.package.packages.apps; {
-          inherit mail;
-        }))
-        
-        (mkIf cfg.enableTables (with config.services.nextcloud.package.packages.apps; {
-          inherit tables;
-        }))
-        
-        (mkIf cfg.enableForms (with config.services.nextcloud.package.packages.apps; {
-          inherit forms;
-        }))
-        
-        (mkIf cfg.enableContacts (with config.services.nextcloud.package.packages.apps; {
-          inherit contacts;
-        }))
-        
-        (mkIf cfg.enableCalendar (with config.services.nextcloud.package.packages.apps; {
-          inherit calendar;
-        }))
-        
-        (mkIf cfg.enableGroupfolders (with config.services.nextcloud.package.packages.apps; {
-          inherit groupfolders;
-        }))
-        
-        # External app is not available as a built-in app, comment it out
-        # (mkIf cfg.enableExternal (with config.services.nextcloud.package.packages.apps; {
-        #   inherit external;
-        # }))
-        
-        # Custom apps (manually fetched)
-        (mkIf cfg.enableElementApp {
-          riotchat = pkgs.fetchNextcloudApp {
-            url = "https://github.com/gary-kim/riotchat/releases/download/v0.19.0/riotchat.tar.gz";
-            sha256 = "X1yYQUdSTD9jZDX2usmM0cdPRQEe67GOAI3Na3FK224=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableUserSaml {
-          user_saml = pkgs.fetchNextcloudApp {
-            url = "https://github.com/nextcloud-releases/user_saml/releases/download/v7.0.0/user_saml-v7.0.0.tar.gz";
-            sha256 = "kE51sQWjGzDbJxgRQNFmexcW+s9/6lcbW2Rxf+Tj6hA=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableRichdocumentscode {
-          richdocumentscode = pkgs.fetchNextcloudApp {
-            url = "https://github.com/CollaboraOnline/richdocumentscode/releases/download/25.4.504/richdocumentscode.tar.gz";
-            sha256 = "y5zNEAGF5Xw1Ba7jHGimzAEK6bk6gWYiVgxofbONEc4=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableIntegrationNotion {
-          integration_notion = pkgs.fetchNextcloudApp {
-            url = "https://github.com/nextcloud-releases/integration_notion/releases/download/v2.0.0/integration_notion-v2.0.0.tar.gz";
-            sha256 = "S4KVhg7YI/T0E/t56X3VlOZ2g4EZlEIMNFxsIj0gTIw=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableIntegrationGithub {
-          integration_github = pkgs.fetchNextcloudApp {
-            url = "https://github.com/nextcloud-releases/integration_github/releases/download/v3.2.1/integration_github-v3.2.1.tar.gz";
-            sha256 = "iBWphFaXmQHNxgoi9qkfV7vCTChwtk6yg0aVr9Lhn4c=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableOfficeonline {
-          officeonline = pkgs.fetchNextcloudApp {
-            url = "https://github.com/nextcloud-releases/officeonline/releases/download/v3.1.0/officeonline-v3.1.0.tar.gz";
-            sha256 = "UoBHQfclI9fQu6tXDJsw1dbnW48q8lWyDa8A79J483c=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableElectronicsignatures {
-          electronicsignatures = pkgs.fetchNextcloudApp {
-            url = "https://github.com/eideasy/nextcloud-electronic-signatures-plugin/releases/download/v3.0.5/electronicsignatures.tar.gz";
-            sha256 = "1VijwoiDHtWQ5ujqj6f0/3Qx28VLB+feViX/poqNHf4=";
-            license = "unfree";
-          };
-        })
-        
-        (mkIf cfg.enableLibresign {
-          libresign = pkgs.fetchNextcloudApp {
-            url = "https://github.com/LibreSign/libresign/releases/download/v12.0.1/libresign-v12.0.1.tar.gz";
-            sha256 = "ey6jH+S20HxxDpA3CcizIvn4ddqk2GGnvYpyW+Iaciw=";
-            license = "agpl3Only";
-          };
-        })
-        
-        (mkIf cfg.enableFilesReadmemd {
-          files_readmemd = pkgs.fetchNextcloudApp {
-            url = "https://github.com/mamatt/files_readmemd/releases/download/V3.0.2/files_readmemd.tar.gz";
-            sha256 = "Sdai8E7MJcveoxYVpDjkdetspLB5G6kNDUSVJ7KOFlQ=";
-            license = "agpl3Only";
-          };
-        })
-      ];
-      
-      # Configuration
+      extraApps = builtinApps
+        // optionalAttrs cfg.enableOfficeApps {
+          inherit (pkg.packages.apps) onlyoffice richdocuments;
+        }
+        // cfg.extraApps;
+
       config = {
         dbtype = "pgsql";
         adminuser = cfg.adminUser;
-        adminpassFile = if cfg.adminPassFile != null then cfg.adminPassFile else config.age.secrets.nextcloud-admin-password.path;
-        # Force installation by setting these required fields
+        adminpassFile = if cfg.adminPassFile != null
+          then cfg.adminPassFile
+          else config.age.secrets.nextcloud-admin-password.path;
         dbname = "nextcloud";
         dbuser = "nextcloud";
         dbhost = "/run/postgresql";
       };
-      
-      # Settings
+
       settings = {
         overwriteProtocol = "https";
         default_phone_region = "US";
-        # Trust proxies for reverse proxy chain (localhost + Tailscale ranges)
         trusted_proxies = [ "127.0.0.1" "10.100.0.0/18" "100.64.0.0/10" "fd7a:115c:a1e0::/48" ];
-        # Custom data directory
         datadirectory = cfg.dataDir;
       };
-      
-      # PHP optimization (suggested by Nextcloud health check)
+
       phpOptions."opcache.interned_strings_buffer" = "16";
     };
 
-    # Configure PHP-FPM for Caddy
-    # Set socket ownership to caddy user/group so Caddy can communicate with PHP-FPM
+    # Allow Caddy to communicate with PHP-FPM
     services.phpfpm.pools.nextcloud.settings = {
       "listen.owner" = config.services.caddy.user;
       "listen.group" = config.services.caddy.group;
     };
-
-    # Add caddy user to nextcloud group for proper permissions
     users.users.caddy.extraGroups = [ "nextcloud" ];
 
-    # Create data directory with proper permissions
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0755 nextcloud nextcloud -"
     ];
-    
-    # Configure Nextcloud to access user home directories
-    # This allows Nextcloud to mount external storage from user directories
-    services.nextcloud.extraOptions = {
-      # Enable external storage app
-      "appstoreenabled" = "true";
-    };
 
-    # Disable problematic services until Nextcloud is manually initialized
-    systemd.services.nextcloud-setup.enable = false;
-    systemd.services.nextcloud-update-db.enable = false;
-
-    # PostgreSQL backups
     services.postgresqlBackup = mkIf cfg.enableBackups {
       enable = true;
       startAt = "*-*-* 01:15:00";
     };
 
-    # Caddy virtual host on David
-    # Caddy serves Nextcloud directly via PHP-FPM Unix socket
+    # Nextcloud requires direct PHP-FPM access via Caddy rather than a simple reverse proxy
     modules.services.vHosts.hosts.${cfg.domain} = {
       rawConfig = true;
+      displayName = "Nextcloud";
+      category = "storage";
+      icon = "nextcloud";
       extraConfig = ''
-        # Serve Nextcloud via PHP-FPM
-        root * ${config.services.nextcloud.package}
-        
-        # PHP FastCGI through Unix socket
+        root * ${pkg}
+
         php_fastcgi unix//run/phpfpm/nextcloud.sock {
           env front_controller_active true
         }
-        
-        # File server
+
         file_server
-        
-        # Compression
         encode gzip
-        
-        # Security headers
+
         header {
           Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
           Referrer-Policy "no-referrer"
@@ -417,8 +154,7 @@ in
           X-XSS-Protection "1; mode=block"
           Permissions-Policy "interest-cohort=()"
         }
-        
-        # Redirect CalDAV/CardDAV well-known endpoints
+
         redir /.well-known/carddav /remote.php/dav 301
         redir /.well-known/caldav /remote.php/dav 301
       '';

--- a/modules/services/storage/nextcloud.nix
+++ b/modules/services/storage/nextcloud.nix
@@ -106,6 +106,7 @@ in
 
       settings = {
         overwriteProtocol = "https";
+        "overwrite.cli.url" = "https://${cfg.domain}";
         default_phone_region = "US";
         trusted_proxies = [ "127.0.0.1" "10.100.0.0/18" "100.64.0.0/10" "fd7a:115c:a1e0::/48" ];
         datadirectory = cfg.dataDir;
@@ -128,6 +129,25 @@ in
     services.postgresqlBackup = mkIf cfg.enableBackups {
       enable = true;
       startAt = "*-*-* 01:15:00";
+    };
+
+    # Fix PostgreSQL collation version mismatch after glibc upgrades.
+    # Runs once after PostgreSQL is ready; harmless if versions already match.
+    systemd.services.nextcloud-refresh-collation = {
+      description = "Refresh Nextcloud PostgreSQL collation version";
+      after = [ "postgresql.service" ];
+      requires = [ "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "postgres";
+        RemainAfterExit = true;
+      };
+      script = ''
+        ${config.services.postgresql.package}/bin/psql nextcloud \
+          -c "ALTER DATABASE nextcloud REFRESH COLLATION VERSION;" \
+          2>&1 | grep -v "^$" || true
+      '';
     };
 
     # Nextcloud requires direct PHP-FPM access via Caddy rather than a simple reverse proxy

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -126,31 +126,7 @@
   modules.services.storage.samba.enable = lib.mkDefault true;
   modules.services.storage.syncthing.enable = lib.mkDefault true;
   
-  # Nextcloud with all apps enabled
-  # modules.services.storage.nextcloud = {
-  #   enable = lib.mkDefault true;
-    
-  #   # Built-in apps
-  #   enableNews = true;
-  #   enableMail = true;
-  #   enableTables = true;
-  #   enableForms = true;
-  #   enableContacts = true;
-  #   enableCalendar = true;
-  #   enableGroupfolders = true;
-  #   enableExternal = true;
-    
-  #   # Custom apps
-  #   enableElementApp = false;
-  #   enableUserSaml = false;
-  #   enableRichdocumentscode = false;
-  #   enableIntegrationNotion = false;
-  #   enableIntegrationGithub = false;
-  #   enableOfficeonline = false;
-  #   enableElectronicsignatures = false;
-  #   enableLibresign = false;
-  #   enableFilesReadmemd = false;
-  # };
+  modules.services.storage.nextcloud.enable = lib.mkDefault true;
 
   # =============================================================================
   # GAMING SERVICES


### PR DESCRIPTION
## Summary

- Rewrote the Nextcloud module from scratch — 345 lines removed, cleaner API
- Enabled in the server profile (deployed and verified running on david)
- Fixes `overwrite.cli.url` domain drift and PostgreSQL collation warning on every glibc upgrade

## What changed

**Module API (`modules/services/storage/nextcloud.nix`)**
- Replaced 15 individual `enable*` booleans with a single `apps` list — callers just write `apps = [ "contacts" "calendar" "mail" ]`
- Fixed domain default from hard-coded `cloud.7andco.dev` → `cloud.${config.networking.domain}`
- Upgraded to `nextcloud32` (v31 was removed from 25.05)
- Added `"overwrite.cli.url"` to `settings` so it follows the domain declaratively (no more stale values after domain changes)
- Removed the `nextcloud-setup.enable = false` hack that blocked auto-initialization
- Removed dead options: `dbTablePrefix`, `enableSnappymail` (defined but never wired), `enableExternal` (commented out in impl), `enableElementApp` (riotchat abandoned in 2022), `package`, `autoUpdateApps`
- Added vHosts metadata: `displayName = "Nextcloud"`, `category = "storage"`, `icon = "nextcloud"`
- `autoUpdateApps` is always `false` (correct for declarative app management)
- Added `nextcloud-refresh-collation` systemd service — runs `ALTER DATABASE nextcloud REFRESH COLLATION VERSION` after each deploy to silence the glibc collation mismatch warning

**Server profile (`profiles/server.nix`)**
- Replaced the 20-line commented-out block with `modules.services.storage.nextcloud.enable = lib.mkDefault true;`

## Verified on david

- HTTP/2 200 on `https://cloud.theyoder.family/login`
- CalDAV well-known redirect working (`/.well-known/caldav → 301 /remote.php/dav`)
- `nextcloud-occ check` returns clean
- `overwrite.cli.url` = `https://cloud.theyoder.family`
- All apps enabled: calendar, contacts, forms, groupfolders, notes, onlyoffice, polls, richdocuments, tables, tasks
- Collation mismatch warning resolved (`ALTER DATABASE` runs on each deploy)
- TLS cert from Let's Encrypt provisioned automatically via Caddy/Cloudflare DNS-01
- DNS record (`cloud.theyoder.family` CNAME → `david.theyoder.family`) registered in Technitium

## Things to review / optional features

1. **`polls` app in default list** — added it since it's a natural fit for the household. Easy to remove from `apps` if unwanted.

2. **`onlyoffice` vs `richdocuments` (Collabora)** — both are enabled by `enableOfficeApps = true` (default). OnlyOffice is the lighter self-contained editor; Collabora (richdocuments) requires a separate Collabora Online server to be fully functional. You may want to disable one. Could be split into `enableOnlyOffice` and `enableCollabora` options if you want finer control.

3. **`extraApps` escape hatch** — `modules.services.storage.nextcloud.extraApps` accepts an attrset of `fetchNextcloudApp` packages if you ever want to install apps not in nixpkgs (e.g. `user_saml` for SSO, `libresign` for document signing).

4. **Mail/SMTP config** — `overwrite.cli.url`, `trusted_proxies`, `datadirectory` are all wired. SMTP isn't configured yet (Nextcloud sends password reset emails etc.). Stalwart is running — worth wiring up if you want email notifications working.

5. **PostgreSQL collation** — the `nextcloud-refresh-collation` service is a oneshot that runs each boot. After the collation is refreshed the first time, subsequent runs are instant no-ops. This could be promoted to a shared pattern for any service using PostgreSQL.