### PR TITLE
feat: add Miniflux RSS reader module

### DIFF
--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -12,5 +12,6 @@
     ./companion.nix
     ./stirling-pdf.nix
     ./paperless-ngx.nix
+    ./miniflux.nix
   ];
 }

--- a/modules/services/productivity/miniflux.nix
+++ b/modules/services/productivity/miniflux.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.miniflux;
+in
+{
+  options.modules.services.productivity.miniflux = {
+    enable = mkEnableOption "Miniflux RSS reader";
+
+    domain = mkOption {
+      type = types.str;
+      default = "miniflux.${config.networking.domain}";
+      description = "Domain for Miniflux";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 8088;
+      description = "Port for Miniflux to listen on";
+    };
+
+    adminCredentialsFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to a file containing admin credentials as environment variables.
+        Required if CREATE_ADMIN is enabled (the default). The file should
+        contain ADMIN_USERNAME and ADMIN_PASSWORD.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.miniflux = {
+      enable = true;
+      createDatabaseLocally = true;
+      adminCredentialsFile = cfg.adminCredentialsFile;
+      config = {
+        LISTEN_ADDR = "127.0.0.1:${toString cfg.port}";
+        BASE_URL = "https://${cfg.domain}";
+        CREATE_ADMIN = mkIf (cfg.adminCredentialsFile == null) 0;
+      };
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Miniflux";
+      category = "productivity";
+      icon = "miniflux";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -104,6 +104,7 @@
   modules.services.productivity.tandoor.enable = lib.mkDefault true;
   modules.services.productivity.stirlingPdf.enable = lib.mkDefault true;
   modules.services.productivity.paperlessNgx.enable = lib.mkDefault true;
+  modules.services.productivity.miniflux.enable = lib.mkDefault true;
 
   # =============================================================================
   # COMMUNICATION SERVICES


### PR DESCRIPTION
Adds a Miniflux module under modules/services/productivity/. Provides self-hosted RSS/Atom feed reading. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/productivity/miniflux.nix` — new module
- `modules/services/productivity/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true