### PR TITLE
feat: add Invoice Ninja invoicing module

### DIFF
--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -58,6 +58,7 @@ with lib;
       "affine-oidc-secret" = { file = ../secrets/affine-oidc-secret.age; owner = "root"; group = "docker"; mode = "0440"; };
       "tandoor-secrets" = { file = ../secrets/tandoor-secrets.age; owner = "root"; group = "docker"; mode = "0440"; };
       "docmost-secrets" = { file = ../secrets/docmost-secrets.age; owner = "root"; group = "docker"; mode = "0440"; };
+      "invoice-ninja-env" = { file = ../secrets/invoice-ninja-env.age; owner = "root"; group = "docker"; mode = "0440"; };
       "wordpress-studio-mysql" = { file = ../secrets/wordpress-studio-mysql.age; owner = "root"; group = "docker"; mode = "0440"; };
       "wordpress-studio-wp" = { file = ../secrets/wordpress-studio-wp.age; owner = "root"; group = "docker"; mode = "0440"; };
       "wordpress-photography-mysql" = { file = ../secrets/wordpress-photography-mysql.age; owner = "root"; group = "docker"; mode = "0440"; };

--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -10,5 +10,6 @@
     ./tandoor.nix
     ./babybuddy.nix
     ./companion.nix
+    ./invoice-ninja.nix
   ];
 }

--- a/modules/services/productivity/invoice-ninja.nix
+++ b/modules/services/productivity/invoice-ninja.nix
@@ -1,0 +1,111 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.invoiceNinja;
+in
+{
+  options.modules.services.productivity.invoiceNinja = {
+    enable = mkEnableOption "Invoice Ninja - open-source invoicing and client management";
+
+    domain = mkOption {
+      type = types.str;
+      default = "invoices.${config.networking.domain}";
+      description = "Domain for Invoice Ninja";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8069;
+      description = "Internal port for Invoice Ninja";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/data/docker-appdata/invoice-ninja";
+      description = "Data directory for Invoice Ninja public and storage volumes";
+    };
+
+    secretsFile = mkOption {
+      type = types.path;
+      default = config.age.secrets.invoice-ninja-env.path;
+      description = ''
+        Path to environment file containing secrets.
+        Required variables: APP_KEY, DB_HOST, DB_DATABASE, DB_USERNAME, DB_PASSWORD.
+        APP_URL is set automatically from the domain option.
+        Create with: cd secrets && ./encrypt-secret.sh -n invoice-ninja-env.age -e
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.docker = {
+      enable = true;
+      autoPrune.enable = true;
+    };
+    virtualisation.oci-containers.backend = "docker";
+
+    virtualisation.oci-containers.containers."invoice-ninja" = {
+      image = "invoiceninja/invoiceninja:5";
+      environmentFiles = [ cfg.secretsFile ];
+      environment = {
+        APP_URL = "https://${cfg.domain}";
+        REQUIRE_HTTPS = "true";
+        APP_ENV = "production";
+      };
+      volumes = [
+        "${cfg.dataDir}/public:/var/www/app/public:rw"
+        "${cfg.dataDir}/storage:/var/www/app/storage:rw"
+      ];
+      ports = [
+        "127.0.0.1:${toString cfg.port}:80/tcp"
+      ];
+      log-driver = "journald";
+      extraOptions = [
+        "--network-alias=invoice-ninja"
+        "--network=invoice-ninja_default"
+      ];
+    };
+
+    systemd.services."docker-invoice-ninja" = {
+      serviceConfig = {
+        Restart = lib.mkOverride 500 "always";
+        RestartMaxDelaySec = lib.mkOverride 500 "1m";
+        RestartSec = lib.mkOverride 500 "100ms";
+        RestartSteps = lib.mkOverride 500 9;
+      };
+      after = [ "docker-network-invoice-ninja_default.service" ];
+      requires = [ "docker-network-invoice-ninja_default.service" ];
+      partOf = [ "docker-compose-invoice-ninja-root.target" ];
+      wantedBy = [ "docker-compose-invoice-ninja-root.target" ];
+    };
+
+    systemd.services."docker-network-invoice-ninja_default" = {
+      path = [ pkgs.docker ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStop = "${pkgs.docker}/bin/docker network rm -f invoice-ninja_default";
+      };
+      script = ''
+        docker network inspect invoice-ninja_default || docker network create invoice-ninja_default
+      '';
+      partOf = [ "docker-compose-invoice-ninja-root.target" ];
+      wantedBy = [ "docker-compose-invoice-ninja-root.target" ];
+    };
+
+    systemd.targets."docker-compose-invoice-ninja-root" = {
+      unitConfig = {
+        Description = "Invoice Ninja Docker services";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Invoice Ninja";
+      category = "productivity";
+      icon = "invoice-ninja";
+    };
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -101,6 +101,7 @@
   modules.services.productivity.actual.enable = lib.mkDefault true;
   modules.services.productivity.outline.enable = lib.mkDefault true;
   modules.services.productivity.tandoor.enable = lib.mkDefault true;
+  modules.services.productivity.invoiceNinja.enable = lib.mkDefault true;
 
   # =============================================================================
   # COMMUNICATION SERVICES


### PR DESCRIPTION
Adds an Invoice Ninja module under modules/services/productivity/. Provides invoicing, client management, and billing. Wired into vHosts. Enabled by default in the server profile.

## Changes
- `modules/services/productivity/invoice-ninja.nix` — new module (OCI container, invoiceninja/invoiceninja:5)
- `modules/services/productivity/default.nix` — import added
- `modules/secrets.nix` — invoice-ninja-env secret stub (gated on david hostname)
- `profiles/server.nix` — enabled with mkDefault true

## Setup required before activation
Create the secrets file before the module activates:
```
cd secrets && ./encrypt-secret.sh -n invoice-ninja-env.age -e
```
Required env vars: APP_KEY, DB_HOST, DB_DATABASE, DB_USERNAME, DB_PASSWORD