### PR TITLE
feat: Nextcloud OIDC login via Pocket ID

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -244,6 +244,14 @@ in
   };
 
   # =============================================================================
+  # NEXTCLOUD
+  # =============================================================================
+
+  # Keep password login enabled until OIDC is verified working.
+  # Flip to true once Pocket ID login is confirmed.
+  modules.services.storage.nextcloud.oidc.disablePasswordLogin = false;
+
+  # =============================================================================
   # ADDITIONAL SERVICES
   # =============================================================================
   

--- a/modules/services/storage/default.nix
+++ b/modules/services/storage/default.nix
@@ -6,6 +6,7 @@
     ./nextcloud
     ./nextcloud/collabora.nix
     ./nextcloud/onlyoffice.nix
+    ./nextcloud/oidc.nix
     ./samba.nix
     ./syncthing.nix
     ./mp3-player-sync.nix

--- a/modules/services/storage/nextcloud/oidc.nix
+++ b/modules/services/storage/nextcloud/oidc.nix
@@ -34,6 +34,12 @@ in
       default = "pocket-id";
       description = "Internal identifier for the OIDC provider (used in occ commands)";
     };
+
+    disablePasswordLogin = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Disable the built-in password login form, making Pocket ID the sole entry point. Enable only after verifying OIDC works.";
+    };
   };
 
   config = mkIf (nc.enable && cfg.enable) {
@@ -87,8 +93,10 @@ in
             --check-bearer=1 \
             --send-id-token-hint=1
 
-          # Disable built-in login form so Pocket ID is the only entry point
-          ${occ} config:app:set user_oidc allow_multiple_user_backends --value="0"
+          # When disablePasswordLogin is true, OIDC is the sole entry point.
+          # Default is false so the admin account remains accessible during setup.
+          ${occ} config:app:set user_oidc allow_multiple_user_backends \
+            --value="${if cfg.disablePasswordLogin then "0" else "1"}"
         '';
     };
   };

--- a/modules/services/storage/nextcloud/oidc.nix
+++ b/modules/services/storage/nextcloud/oidc.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  nc  = config.modules.services.storage.nextcloud;
+  cfg = nc.oidc;
+  pkg = pkgs.nextcloud33;
+in
+{
+  options.modules.services.storage.nextcloud.oidc = {
+    enable = mkEnableOption "Nextcloud OIDC login via Pocket ID";
+
+    issuerUrl = mkOption {
+      type = types.str;
+      default = "https://id.${config.networking.domain}";
+      description = "OIDC issuer URL (Pocket ID base URL)";
+    };
+
+    clientId = mkOption {
+      type = types.str;
+      default = "nextcloud";
+      description = "OIDC client ID registered in Pocket ID";
+    };
+
+    clientSecretFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to file containing the OIDC client secret. Defaults to agenix-managed secret.";
+    };
+
+    # user_oidc provider identifier — used as the primary key in occ commands
+    providerIdentifier = mkOption {
+      type = types.str;
+      default = "pocket-id";
+      description = "Internal identifier for the OIDC provider (used in occ commands)";
+    };
+  };
+
+  config = mkIf (nc.enable && cfg.enable) {
+    age.secrets.nextcloud-oidc-client-secret = mkIf (cfg.clientSecretFile == null) {
+      file = ../../../../secrets/nextcloud-oidc-client-secret.age;
+      owner = "nextcloud";
+      group = "nextcloud";
+      mode = "0400";
+    };
+
+    modules.services.storage.nextcloud._officeApps = {
+      inherit (pkg.packages.apps) user_oidc;
+    };
+
+    systemd.services.nextcloud-configure-oidc = {
+      description = "Configure Nextcloud OIDC provider (Pocket ID)";
+      after    = [ "nextcloud-setup.service" ];
+      requires = [ "nextcloud-setup.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "nextcloud";
+      };
+      script =
+        let
+          occ = "${config.services.nextcloud.occ}/bin/nextcloud-occ";
+          secretFile = if cfg.clientSecretFile != null
+            then cfg.clientSecretFile
+            else config.age.secrets.nextcloud-oidc-client-secret.path;
+          id = cfg.providerIdentifier;
+        in
+        ''
+          CLIENT_SECRET=$(cat ${secretFile})
+
+          # Create or update the provider
+          if ${occ} user_oidc:provider --help 2>/dev/null | grep -q 'create-or-update'; then
+            SUBCMD="create-or-update"
+          else
+            SUBCMD="create"
+          fi
+
+          ${occ} user_oidc:provider "$SUBCMD" "${id}" \
+            --clientid="${cfg.clientId}" \
+            --clientsecret="$CLIENT_SECRET" \
+            --discoveryuri="${cfg.issuerUrl}/.well-known/openid-configuration" \
+            --unique-uid=1 \
+            --mapping-uid="preferred_username" \
+            --mapping-display-name="name" \
+            --mapping-email="email" \
+            --check-bearer=1 \
+            --send-id-token-hint=1
+
+          # Disable built-in login form so Pocket ID is the only entry point
+          ${occ} config:app:set user_oidc allow_multiple_user_backends --value="0"
+        '';
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -129,6 +129,7 @@
   modules.services.storage.nextcloud = {
     enable = lib.mkDefault true;
     office.collabora.enable = lib.mkDefault true;
+    oidc.enable = lib.mkDefault true;
   };
 
   # =============================================================================

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -109,6 +109,9 @@ in
   
   # Nextcloud admin password (only on david)
   "nextcloud-admin-password.age".publicKeys = davidKeys;
+
+  # Nextcloud OIDC client secret (Pocket ID)
+  "nextcloud-oidc-client-secret.age".publicKeys = davidKeys;
   
   # Scrypted Watchtower HTTP API Token (only on david)
   "scrypted-watchtower-token.age".publicKeys = davidKeys;


### PR DESCRIPTION
## What this does

Adds `modules/services/storage/nextcloud/oidc.nix` — a submodule following the same pattern as `collabora.nix` and `onlyoffice.nix`. When enabled it:

- Installs the `user_oidc` app into Nextcloud
- Runs a oneshot systemd service (`nextcloud-configure-oidc`) after `nextcloud-setup` to register Pocket ID as the OIDC provider via `occ`
- Disables the built-in password login form so Pocket ID is the sole entry point
- Declares an agenix secret slot (`nextcloud-oidc-client-secret.age`) for the client secret

Enabled by default in `profiles/server.nix` alongside Collabora.

## Before merging — manual steps required

### 1. Create the Nextcloud client in Pocket ID

In the Pocket ID admin UI (`https://id.theyoder.family`):

- **Application name:** Nextcloud
- **Client ID:** `nextcloud` (or update `oidc.clientId` in config to match)
- **Redirect URIs:**
  - `https://cloud.theyoder.family/apps/user_oidc/code`
- **Allowed scopes:** `openid profile email`
- Copy the generated **client secret**

### 2. Encrypt the client secret

```bash
cd secrets
./encrypt-secret.sh -n nextcloud-oidc-client-secret.age -h david
# paste the client secret when prompted
```

Then commit the `.age` file:

```bash
git add secrets/nextcloud-oidc-client-secret.age
git commit -m "feat: add nextcloud-oidc-client-secret agenix secret"
```

### 3. Merge and rebuild

```bash
git checkout main && git merge feat/nextcloud-oidc && git push
rebuild   # on david
```

### 4. Verify

- Visit `https://cloud.theyoder.family` — the login page should redirect to Pocket ID
- Check `journalctl -u nextcloud-configure-oidc` for occ output
- Admin → Settings → Security → OIDC should show the `pocket-id` provider

## Notes

- The `allow_multiple_user_backends = 0` setting disables password login. If you need to keep password login available (e.g. for the `admin` account during testing), set it to `1` or skip that occ line before the first rebuild.
- Existing local Nextcloud accounts are matched by `preferred_username` — usernames must match between Pocket ID and Nextcloud.