### PR TITLE
feat: add InvokeAI image generation module

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -162,14 +162,10 @@ in
     category = "media";
   };
 
-  # InvokeAI
-  modules.services.vHosts.hosts."invoke.${config.networking.domain}" = {
-    reverseProxyHost = "tristons-workstation.${config.networking.domain}";
-    reverseProxyPort = 9090;
-    displayName = "InvokeAI";
-    category = "ai";
-    icon = "invoke-ai";
-    monitor = false; # runs on workstation, not always reachable
+  # InvokeAI — proxy to tristons-workstation (RTX 4080)
+  modules.services.ai.invokeAi = {
+    enable = true;
+    proxyHost = "tristons-workstation.${config.networking.domain}";
   };
 
   # =============================================================================

--- a/modules/services/ai/default.nix
+++ b/modules/services/ai/default.nix
@@ -4,6 +4,7 @@
     # from the upstream NousResearch flake, which is only imported on david.
     # It's added directly to david's module list in flake.nix alongside
     # hermes-agent.nixosModules.default.
+    ./invoke-ai.nix
     ./litellm.nix
     ./ollama.nix
     ./open-webui.nix

--- a/modules/services/ai/invoke-ai.nix
+++ b/modules/services/ai/invoke-ai.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.ai.invokeAi;
+in
+{
+  options.modules.services.ai.invokeAi = {
+    enable = mkEnableOption "InvokeAI Stable Diffusion image generation";
+
+    domain = mkOption {
+      type = types.str;
+      default = "invoke.${config.networking.domain}";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 9090;
+    };
+
+    proxyHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "If set, proxy to this host instead of running InvokeAI locally. Use for david proxying to tristons-workstation.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Local service — only when not in proxy mode
+    virtualisation.oci-containers.containers = mkIf (cfg.proxyHost == null) {
+      "invoke-ai" = {
+        image = "ghcr.io/invoke-ai/invokeai:latest";
+        ports = [ "127.0.0.1:${toString cfg.port}:9090" ];
+        volumes = [ "/var/lib/invoke-ai:/invokeai" ];
+        extraOptions = [ "--gpus=all" "--runtime=nvidia" ];
+      };
+    };
+
+    # NVIDIA container toolkit — required for GPU passthrough in OCI containers
+    hardware.nvidia.container-toolkit.enable = mkIf (cfg.proxyHost == null) true;
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      reverseProxyHost = mkIf (cfg.proxyHost != null) cfg.proxyHost;
+      displayName = "InvokeAI";
+      category = "ai";
+      icon = "invoke-ai";
+      monitor = false; # GPU workstation service, not always reachable
+    };
+  };
+}


### PR DESCRIPTION
Adds an InvokeAI module under modules/services/ai/. Provides Stable Diffusion image generation via the RTX 4080 on tristons-workstation. Wired into vHosts as a reverse proxy to the workstation. Enabled in hosts/david/configuration.nix (proxied) and separately configurable on the workstation host.

## Changes
- `modules/services/ai/invoke-ai.nix` — new module with proxy/server dual-mode support
- `modules/services/ai/default.nix` — import added
- `hosts/david/configuration.nix` — replaced manual vHosts entry with module enable (proxy mode)