### PR TITLE
feat: add Kavita ebook/comic library module

### DIFF
--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -9,6 +9,7 @@
     ./jellyplex-watched.nix
     ./jellyseerr.nix
     ./music-dedup.nix
+    ./kavita.nix
     ./navidrome.nix
     ./plex.nix
     ./sunshine.nix

--- a/modules/services/media/kavita.nix
+++ b/modules/services/media/kavita.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.kavita;
+in
+{
+  options.modules.services.media.kavita = {
+    enable = mkEnableOption "Kavita ebook and comic library server";
+
+    domain = mkOption {
+      type = types.str;
+      default = "kavita.${config.networking.domain}";
+      description = "Domain for Kavita";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 5000;
+      description = "Port for Kavita to listen on";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.kavita = {
+      enable = true;
+      port = cfg.port;
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Kavita";
+      category = "media";
+      icon = "kavita";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -66,6 +66,7 @@
   # =============================================================================
   
   modules.services.media.immich.enable = lib.mkDefault true;
+  modules.services.media.kavita.enable = lib.mkDefault true;
   modules.services.media.jellyfin = {
     enable = lib.mkDefault true;
     pluginRepositories = lib.mkDefault [


### PR DESCRIPTION
Adds a Kavita module under modules/services/media/. Provides ebook and comic library management. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/media/kavita.nix` — new module
- `modules/services/media/default.nix` — import added
- `profiles/server.nix` — enabled with mkDefault true