### PR TITLE
feat: add Vikunja task management module

### DIFF
--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -10,5 +10,6 @@
     ./tandoor.nix
     ./babybuddy.nix
     ./companion.nix
+    ./vikunja.nix
   ];
 }

--- a/modules/services/productivity/vikunja.nix
+++ b/modules/services/productivity/vikunja.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.vikunja;
+in
+{
+  options.modules.services.productivity.vikunja = {
+    enable = mkEnableOption "Vikunja task and project management";
+
+    domain = mkOption {
+      type = types.str;
+      default = "vikunja.${config.networking.domain}";
+      description = "Domain for Vikunja";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 3456;
+      description = "Port for Vikunja to listen on";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.vikunja = {
+      enable = true;
+      port = cfg.port;
+      frontendScheme = "https";
+      frontendHostname = cfg.domain;
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Vikunja";
+      category = "productivity";
+      icon = "vikunja";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -101,6 +101,7 @@
   modules.services.productivity.actual.enable = lib.mkDefault true;
   modules.services.productivity.outline.enable = lib.mkDefault true;
   modules.services.productivity.tandoor.enable = lib.mkDefault true;
+  modules.services.productivity.vikunja.enable = lib.mkDefault true;
 
   # =============================================================================
   # COMMUNICATION SERVICES


### PR DESCRIPTION
Adds a Vikunja module under modules/services/productivity/. Provides Kanban and list-based task management with iOS app support. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/productivity/vikunja.nix` — new module
- `modules/services/productivity/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true