### PR TITLE
fix: stop deploy CI from failing on collisions and unrelated service crashes

### DIFF
--- a/.github/workflows/deploy-nixos-config.yml
+++ b/.github/workflows/deploy-nixos-config.yml
@@ -1,5 +1,15 @@
 name: Deploy NixOS Flake Configuration
 
+# Serialize deploy runs. Test workflow completions can fire in quick succession
+# (e.g. several PRs merged within minutes), and overlapping deploys race each
+# other's `nixos-rebuild switch` SSH sessions on the same host — the second one
+# fails with "Unit nixos-rebuild-switch-to-configuration.service was already
+# loaded or has a fragment file." Queue instead of canceling so an in-progress
+# activation is never interrupted mid-switch.
+concurrency:
+  group: deploy-nixos-config
+  cancel-in-progress: false
+
 on:
   workflow_run:
     workflows: ["Test NixOS Flake Configuration"]
@@ -246,8 +256,22 @@ jobs:
 
         # Closures are pre-built in the binary cache; --refresh ensures nix fetches
         # the latest HEAD rather than a locally cached flake resolution.
+        set +e
         ssh ${{ secrets.NIXOS_SERVER_USER }}@$SERVER_HOSTNAME \
           "sudo nixos-rebuild switch --flake 'github:TristonYoder/nix-config#${{ matrix.host }}' --refresh"
+        DEPLOY_EXIT=$?
+        set -e
+
+        # switch-to-configuration exits 4 specifically when the config activated
+        # but one or more systemd units failed to reach "active" afterward — a
+        # runtime/service-health issue, not a config or activation error. Service
+        # health is already covered by Gatus monitoring, so don't fail the whole
+        # deploy over it (any other exit code still fails the job).
+        if [ "$DEPLOY_EXIT" -eq 4 ]; then
+          echo "::warning::${{ matrix.host }} activated but one or more systemd units failed to start post-activation. Check 'systemctl --failed' on the host."
+          exit 0
+        fi
+        exit "$DEPLOY_EXIT"
 
     - name: Notify success
       if: success()


### PR DESCRIPTION
## Summary

Every deploy run for the past week+ has failed (`gh run list --workflow "Deploy NixOS Flake Configuration"`). Two distinct root causes, both in `.github/workflows/deploy-nixos-config.yml`:

- **No concurrency control.** When several PRs merge in quick succession, overlapping deploy runs launch simultaneous `nixos-rebuild switch` SSH sessions against the same host. The second collides with the first's still-loaded transient unit: `Unit nixos-rebuild-switch-to-configuration.service was already loaded or has a fragment file.` Confirmed by identical-timestamp failures on both `david` and `pits` within the same overlapping run (runs 28755290719 / 28755369562).
- **`david` fails on every deploy, independent of concurrency**, because three unrelated services are currently unhealthy: `open-webui` (`ModuleNotFoundError: No module named 'qdrant_client'` — a known nixpkgs packaging gap, already flagged in `modules/services/ai/open-webui.nix` with `monitor = false`), and `docker-stirling-pdf` / `docker-watchtower` (`start-limit-hit`). `nixos-rebuild switch` exits 4 specifically when the config activates but some unit fails to reach `active` — so the config change itself was correct every time, but the CI job still failed.

## Fix

- Added a `concurrency` group (`deploy-nixos-config`, `cancel-in-progress: false`) to serialize deploy runs instead of racing.
- The deploy step now captures the SSH exit code: if it's exit 4 (activation succeeded, some unit unhealthy), emit an `::warning::` annotation instead of failing the job. Any other exit code (real eval/build/activation errors) still fails hard as before.

Service health is already covered by Gatus monitoring, so gating CI success on transient container health was redundant and was masking every real deploy behind unrelated failures.

## Follow-up (not in this PR)

`docker-stirling-pdf.service` and `docker-watchtower.service` hitting `start-limit-hit` on every activation of `david` is still worth root-causing on the host itself (e.g. `journalctl -u docker.service -u docker-stirling-pdf.service` around a deploy, to check for a Docker daemon restart race). Left out of this PR since it needs host-level log access to diagnose safely rather than a guess.

## Test plan

- [x] Validated YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Merge and confirm the next deploy run on `david` succeeds (warns instead of failing) while `pits`/`tristons-workstation` are unaffected
- [ ] Confirm two near-simultaneous merges no longer produce overlapping deploy collisions