### PR TITLE
feat: expose raw model names alongside LiteLLM tier aliases

### DIFF
--- a/modules/services/ai/litellm.nix
+++ b/modules/services/ai/litellm.nix
@@ -39,6 +39,18 @@ in
             default = null;
             description = "Environment variable name holding the API key, e.g. 'ANTHROPIC_API_KEY'. LiteLLM reads it as os.environ/<name>.";
           };
+          exposeModelName = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Also register this route under its raw model name (everything
+              in `model` after the first '/', e.g. "anthropic/claude-sonnet-4.6"
+              or "hermes3") in addition to `name`. Lets clients pick either the
+              tier alias (fast/smart/local/...) — which can be repointed at a
+              different underlying model later without callers noticing — or
+              the specific model directly, e.g. from Open WebUI's dropdown.
+            '';
+          };
         };
       });
       default = [];
@@ -86,16 +98,27 @@ in
       environmentFile = cfg.environmentFile;
 
       settings = {
-        model_list = map (m: {
-          model_name = m.name;
-          litellm_params = {
-            model = m.model;
-          } // optionalAttrs (m.apiBase != null) {
-            api_base = m.apiBase;
-          } // optionalAttrs (m.apiKeyEnv != null) {
-            api_key = "os.environ/${m.apiKeyEnv}";
-          };
-        }) cfg.models;
+        model_list =
+          let
+            # Everything after the first '/' in the litellm model string, e.g.
+            # "openrouter/anthropic/claude-sonnet-4.6" -> "anthropic/claude-sonnet-4.6",
+            # "ollama/hermes3" -> "hermes3".
+            rawNameOf = m: removePrefix ("${head (splitString "/" m.model)}/") m.model;
+            mkEntry = modelName: m: {
+              model_name = modelName;
+              litellm_params = {
+                model = m.model;
+              } // optionalAttrs (m.apiBase != null) {
+                api_base = m.apiBase;
+              } // optionalAttrs (m.apiKeyEnv != null) {
+                api_key = "os.environ/${m.apiKeyEnv}";
+              };
+            };
+          in
+          concatMap (m:
+            [ (mkEntry m.name m) ]
+            ++ optional (m.exposeModelName && rawNameOf m != m.name) (mkEntry (rawNameOf m) m)
+          ) cfg.models;
 
         litellm_settings = {
           telemetry = false;


### PR DESCRIPTION
## Summary
- Open WebUI's model dropdown only showed the friendly tier tags (fast, smart, local, etc) since that's all LiteLLM registered clients under.
- Each configured model in `modules.services.ai.litellm.models` is now also registered under its raw model name (everything after the first `/` in the litellm model string, e.g. `anthropic/claude-sonnet-4.6`, `hermes3`) alongside its tier alias, via a new per-entry `exposeModelName` option (default `true`).
- Lets you keep the tags (fast/smart/local/etc) to swap the underlying model later without touching callers, while also being able to pick the specific model directly from Open WebUI (or any other LiteLLM client).

## Test plan
- [x] `nixos-rebuild dry-run`/`build` against david (branch flake URL) - passed
- [x] `nixos-rebuild switch` on david - activated cleanly, `litellm.service` active
- [x] Verified generated `config.yaml` lists all 12 aliases + 12 raw names, no name collisions
- [x] Verified `/v1/models` (authenticated) returns all 24 model IDs live