### PR TITLE
feat: iPod auto-sync via iopod

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1782765199,
-        "narHash": "sha256-puu8C61mwpxher4QI5EVjwk+4E8eawbqYpak31ElAGE=",
+        "lastModified": 1782765551,
+        "narHash": "sha256-TxOInn4prmQ0pC3KJdqXA+Mig/SgrnJKtokfbV9F2r4=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "fd5cbe03dd4e72ac43c1663211863d4de4c36d89",
+        "rev": "e4101491a3051281426baa8cc4d65c0c3a8870e5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -307,15 +307,16 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1782770444,
-        "narHash": "sha256-lYP8IWZnOtrV2HfFb5YvED8Qn8WvQADG4mAhNp9U+XM=",
+        "lastModified": 1783288724,
+        "narHash": "sha256-PJOxNZ1d6tSNcJLQb2EevCLKU1IpyWwrj29LL315wfQ=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "54f692dde2ca064084eed7fff09cae5e65bd0f81",
+        "rev": "b6e05cef4a0e322e1a45e756a567c1059f314daa",
         "type": "github"
       },
       "original": {
         "owner": "TristonYoder",
+        "ref": "feat/cli-sync",
         "repo": "iOpenPodCLI",
         "type": "github"
       }
@@ -500,11 +501,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782666739,
-        "narHash": "sha256-2CYuaRDT7hcYnGW+3TTTy+fNnY4jQ6/mGk6ew035XP4=",
+        "lastModified": 1783247743,
+        "narHash": "sha256-9b2xGt5CAd6WriPJOZs/EYXq9fGVCeoisYo1P3nhL2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "534ee3d8beb1737b5342995f8837e2b2705ce0d8",
+        "rev": "c4013e501c048ae7c4a8940c92837636042bf6c3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1782764838,
-        "narHash": "sha256-fjTikq89r9yirJAURN9kw6TZqws9r0GPURKwQREMAmg=",
+        "lastModified": 1782765199,
+        "narHash": "sha256-puu8C61mwpxher4QI5EVjwk+4E8eawbqYpak31ElAGE=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "c21426904d010a690e6b13cff81be54d5c6bddbb",
+        "rev": "fd5cbe03dd4e72ac43c1663211863d4de4c36d89",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1782765551,
-        "narHash": "sha256-TxOInn4prmQ0pC3KJdqXA+Mig/SgrnJKtokfbV9F2r4=",
+        "lastModified": 1782770444,
+        "narHash": "sha256-lYP8IWZnOtrV2HfFb5YvED8Qn8WvQADG4mAhNp9U+XM=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "e4101491a3051281426baa8cc4d65c0c3a8870e5",
+        "rev": "54f692dde2ca064084eed7fff09cae5e65bd0f81",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -307,16 +307,15 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1783288724,
+        "lastModified": 1783294415,
         "narHash": "sha256-PJOxNZ1d6tSNcJLQb2EevCLKU1IpyWwrj29LL315wfQ=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "b6e05cef4a0e322e1a45e756a567c1059f314daa",
+        "rev": "c5b74c2258343791624d694f02f535b0bc9ba959",
         "type": "github"
       },
       "original": {
         "owner": "TristonYoder",
-        "ref": "feat/cli-sync",
         "repo": "iOpenPodCLI",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1782764412,
-        "narHash": "sha256-GxuaYSJqJK1T3BpZtMyJIst9lkqOu/K8d7+6HM2Z51I=",
+        "lastModified": 1782764838,
+        "narHash": "sha256-fjTikq89r9yirJAURN9kw6TZqws9r0GPURKwQREMAmg=",
         "owner": "TristonYoder",
         "repo": "iOpenPodCLI",
-        "rev": "0f3944002e85717a0cb322507090df51b959417b",
+        "rev": "c21426904d010a690e6b13cff81be54d5c6bddbb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -166,6 +166,24 @@
         "systems": "systems_5"
       },
       "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
         "lastModified": 1681202837,
         "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
@@ -283,11 +301,30 @@
         "type": "github"
       }
     },
+    "iopodcli": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1782764412,
+        "narHash": "sha256-GxuaYSJqJK1T3BpZtMyJIst9lkqOu/K8d7+6HM2Z51I=",
+        "owner": "TristonYoder",
+        "repo": "iOpenPodCLI",
+        "rev": "0f3944002e85717a0cb322507090df51b959417b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "TristonYoder",
+        "repo": "iOpenPodCLI",
+        "type": "github"
+      }
+    },
     "nix-bitcoin": {
       "inputs": {
         "extra-container": "extra-container",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_4",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
@@ -345,7 +382,7 @@
     },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1781622756,
@@ -364,8 +401,8 @@
     },
     "nixos-vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_6"
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1770124655,
@@ -463,6 +500,22 @@
     },
     "nixpkgs_4": {
       "locked": {
+        "lastModified": 1782666739,
+        "narHash": "sha256-2CYuaRDT7hcYnGW+3TTTy+fNnY4jQ6/mGk6ew035XP4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "534ee3d8beb1737b5342995f8837e2b2705ce0d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1734323986,
         "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "NixOS",
@@ -477,7 +530,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
@@ -490,7 +543,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1682134069,
         "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
@@ -504,7 +557,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1781808408,
         "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
@@ -637,12 +690,13 @@
         "home-manager": "home-manager_2",
         "home-manager-unstable": "home-manager-unstable",
         "iopenpod-flake": "iopenpod-flake",
+        "iopodcli": "iopodcli",
         "nix-bitcoin": "nix-bitcoin",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixos-hardware": "nixos-hardware",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       }
     },
@@ -707,6 +761,21 @@
       }
     },
     "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
     # External app flakes
     iopenpod-flake.url = "github:TristonYoder/iopenpod-flake";
-    iopodcli.url = "github:TristonYoder/iOpenPodCLI/feat/cli-sync";
+    iopodcli.url = "github:TristonYoder/iOpenPodCLI";
 
     # Hermes Agent (NousResearch) — official NixOS module
     hermes-agent.url = "github:NousResearch/hermes-agent";

--- a/flake.nix
+++ b/flake.nix
@@ -42,12 +42,13 @@
 
     # External app flakes
     iopenpod-flake.url = "github:TristonYoder/iopenpod-flake";
+    iopodcli.url = "github:TristonYoder/iOpenPodCLI";
 
     # Hermes Agent (NousResearch) — official NixOS module
     hermes-agent.url = "github:NousResearch/hermes-agent";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, flake-utils, iopenpod-flake, hermes-agent, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, flake-utils, iopenpod-flake, iopodcli, hermes-agent, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -152,7 +153,7 @@
           ];
           
           specialArgs = {
-            inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake iopodcli;
           };
         };
 
@@ -193,7 +194,7 @@
           ];
 
           specialArgs = {
-            inherit self nixpkgs nixpkgs-unstable iopenpod-flake;
+            inherit self nixpkgs nixpkgs-unstable iopenpod-flake iopodcli;
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
     # External app flakes
     iopenpod-flake.url = "github:TristonYoder/iopenpod-flake";
-    iopodcli.url = "github:TristonYoder/iOpenPodCLI";
+    iopodcli.url = "github:TristonYoder/iOpenPodCLI/feat/cli-sync";
 
     # Hermes Agent (NousResearch) — official NixOS module
     hermes-agent.url = "github:NousResearch/hermes-agent";

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -224,6 +224,13 @@ in
 
   modules.services.storage.wiiHddSync.enable = true;
 
+  modules.services.storage.ipodSync = {
+    enable = true;
+    user = "tristonyoder";
+    configFile = "/data/tristonyoder/home/.config/iopenpodcli/config.yaml";
+    autoMount = true;  # headless server — no udisks desktop session
+  };
+
   modules.services.storage.mp3PlayerSync = {
     enable = true;
     uuid = "EC95-4FBB";

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -337,4 +337,12 @@
   ];
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
+
+  modules.services.storage.ipodSync = {
+    enable = true;
+    user = "tristonyoder";
+    configFile = "/home/tristonyoder/.config/iopenpodcli/config.yaml";
+    # KDE/udisks auto-mounts the iPod; no manual mount needed
+    autoMount = false;
+  };
 }

--- a/modules/services/storage/default.nix
+++ b/modules/services/storage/default.nix
@@ -8,6 +8,7 @@
     ./nextcloud/onlyoffice.nix
     ./samba.nix
     ./syncthing.nix
+    ./ipod-sync.nix
     ./mp3-player-sync.nix
     ./wii-hdd-sync.nix
     ./zfs.nix

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -96,9 +96,52 @@ in
             ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
           '' else ''
             set -euo pipefail
-            # On desktop hosts udisks auto-mounts the iPod; iopod
-            # discovers it by scanning mounted volumes via scan_for_ipods().
-            ${pkgs.iopod}/bin/iopod --config ${cfg.configFile}
+
+            # Find the FAT partition on the first Apple block device
+            DEVICE=$(${pkgs.util-linux}/bin/lsblk -ndo NAME,VENDOR \
+              | ${pkgs.gnugrep}/bin/grep -i "apple" \
+              | ${pkgs.gawk}/bin/awk '{print "/dev/" $1}' \
+              | head -1)
+
+            if [ -z "$DEVICE" ]; then
+              echo "No Apple USB storage device found — skipping sync."
+              exit 0
+            fi
+
+            PART=$(${pkgs.util-linux}/bin/lsblk -nrpo NAME,TYPE "$DEVICE" \
+              | ${pkgs.gnugrep}/bin/grep part \
+              | ${pkgs.gawk}/bin/awk '{print $1}' \
+              | head -1)
+            PART="''${PART:-$DEVICE}"
+
+            # Mount via udisks (under /run/media/<user>) if not already mounted
+            MOUNT=$(${pkgs.util-linux}/bin/lsblk -nro NAME,MOUNTPOINTS \
+              | ${pkgs.gnugrep}/bin/grep "$(basename $PART)" \
+              | ${pkgs.gawk}/bin/awk '{print $2}')
+
+            MOUNTED_HERE=0
+            if [ -z "$MOUNT" ]; then
+              echo "Mounting $PART via udisksctl..."
+              UDISKS_OUT=$(${pkgs.udisks2}/bin/udisksctl mount -b "$PART" --no-user-interaction)
+              MOUNT=$(echo "$UDISKS_OUT" | ${pkgs.gnugrep}/bin/grep -oP '(?<=at ).*' | tr -d '.')
+              MOUNTED_HERE=1
+            fi
+
+            if [ -z "$MOUNT" ]; then
+              echo "Failed to determine mount point — aborting."
+              exit 1
+            fi
+
+            echo "iPod at $MOUNT"
+            cleanup() {
+              if [ "$MOUNTED_HERE" = "1" ]; then
+                echo "Unmounting $PART"
+                ${pkgs.udisks2}/bin/udisksctl unmount -b "$PART" --no-user-interaction || true
+              fi
+            }
+            trap cleanup EXIT
+
+            ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
           ''
         );
       };

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -54,14 +54,14 @@ in
 
       serviceConfig = {
         Type = "oneshot";
-        User = cfg.user;
+        # Run as root so we can mount; iopod itself is invoked via runuser
+        User = "root";
         TimeoutStartSec = "5min";
         # Keep logs for the last 10 runs
         StandardOutput = "journal";
         StandardError = "journal";
         SyslogIdentifier = "ipod-sync";
-        ExecStart = pkgs.writeShellScript "ipod-sync-run" (
-          if cfg.autoMount then ''
+        ExecStart = pkgs.writeShellScript "ipod-sync-run" ''
             set -euo pipefail
 
             MOUNT="${cfg.mountPoint}"
@@ -84,66 +84,35 @@ in
               | head -1)
             PART="''${PART:-$DEVICE}"
 
-            echo "Mounting $PART -> $MOUNT"
-            ${pkgs.util-linux}/bin/mount -t vfat -o uid=$(id -u ${cfg.user}),gid=$(id -g ${cfg.user}),umask=002,flush "$PART" "$MOUNT"
-
-            cleanup() {
-              echo "Unmounting $MOUNT"
-              ${pkgs.util-linux}/bin/umount "$MOUNT" || true
-            }
-            trap cleanup EXIT
-
-            ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
-          '' else ''
-            set -euo pipefail
-
-            # Find the FAT partition on the first Apple block device
-            DEVICE=$(${pkgs.util-linux}/bin/lsblk -ndo NAME,VENDOR \
-              | ${pkgs.gnugrep}/bin/grep -i "apple" \
-              | ${pkgs.gawk}/bin/awk '{print "/dev/" $1}' \
-              | head -1)
-
-            if [ -z "$DEVICE" ]; then
-              echo "No Apple USB storage device found — skipping sync."
-              exit 0
-            fi
-
-            PART=$(${pkgs.util-linux}/bin/lsblk -nrpo NAME,TYPE "$DEVICE" \
-              | ${pkgs.gnugrep}/bin/grep part \
-              | ${pkgs.gawk}/bin/awk '{print $1}' \
-              | head -1)
-            PART="''${PART:-$DEVICE}"
-
-            # Mount via udisks (under /run/media/<user>) if not already mounted
-            MOUNT=$(${pkgs.util-linux}/bin/lsblk -nro NAME,MOUNTPOINTS \
-              | ${pkgs.gnugrep}/bin/grep "$(basename $PART)" \
-              | ${pkgs.gawk}/bin/awk '{print $2}')
+            # Use existing mount if already mounted (e.g. by udisks/KDE)
+            EXISTING=$(${pkgs.util-linux}/bin/lsblk -nro NAME,MOUNTPOINTS \
+              | ${pkgs.gnugrep}/bin/grep "$(basename "$PART")" \
+              | ${pkgs.gawk}/bin/awk '{print $2}' | head -1)
 
             MOUNTED_HERE=0
-            if [ -z "$MOUNT" ]; then
-              echo "Mounting $PART via udisksctl..."
-              UDISKS_OUT=$(${pkgs.udisks2}/bin/udisksctl mount -b "$PART" --no-user-interaction)
-              MOUNT=$(echo "$UDISKS_OUT" | ${pkgs.gnugrep}/bin/grep -oP '(?<=at ).*' | tr -d '.')
+            if [ -n "$EXISTING" ]; then
+              MOUNT="$EXISTING"
+              echo "iPod already mounted at $MOUNT"
+            else
+              mkdir -p "$MOUNT"
+              echo "Mounting $PART -> $MOUNT"
+              ${pkgs.util-linux}/bin/mount -t vfat \
+                -o uid=$(id -u ${cfg.user}),gid=$(id -g ${cfg.user}),umask=002,flush \
+                "$PART" "$MOUNT"
               MOUNTED_HERE=1
             fi
 
-            if [ -z "$MOUNT" ]; then
-              echo "Failed to determine mount point — aborting."
-              exit 1
-            fi
-
-            echo "iPod at $MOUNT"
             cleanup() {
               if [ "$MOUNTED_HERE" = "1" ]; then
-                echo "Unmounting $PART"
-                ${pkgs.udisks2}/bin/udisksctl unmount -b "$PART" --no-user-interaction || true
+                echo "Unmounting $MOUNT"
+                ${pkgs.util-linux}/bin/umount "$MOUNT" || true
               fi
             }
             trap cleanup EXIT
 
-            ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
-          ''
-        );
+            ${pkgs.util-linux}/bin/runuser -u ${cfg.user} -- \
+              ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
+          '';
       };
     };
 

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -56,7 +56,7 @@ in
         Type = "oneshot";
         # Run as root so we can mount; iopod itself is invoked via runuser
         User = "root";
-        TimeoutStartSec = "5min";
+        TimeoutStartSec = "2h";
         # Keep logs for the last 10 runs
         StandardOutput = "journal";
         StandardError = "journal";

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -1,0 +1,113 @@
+{ config, lib, pkgs, iopenpod-flake, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.storage.ipodSync;
+in
+{
+  options.modules.services.storage.ipodSync = {
+    enable = mkEnableOption "iPod auto-sync via iopenpod-sync";
+
+    user = mkOption {
+      type = types.str;
+      description = "User to run the sync as (needs read access to music library)";
+    };
+
+    configFile = mkOption {
+      type = types.str;
+      description = "Path to the iopenpod-sync YAML config file";
+      example = "/home/tristonyoder/.config/iopenpodcli/config.yaml";
+    };
+
+    # On headless hosts (david) the iPod won't be auto-mounted by udisks.
+    # Set this to have the service mount and unmount it manually.
+    autoMount = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Mount the iPod manually before sync and unmount after.
+        Use on headless/server hosts without a desktop session.
+        On desktop hosts (KDE), leave false — udisks auto-mounts the device.
+      '';
+    };
+
+    mountPoint = mkOption {
+      type = types.str;
+      default = "/mnt/ipod";
+      description = "Mount point used when autoMount = true";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Pull iopenpod-sync from the iopenpod-flake overlay (Qt-free headless build)
+    nixpkgs.overlays = [ iopenpod-flake.overlays.default ];
+
+    systemd.tmpfiles.rules = mkIf cfg.autoMount [
+      "d ${cfg.mountPoint} 0755 root root -"
+    ];
+
+    systemd.services.ipod-sync = {
+      description = "Sync iPod via iopenpod-sync";
+      # Don't block boot if triggered at startup; only run on-demand from udev
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        TimeoutStartSec = "5min";
+        # Keep logs for the last 10 runs
+        StandardOutput = "journal";
+        StandardError = "journal";
+        SyslogIdentifier = "ipod-sync";
+        ExecStart = pkgs.writeShellScript "ipod-sync-run" (
+          if cfg.autoMount then ''
+            set -euo pipefail
+
+            MOUNT="${cfg.mountPoint}"
+
+            # Find the Apple USB mass storage device (first one found)
+            DEVICE=$(${pkgs.util-linux}/bin/lsblk -ndo NAME,VENDOR \
+              | ${pkgs.gnugrep}/bin/grep -i "apple" \
+              | ${pkgs.gawk}/bin/awk '{print "/dev/" $1}' \
+              | head -1)
+
+            if [ -z "$DEVICE" ]; then
+              echo "No Apple USB storage device found — skipping sync."
+              exit 0
+            fi
+
+            # Find the FAT partition on the device
+            PART=$(${pkgs.util-linux}/bin/lsblk -nrpo NAME,TYPE "$DEVICE" \
+              | ${pkgs.gnugrep}/bin/grep part \
+              | ${pkgs.gawk}/bin/awk '{print $1}' \
+              | head -1)
+            PART="''${PART:-$DEVICE}"
+
+            echo "Mounting $PART -> $MOUNT"
+            ${pkgs.util-linux}/bin/mount -t vfat -o uid=$(id -u ${cfg.user}),gid=$(id -g ${cfg.user}),umask=002,flush "$PART" "$MOUNT"
+
+            cleanup() {
+              echo "Unmounting $MOUNT"
+              ${pkgs.util-linux}/bin/umount "$MOUNT" || true
+            }
+            trap cleanup EXIT
+
+            ${pkgs.iopenpod-sync}/bin/iopenpod-sync --device "$MOUNT" --config ${cfg.configFile}
+          '' else ''
+            set -euo pipefail
+            # On desktop hosts udisks auto-mounts the iPod; iopenpod-sync
+            # discovers it by scanning mounted volumes via scan_for_ipods().
+            ${pkgs.iopenpod-sync}/bin/iopenpod-sync --config ${cfg.configFile}
+          ''
+        );
+      };
+    };
+
+    # Trigger the sync when any Apple USB mass storage device is connected.
+    # Apple Vendor ID: 05ac; iPod product IDs span 0x1200–0x12ff.
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[0-9a-f][0-9a-f]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ipod-sync.service"
+    '';
+  };
+}

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -19,45 +19,79 @@ in
       example = "/home/tristonyoder/.config/iopenpodcli/config.yaml";
     };
 
-    # On headless hosts (david) the iPod won't be auto-mounted by udisks.
-    # Set this to have the service mount and unmount it manually.
     autoMount = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        Mount the iPod manually before sync and unmount after.
-        Use on headless/server hosts without a desktop session.
-        On desktop hosts (KDE), leave false — udisks auto-mounts the device.
+        Kept for backwards compatibility. The service always reuses an existing
+        KDE/udisks mount and falls back to mounting directly if none is found.
       '';
     };
 
     mountPoint = mkOption {
       type = types.str;
       default = "/mnt/ipod";
-      description = "Mount point used when autoMount = true";
+      description = "Fallback mount point when the device is not already mounted";
+    };
+
+    cacheDir = mkOption {
+      type = types.str;
+      default = "/var/cache/iopod";
+      description = "Directory for pre-staged fingerprints and podcast episodes";
+    };
+
+    prepareInterval = mkOption {
+      type = types.str;
+      default = "hourly";
+      description = "How often to run iopod prepare (systemd calendar expression)";
     };
   };
 
   config = mkIf cfg.enable {
-    # Pull iopod (Qt-free headless CLI) from the iOpenPodCLI flake overlay
     nixpkgs.overlays = [ iopodcli.overlays.default ];
 
-    systemd.tmpfiles.rules = mkIf cfg.autoMount [
+    systemd.tmpfiles.rules = [
       "d ${cfg.mountPoint} 0755 root root -"
+      "d ${cfg.cacheDir} 0755 ${cfg.user} ${cfg.user} -"
     ];
 
-    systemd.services.ipod-sync = {
-      description = "Sync iPod via iopod";
-      # Don't block boot if triggered at startup; only run on-demand from udev
-      after = [ "network.target" ];
-      wants = [ "network.target" ];
-
+    # ── prepare: runs on a timer, no iPod needed ─────────────────────────────
+    # Fingerprints playlist tracks and downloads podcast episodes ahead of time
+    # so ipod-sync.service is fast when the iPod connects.
+    systemd.services.iopod-prepare = {
+      description = "Pre-stage iPod sync content (fingerprint + podcast download)";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       serviceConfig = {
         Type = "oneshot";
-        # Run as root so we can mount; iopod itself is invoked via runuser
+        User = cfg.user;
+        TimeoutStartSec = "2h";
+        StandardOutput = "journal";
+        StandardError = "journal";
+        SyslogIdentifier = "iopod-prepare";
+        ExecStart = "${pkgs.iopod}/bin/iopod prepare --config ${cfg.configFile} --cache-dir ${cfg.cacheDir}";
+      };
+    };
+
+    systemd.timers.iopod-prepare = {
+      description = "Run iopod prepare on a schedule";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.prepareInterval;
+        Persistent = true;
+        RandomizedDelaySec = "5min";
+      };
+    };
+
+    # ── sync: triggered by udev on iPod connect ───────────────────────────────
+    systemd.services.ipod-sync = {
+      description = "Sync iPod via iopod";
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      serviceConfig = {
+        Type = "oneshot";
         User = "root";
         TimeoutStartSec = "2h";
-        # Keep logs for the last 10 runs
         StandardOutput = "journal";
         StandardError = "journal";
         SyslogIdentifier = "ipod-sync";
@@ -66,25 +100,22 @@ in
 
             MOUNT="${cfg.mountPoint}"
 
-            # Find the Apple USB mass storage device (first one found)
             DEVICE=$(${pkgs.util-linux}/bin/lsblk -ndo NAME,VENDOR \
               | ${pkgs.gnugrep}/bin/grep -i "apple" \
               | ${pkgs.gawk}/bin/awk '{print "/dev/" $1}' \
               | head -1)
 
             if [ -z "$DEVICE" ]; then
-              echo "No Apple USB storage device found — skipping sync."
+              echo "No Apple USB storage device found -- skipping sync."
               exit 0
             fi
 
-            # Find the FAT partition on the device
             PART=$(${pkgs.util-linux}/bin/lsblk -nrpo NAME,TYPE "$DEVICE" \
               | ${pkgs.gnugrep}/bin/grep part \
               | ${pkgs.gawk}/bin/awk '{print $1}' \
               | head -1)
             PART="''${PART:-$DEVICE}"
 
-            # Use existing mount if already mounted (e.g. by udisks/KDE)
             EXISTING=$(${pkgs.util-linux}/bin/lsblk -nro NAME,MOUNTPOINTS \
               | ${pkgs.gnugrep}/bin/grep "$(basename "$PART")" \
               | ${pkgs.gawk}/bin/awk '{print $2}' | head -1)
@@ -111,13 +142,14 @@ in
             trap cleanup EXIT
 
             ${pkgs.util-linux}/bin/runuser -u ${cfg.user} -- \
-              ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
+              ${pkgs.iopod}/bin/iopod sync \
+                --device "$MOUNT" \
+                --config ${cfg.configFile} \
+                --cache-dir ${cfg.cacheDir}
           '';
       };
     };
 
-    # Trigger the sync when any Apple USB mass storage device is connected.
-    # Apple Vendor ID: 05ac; iPod product IDs span 0x1200–0x12ff.
     services.udev.extraRules = ''
       ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[0-9a-f][0-9a-f]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ipod-sync.service"
     '';

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, iopenpod-flake, ... }:
+{ config, lib, pkgs, iopodcli, ... }:
 
 with lib;
 let
@@ -39,8 +39,8 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Pull iopod from the iopenpod-flake overlay (Qt-free headless build)
-    nixpkgs.overlays = [ iopenpod-flake.overlays.default ];
+    # Pull iopod (Qt-free headless CLI) from the iOpenPodCLI flake overlay
+    nixpkgs.overlays = [ iopodcli.overlays.default ];
 
     systemd.tmpfiles.rules = mkIf cfg.autoMount [
       "d ${cfg.mountPoint} 0755 root root -"

--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -6,7 +6,7 @@ let
 in
 {
   options.modules.services.storage.ipodSync = {
-    enable = mkEnableOption "iPod auto-sync via iopenpod-sync";
+    enable = mkEnableOption "iPod auto-sync via iopod";
 
     user = mkOption {
       type = types.str;
@@ -15,7 +15,7 @@ in
 
     configFile = mkOption {
       type = types.str;
-      description = "Path to the iopenpod-sync YAML config file";
+      description = "Path to the iopod YAML config file";
       example = "/home/tristonyoder/.config/iopenpodcli/config.yaml";
     };
 
@@ -39,7 +39,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Pull iopenpod-sync from the iopenpod-flake overlay (Qt-free headless build)
+    # Pull iopod from the iopenpod-flake overlay (Qt-free headless build)
     nixpkgs.overlays = [ iopenpod-flake.overlays.default ];
 
     systemd.tmpfiles.rules = mkIf cfg.autoMount [
@@ -47,7 +47,7 @@ in
     ];
 
     systemd.services.ipod-sync = {
-      description = "Sync iPod via iopenpod-sync";
+      description = "Sync iPod via iopod";
       # Don't block boot if triggered at startup; only run on-demand from udev
       after = [ "network.target" ];
       wants = [ "network.target" ];
@@ -93,12 +93,12 @@ in
             }
             trap cleanup EXIT
 
-            ${pkgs.iopenpod-sync}/bin/iopenpod-sync --device "$MOUNT" --config ${cfg.configFile}
+            ${pkgs.iopod}/bin/iopod --device "$MOUNT" --config ${cfg.configFile}
           '' else ''
             set -euo pipefail
-            # On desktop hosts udisks auto-mounts the iPod; iopenpod-sync
+            # On desktop hosts udisks auto-mounts the iPod; iopod
             # discovers it by scanning mounted volumes via scan_for_ipods().
-            ${pkgs.iopenpod-sync}/bin/iopenpod-sync --config ${cfg.configFile}
+            ${pkgs.iopod}/bin/iopod --config ${cfg.configFile}
           ''
         );
       };


### PR DESCRIPTION
## Summary

- Adds \`modules.services.storage.ipodSync\` — a NixOS module for automatic iPod sync on USB connect
- \`iopod-prepare.timer\` runs hourly to pre-fingerprint playlist tracks and download podcast episodes to \`/var/cache/iopod\`
- \`ipod-sync.service\` triggers via udev on Apple USB storage connect, mounts the device as root, then runs \`iopod sync\` as the configured user
- \`iopodcli\` flake input tracks \`TristonYoder/iOpenPodCLI\` main (CLI lives in that fork)

## Test plan

- [x] \`iopod-prepare.timer\` fires on schedule and builds manifest
- [x] \`ipod-sync.service\` triggers on iPod connect and syncs playlist tracks + podcasts
- [x] iPod contains exactly the configured playlist tracks (not the full music library)
- [x] Podcasts sync with staged episodes from prepare cache