### PR TITLE
fix: flake syntax check silently ignores failures

### DIFF
--- a/.github/workflows/test-nixos-config.yml
+++ b/.github/workflows/test-nixos-config.yml
@@ -84,7 +84,6 @@ jobs:
         echo "Testing flake syntax..."
         nix flake check --all-systems
         echo "✅ Flake syntax check passed!"
-      continue-on-error: true
 
     - name: Notify success
       if: success()


### PR DESCRIPTION
The \`Check flake syntax\` step in \`test-nixos-config.yml\` had \`continue-on-error: true\`, which caused \`nix flake check\` failures to be swallowed silently.

Because \`test-configurations\` uses \`needs: check-flake-syntax\`, and \`continue-on-error\` makes a failing step not fail the job, the matrix dry-run jobs would run anyway even if the syntax check failed. This defeats the purpose of the fast-fail syntax gate.

Fix: remove \`continue-on-error: true\` from the syntax check step so a failed \`nix flake check\` correctly blocks downstream jobs.