### PR TITLE
feat: add Stirling PDF tools module

### DIFF
--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -10,5 +10,6 @@
     ./tandoor.nix
     ./babybuddy.nix
     ./companion.nix
+    ./stirling-pdf.nix
   ];
 }

--- a/modules/services/productivity/stirling-pdf.nix
+++ b/modules/services/productivity/stirling-pdf.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.stirlingPdf;
+in
+{
+  options.modules.services.productivity.stirlingPdf = {
+    enable = mkEnableOption "Stirling PDF self-hosted PDF manipulation tools";
+
+    domain = mkOption {
+      type = types.str;
+      default = "pdf.${config.networking.domain}";
+      description = "Domain for Stirling PDF";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 7878;
+      description = "Port for Stirling PDF to listen on";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.oci-containers.containers."stirling-pdf" = {
+      image = "frooodle/s-pdf:latest";
+      ports = [ "127.0.0.1:${toString cfg.port}:8080" ];
+      volumes = [
+        "/var/lib/stirling-pdf/data:/usr/share/tessdata"
+        "/var/lib/stirling-pdf/configs:/configs"
+      ];
+      environment = {
+        DOCKER_ENABLE_SECURITY = "false";
+      };
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Stirling PDF";
+      category = "productivity";
+      icon = "stirling-pdf";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -101,6 +101,7 @@
   modules.services.productivity.actual.enable = lib.mkDefault true;
   modules.services.productivity.outline.enable = lib.mkDefault true;
   modules.services.productivity.tandoor.enable = lib.mkDefault true;
+  modules.services.productivity.stirlingPdf.enable = lib.mkDefault true;
 
   # =============================================================================
   # COMMUNICATION SERVICES


### PR DESCRIPTION
Adds a Stirling PDF module under modules/services/productivity/. Provides merge, split, compress, OCR, and other PDF operations. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/productivity/stirling-pdf.nix` — new module
- `modules/services/productivity/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true