### PR TITLE
fix: allow insecure pnpm-10.29.2 required by cherry-studio

### DIFF
--- a/common/system.nix
+++ b/common/system.nix
@@ -40,6 +40,7 @@ in
     "electron-35.7.5"  # Required for gfn-electron (GeForce Now)
     "electron-39.8.10" # Required for feishin (upgraded from electron-36 in 26.05)
     "olm-3.2.16"       # Required for Matrix communication bridges
+    "pnpm-10.29.2"     # Required for cherry-studio (pnpm 10.29.3+ breaks its electron-builder step)
   ];
 
   # =============================================================================


### PR DESCRIPTION
## Summary
The NixOS Flake Updater workflow failed on david's dry-run after the latest `nix flake update` (run [28788785483](https://github.com/TristonYoder/nix-config/actions/runs/28788785483)):

```
error: Refusing to evaluate package 'pnpm-10.29.2' ... because it is marked as insecure
Known issues: CVE-2026-48995, CVE-2026-50014, CVE-2026-50015, CVE-2026-50016, CVE-2026-50017, CVE-2026-50573, CVE-2026-55699
```

`cherry-studio` (installed via `profiles/workstation.nix`, which `david` imports directly in `flake.nix` alongside the server profile) hardcodes `pnpm_10_29_2` in its nixpkgs derivation, because pnpm 10.29.3+ breaks cherry-studio's electron-builder step. This pnpm build just got flagged with 7 CVEs upstream, so evaluation now refuses outright. `pits` isn't affected since it doesn't use the workstation profile.

This adds `pnpm-10.29.2` to `nixpkgs.config.permittedInsecurePackages` in `common/system.nix`, following the exact pattern already used for `electron-35.7.5`, `electron-39.8.10`, and `olm-3.2.16` — all functional-but-flagged build-time deps.

Related: opened an issue to track removing this allowance once cherry-studio's nixpkgs packaging moves off the pinned insecure pnpm.

## Test plan
- [ ] Dry-run david and pits on this branch before merging (`rebuild --branch <this-branch> test` or the CI test workflow)