### PR TITLE
fix: disable gaming module by default in workstation profile

### DIFF
--- a/hosts/tristons-nixbook-pro/configuration.nix
+++ b/hosts/tristons-nixbook-pro/configuration.nix
@@ -127,4 +127,6 @@
   ];
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
+
+  modules.services.gaming.enable = true;
 }

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -88,4 +88,6 @@
   ];
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
+
+  modules.services.gaming.enable = true;
 }

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -287,7 +287,7 @@
   # GAMING — re-enabled now that the system has its own swap (see above)
   # =============================================================================
 
-  # profiles/workstation.nix already defaults this to true; no override needed.
+  modules.services.gaming.enable = true;
 
   # /data is NFS-mounted from david, so hit the cache directly on disk rather
   # than going through the HTTPS endpoint.

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -84,7 +84,7 @@
   # =============================================================================
 
   modules.services.gaming = {
-    enable = lib.mkDefault true;
+    enable = lib.mkDefault false;
     steam.steamRomManager = true;
   };
 }


### PR DESCRIPTION
The gaming module (Steam + 11 emulators + DaVinci Resolve) was enabled with mkDefault true in profiles/workstation.nix, meaning all workstation-profile hosts installed the full gaming closure by default. This is the root cause of the OOM during nixos-install documented in CLAUDE.md — a swapless live USB environment can exhaust RAM during the heavy closure download.

## Changes
- profiles/workstation.nix: gaming.enable = mkDefault false
- hosts/tristons-workstation/configuration.nix: explicitly enable gaming
- hosts/tristons-nixbook/configuration.nix: explicitly enable gaming
- hosts/tristons-nixbook-pro/configuration.nix: explicitly enable gaming

New workstation-profile hosts will no longer pull in the gaming closure by default. Existing hosts retain gaming via explicit opt-in.