### PR TITLE
fix: resolve four failing services on david

### DIFF
--- a/docker/watchtower.nix
+++ b/docker/watchtower.nix
@@ -5,12 +5,16 @@
 {
 
   # Watchtower
+  # containrrr/watchtower is archived (last published 2023-11-11) and its
+  # bundled Docker client can't negotiate with newer Docker daemons ("client
+  # version 1.25 is too old, minimum supported API version is 1.40"). Use the
+  # actively maintained fork instead.
   virtualisation.oci-containers.containers."watchtower" = {
     autoStart = true;
-    image = "containrrr/watchtower";
+    image = "nickfedor/watchtower";
     volumes = [
       "/var/run/docker.sock:/var/run/docker.sock"
-    ]; 
+    ];
   };
 
 }

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -66,6 +66,10 @@ in
   # Stalwart Mail Server
   modules.services.communication.stalwart-mail.enable = false;
 
+  # Stirling PDF's default port 7878 collides with Radarr, which also runs on
+  # this host and already owns that port.
+  modules.services.productivity.stirlingPdf.port = 7879;
+
   # dns-sync: use local Technitium directly (avoids Caddy loopback for the API)
   modules.services.providers.dns-technitium.url = "http://localhost:5380";
 

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -70,6 +70,11 @@ in
   # this host and already owns that port.
   modules.services.productivity.stirlingPdf.port = 7879;
 
+  # Scrutiny and Pixelfed both default to port 8085. Pixelfed's port is
+  # externally referenced (PITS reverse proxy, ActivityPub webfinger), so
+  # move Scrutiny instead — it's Caddy-proxied and localhost-only.
+  modules.services.infrastructure.scrutiny.port = 8087;
+
   # dns-sync: use local Technitium directly (avoids Caddy loopback for the API)
   modules.services.providers.dns-technitium.url = "http://localhost:5380";
 

--- a/modules/services/ai/open-webui.nix
+++ b/modules/services/ai/open-webui.nix
@@ -87,6 +87,12 @@ in
   config = mkIf cfg.enable {
     services.open-webui = {
       enable = true;
+      # nixpkgs' open-webui only gates qdrant_client behind its "all" optional
+      # dependency group (unused by the NixOS module), so importing qdrant
+      # support requires overriding the package directly.
+      package = mkIf cfg.enableQdrant (pkgs.open-webui.overridePythonAttrs (old: {
+        dependencies = old.dependencies ++ [ pkgs.python3Packages.qdrant-client ];
+      }));
       host = "127.0.0.1";
       port = cfg.port;
       environment = {
@@ -138,7 +144,6 @@ in
       displayName = "Open WebUI";
       category = "ai";
       icon = "open-webui";
-      monitor = false; # service crashes on nixpkgs missing qdrant_client
     };
   };
 }


### PR DESCRIPTION
## Summary
- **stirling-pdf**: default port 7878 collided with Radarr (already bound to it on david) — moved to 7879.
- **watchtower**: `containrrr/watchtower` is archived (last published 2023-11-11); its bundled Docker client can't negotiate with david's newer Docker daemon ("client version 1.25 is too old, minimum supported API version is 1.40"). Switched to the actively maintained `nickfedor/watchtower` fork.
- **open-webui**: nixpkgs' `open-webui` package only includes `qdrant_client` under an unused "all" optional-dependency group, causing `ModuleNotFoundError` at startup when `enableQdrant = true`. Overrode the package to add `qdrant-client` when qdrant is enabled, and removed the now-stale `monitor = false` workaround.
- **scrutiny**: default port 8085 collided with Pixelfed's nginx (also 8085, bound to 0.0.0.0) on david. Moved Scrutiny to 8087 instead of touching Pixelfed's port, since Pixelfed's port is referenced externally (PITS reverse proxy, ActivityPub webfinger endpoints) while Scrutiny is localhost-only and Caddy-proxied.

## Test plan
- [x] `nixos-rebuild dry-run`/`build` against `github:TristonYoder/nix-config/fix/david-service-failures#david` — clean build both times
- [x] `nixos-rebuild switch` on david — applied successfully
- [x] Verified all four services `active (running)` post-switch: `docker-stirling-pdf`, `docker-watchtower`, `open-webui` (no more qdrant_client error), `scrutiny` (bound to new port, no bind conflict)