### PR TITLE
feat: add Scrutiny disk health monitoring module

### DIFF
--- a/modules/services/infrastructure/default.nix
+++ b/modules/services/infrastructure/default.nix
@@ -7,6 +7,7 @@
     ./headscale.nix
     ./nix-cache-server.nix
     ./postgresql.nix
+    ./scrutiny.nix
     ./tailscale.nix
     ./technitium.nix
   ];

--- a/modules/services/infrastructure/scrutiny.nix
+++ b/modules/services/infrastructure/scrutiny.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.infrastructure.scrutiny;
+in
+{
+  options.modules.services.infrastructure.scrutiny = {
+    enable = mkEnableOption "Scrutiny S.M.A.R.T. disk health monitoring";
+
+    domain = mkOption {
+      type = types.str;
+      default = "scrutiny.${config.networking.domain}";
+      description = "Domain for Scrutiny";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 8085;
+      description = "Port for Scrutiny to listen on";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.scrutiny = {
+      enable = true;
+      settings.web.listen = {
+        port = cfg.port;
+        host = "127.0.0.1";
+      };
+      collector.enable = true;
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Scrutiny";
+      category = "infrastructure";
+      icon = "scrutiny";
+      monitor = true;
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -58,6 +58,7 @@
     tokenFile = lib.mkDefault config.age.secrets.cloudflared-token-current.path;
   };
   modules.services.infrastructure.postgresql.enable = lib.mkDefault true;
+  modules.services.infrastructure.scrutiny.enable = lib.mkDefault true;
   modules.services.infrastructure.tailscale.enable = lib.mkDefault true;
   modules.services.infrastructure.technitium.enable = lib.mkDefault true;
 


### PR DESCRIPTION
Adds a Scrutiny module under modules/services/infrastructure/. Monitors disk S.M.A.R.T. data with alerting. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/infrastructure/scrutiny.nix` — new module
- `modules/services/infrastructure/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true