### PR TITLE
feat: add Paperless-ngx document management module

### DIFF
--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -11,5 +11,6 @@
     ./babybuddy.nix
     ./companion.nix
     ./stirling-pdf.nix
+    ./paperless-ngx.nix
   ];
 }

--- a/modules/services/productivity/paperless-ngx.nix
+++ b/modules/services/productivity/paperless-ngx.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.paperlessNgx;
+in
+{
+  options.modules.services.productivity.paperlessNgx = {
+    enable = mkEnableOption "Paperless-ngx document management with OCR";
+
+    domain = mkOption {
+      type = types.str;
+      default = "paperless.${config.networking.domain}";
+      description = "Domain for Paperless-ngx";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 28981;
+      description = "Port for Paperless-ngx to listen on";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/paperless";
+      description = "Directory for Paperless-ngx data";
+    };
+
+    mediaDir = mkOption {
+      type = types.str;
+      default = "/var/lib/paperless/media";
+      description = "Directory for Paperless-ngx media files";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.paperless = {
+      enable = true;
+      port = cfg.port;
+      address = "127.0.0.1";
+      dataDir = cfg.dataDir;
+      mediaDir = cfg.mediaDir;
+      database.createLocally = true;
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Paperless-ngx";
+      category = "productivity";
+      icon = "paperless-ngx";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -103,6 +103,7 @@
   modules.services.productivity.outline.enable = lib.mkDefault true;
   modules.services.productivity.tandoor.enable = lib.mkDefault true;
   modules.services.productivity.stirlingPdf.enable = lib.mkDefault true;
+  modules.services.productivity.paperlessNgx.enable = lib.mkDefault true;
 
   # =============================================================================
   # COMMUNICATION SERVICES


### PR DESCRIPTION
Adds a Paperless-ngx module under modules/services/productivity/. Enables OCR document management. Wired into vHosts (Caddy, DNS, Gatus, Homepage). Enabled by default in the server profile.

## Changes
- `modules/services/productivity/paperless-ngx.nix` — new module
- `modules/services/productivity/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true