### PR TITLE
feat: KDE app shortcuts from vHosts manifest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,7 @@
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
+              home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }
           ];
 
@@ -228,6 +229,7 @@
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
+              home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }
           ];
 
@@ -258,6 +260,7 @@
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
+              home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }
           ];
 

--- a/home/carolineyoder.nix
+++ b/home/carolineyoder.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+    ./modules/app-shortcuts.nix
+  ];
+
+  home.username = "carolineyoder";
+  home.stateVersion = "25.05";
+
+  programs.home-manager.enable = true;
+
+  modules.appShortcuts.enable = true;
+}

--- a/home/modules/app-shortcuts.nix
+++ b/home/modules/app-shortcuts.nix
@@ -1,0 +1,111 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.appShortcuts;
+in
+{
+  options.modules.appShortcuts = {
+    enable = mkEnableOption "KDE app shortcuts generated from the vHosts app manifest";
+
+    manifestUrl = mkOption {
+      type    = types.str;
+      default = "https://apps-manifest.theyoder.family/apps.json";
+      description = "URL to the app manifest JSON served by the app-manifest provider.";
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      updateScript = pkgs.writeShellScript "update-app-shortcuts" ''
+        set -euo pipefail
+
+        MANIFEST_URL="${cfg.manifestUrl}"
+        APPS_DIR="$HOME/.local/share/applications"
+        ICONS_DIR="$HOME/.local/share/icons/app-shortcuts"
+        PREFIX="app-shortcut-"
+
+        mkdir -p "$APPS_DIR" "$ICONS_DIR"
+
+        manifest=$(${pkgs.curl}/bin/curl -sf --max-time 10 "$MANIFEST_URL") || {
+          echo "app-shortcuts: failed to fetch manifest from $MANIFEST_URL" >&2
+          exit 0
+        }
+
+        # Remove previously managed shortcuts
+        rm -f "$APPS_DIR/$PREFIX"*.desktop
+
+        echo "$manifest" | ${pkgs.jq}/bin/jq -r '.apps[] | @base64' | while IFS= read -r encoded; do
+          app=$(echo "$encoded" | ${pkgs.coreutils}/bin/base64 -d)
+
+          name=$(echo "$app"      | ${pkgs.jq}/bin/jq -r '.name')
+          url=$(echo "$app"       | ${pkgs.jq}/bin/jq -r '.url')
+          icon_slug=$(echo "$app" | ${pkgs.jq}/bin/jq -r '.icon // ""')
+          category=$(echo "$app"  | ${pkgs.jq}/bin/jq -r '.category // "services"')
+
+          slug=$(echo "$name" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/-\+$//')
+
+          # Resolve icon: try dashboard-icons CDN, fall back to slug (KDE theme lookup)
+          icon_val="application-x-executable"
+          if [ -n "$icon_slug" ] && [ "$icon_slug" != "null" ]; then
+            icon_file="$ICONS_DIR/$slug.png"
+            cdn_url="https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/''${icon_slug}.png"
+            if ${pkgs.curl}/bin/curl -sf --max-time 5 "$cdn_url" -o "$icon_file" 2>/dev/null; then
+              icon_val="$icon_file"
+            else
+              icon_val="$icon_slug"
+            fi
+          fi
+
+          # Map category to XDG Categories
+          case "$category" in
+            media)          xdg_cat="AudioVideo;Video;Network;" ;;
+            productivity)   xdg_cat="Office;Network;" ;;
+            infrastructure) xdg_cat="System;Network;" ;;
+            development)    xdg_cat="Development;Network;" ;;
+            storage)        xdg_cat="System;FileTools;Network;" ;;
+            communication)  xdg_cat="Network;Chat;" ;;
+            gaming)         xdg_cat="Game;Network;" ;;
+            *)              xdg_cat="Network;" ;;
+          esac
+
+          cat > "$APPS_DIR/$PREFIX$slug.desktop" <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=$name
+Exec=${pkgs.firefox}/bin/firefox --new-window $url
+Icon=$icon_val
+Categories=''${xdg_cat}
+StartupNotify=true
+StartupWMClass=firefox
+EOF
+        done
+
+        # Rebuild KDE's app cache so shortcuts appear immediately
+        ${pkgs.kdePackages.kservice}/bin/kbuildsycoca6 --noincremental 2>/dev/null || true
+      '';
+    in
+    {
+      home.packages = [ pkgs.jq pkgs.curl ];
+
+      systemd.user.services.app-shortcuts = {
+        Unit = {
+          Description = "Generate KDE app shortcuts from vHosts manifest";
+          After       = [ "network-online.target" "graphical-session.target" ];
+          Wants       = [ "network-online.target" ];
+          PartOf      = [ "graphical-session.target" ];
+        };
+        Service = {
+          Type            = "oneshot";
+          ExecStart       = "${updateScript}";
+          RemainAfterExit = true;
+        };
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+      };
+    }
+  );
+}

--- a/home/tristonyoder.nix
+++ b/home/tristonyoder.nix
@@ -6,6 +6,7 @@
 {
   imports = [
     ./common.nix
+    ./modules/app-shortcuts.nix
   ];
   
   # User (platform-specific)

--- a/hosts/tristons-nixbook-pro/configuration.nix
+++ b/hosts/tristons-nixbook-pro/configuration.nix
@@ -125,4 +125,6 @@
     vscode
     nfs-utils
   ];
+
+  home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 }

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -86,4 +86,6 @@
     # NFS client support
     nfs-utils
   ];
+
+  home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 }

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -335,4 +335,6 @@
     openrgb
     vlc
   ];
+
+  home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 }

--- a/modules/services/providers/app-manifest.nix
+++ b/modules/services/providers/app-manifest.nix
@@ -1,0 +1,44 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.services.providers.appManifest;
+
+  shortcutHosts = filter (h: h.enable && h.shortcut)
+    (attrValues config.modules.services.vHosts.hosts);
+
+  appsJson = builtins.toJSON {
+    apps = map (h: {
+      name     = h.displayName;
+      url      = "https://${h.virtualHost}";
+      category = if h.category != "" then h.category else "services";
+      icon     = h.icon;
+    }) shortcutHosts;
+  };
+in
+{
+  options.modules.services.providers.appManifest = {
+    enable = mkEnableOption "App manifest JSON endpoint (consumed by desktop app-shortcuts)";
+
+    domain = mkOption {
+      type    = types.str;
+      default = "apps-manifest.${config.networking.domain}";
+      description = "Domain to serve the JSON manifest on.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      shortcut    = false;
+      monitor     = false;
+      dnsChallenge = false;
+      rawConfig   = true;
+      extraConfig = ''
+        header Access-Control-Allow-Origin "*"
+        header Content-Type "application/json; charset=utf-8"
+        respond `${appsJson}` 200
+      '';
+    };
+  };
+}

--- a/modules/services/providers/default.nix
+++ b/modules/services/providers/default.nix
@@ -6,5 +6,6 @@
     ./monitoring.nix
     ./dashboard-homepage.nix
     ./dashboard-homarr.nix
+    ./app-manifest.nix
   ];
 }

--- a/modules/services/vhosts.nix
+++ b/modules/services/vhosts.nix
@@ -137,6 +137,12 @@ in
             description = "Whether the monitoring provider should track uptime for this host.";
           };
 
+          shortcut = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether to include this host in the app-manifest JSON (and thus generate a desktop shortcut).";
+          };
+
           localHostsEntry = mkOption {
             type = types.bool;
             default = true;

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -163,6 +163,8 @@
 
   modules.services.providers.dashboard-homepage.enable = lib.mkDefault true;
 
+  modules.services.providers.appManifest.enable = lib.mkDefault true;
+
   # =============================================================================
   # DNS CONFIGURATION
   # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `modules/services/providers/app-manifest.nix` — serves a build-time JSON manifest of all vHosts (where `shortcut = true`) via Caddy at `https://apps-manifest.<domain>/apps.json`. Enabled by default in the server profile.
- Adds `home/modules/app-shortcuts.nix` — Home Manager module with a systemd user service that runs at graphical login, fetches the manifest, downloads icons from the dashboard-icons CDN, and writes `.desktop` files opening each app as `firefox --new-window <url>`. Runs `kbuildsycoca6` after so shortcuts appear in KDE's launcher immediately.
- Adds `home/carolineyoder.nix` — minimal Home Manager config for carolineyoder with app-shortcuts enabled.
- Wires both `tristonyoder` and `carolineyoder` into Home Manager for `tristons-workstation`, `tristons-nixbook`, and `tristons-nixbook-pro`.
- New `shortcut` bool option on vHosts (default `true`) controls manifest inclusion; the manifest endpoint itself is automatically excluded.