### PR TITLE
feat: add AzuraCast internet radio module

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -84,6 +84,9 @@ in
   # Feishin - Web music player (Jellyfin/Navidrome/Subsonic client)
   modules.services.media.feishin.enable = true;
 
+  # AzuraCast - Internet radio station management (azuracast.* admin, radio.* public player)
+  modules.services.media.azuracast.enable = true;
+
   # Beets - Auto-organize music library from Downloads into Music
   modules.services.media.beets.enable = true;
 

--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -112,6 +112,10 @@ in
         AZURACAST_SFTP_PORT = toString cfg.sftpPort;
         AUTO_ASSIGN_PORT_MIN = toString cfg.stationPortMin;
         AUTO_ASSIGN_PORT_MAX = toString cfg.stationPortMax;
+        # Required for first-boot DB init (upstream mariadb entrypoint aborts
+        # without one of the MYSQL_*_PASSWORD vars). The DB isn't reachable
+        # outside the container, so a random root password is fine.
+        MYSQL_RANDOM_ROOT_PASSWORD = "yes";
       };
       volumes = [
         "${cfg.dataDir}/stations:/var/azuracast/stations:rw"

--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -66,6 +66,29 @@ in
       description = "Data directory for AzuraCast (stations, database, uploads, backups)";
     };
 
+    mediaDir = mkOption {
+      type = types.str;
+      default = "/data/media";
+      description = "Root shared media directory (matches modules.services.media.jellyfin.mediaDir)";
+    };
+
+    libraryMounts = mkOption {
+      type = types.listOf types.str;
+      default = [ "Music" "Podcasts" "Audiobooks" ];
+      description = ''
+        Subdirectories of mediaDir to mount read-only into the container so
+        they can be added as AzuraCast Storage Locations. Read-only because
+        AzuraCast's media manager can rename/tag/reorganize files it can
+        write to, which would fight with beets/Jellyfin's management of the
+        same library. Each is mounted at /var/azuracast/media/<lowercased name>.
+
+        After first login, add a Storage Location (Administration >
+        Storage Locations) pointing at the container path for each library
+        you want a station to use, then assign it as that station's Media
+        storage location.
+      '';
+    };
+
     version = mkOption {
       type = types.str;
       default = "latest";
@@ -101,7 +124,7 @@ in
         "${cfg.dataDir}/geoip:/var/azuracast/storage/geoip:rw"
         "${cfg.dataDir}/sftpgo:/var/azuracast/storage/sftpgo:rw"
         "${cfg.dataDir}/acme:/var/azuracast/storage/acme:rw"
-      ];
+      ] ++ map (name: "${cfg.mediaDir}/${name}:/var/azuracast/media/${toLower name}:ro") cfg.libraryMounts;
       ports = [
         "${toString cfg.httpPort}:${toString cfg.httpPort}/tcp"
         "${toString cfg.sftpPort}:${toString cfg.sftpPort}/tcp"

--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -94,6 +94,18 @@ in
       default = "latest";
       description = "AzuraCast image tag";
     };
+
+    puid = mkOption {
+      type = types.int;
+      default = 1000;
+      description = "UID the container's internal azuracast user runs as (also used to pre-own bind-mounted data dirs)";
+    };
+
+    pgid = mkOption {
+      type = types.int;
+      default = 1000;
+      description = "GID the container's internal azuracast user runs as (also used to pre-own bind-mounted data dirs)";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -102,6 +114,16 @@ in
       autoPrune.enable = true;
     };
     virtualisation.oci-containers.backend = "docker";
+
+    # AzuraCast's own startup scripts chown /var/azuracast/storage/* to the
+    # azuracast user on every boot, but NOT /var/azuracast/stations or
+    # /var/azuracast/backups. Left to Docker's default bind-mount behavior
+    # those two would be created as root and the app (running as puid/pgid)
+    # can't write to them, so pre-create and own them ourselves.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}/stations 0755 ${toString cfg.puid} ${toString cfg.pgid} -"
+      "d ${cfg.dataDir}/backups 0755 ${toString cfg.puid} ${toString cfg.pgid} -"
+    ];
 
     virtualisation.oci-containers.containers."azuracast" = {
       image = "ghcr.io/azuracast/azuracast:${cfg.version}";
@@ -116,6 +138,8 @@ in
         # without one of the MYSQL_*_PASSWORD vars). The DB isn't reachable
         # outside the container, so a random root password is fine.
         MYSQL_RANDOM_ROOT_PASSWORD = "yes";
+        PUID = toString cfg.puid;
+        PGID = toString cfg.pgid;
       };
       volumes = [
         "${cfg.dataDir}/stations:/var/azuracast/stations:rw"

--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -1,0 +1,160 @@
+# AzuraCast - Self-hosted internet radio management (stations, Icecast/Liquidsoap, web player)
+# All-in-one image: nginx, PHP, MariaDB, Redis, and the station streaming engines
+# all run inside the single "web" container. See:
+# https://github.com/AzuraCast/AzuraCast/blob/main/docker-compose.sample.yml
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.azuracast;
+in
+{
+  options.modules.services.media.azuracast = {
+    enable = mkEnableOption "AzuraCast internet radio server";
+
+    domain = mkOption {
+      type = types.str;
+      default = "azuracast.${config.networking.domain}";
+      description = "Domain for the AzuraCast admin/station management UI";
+    };
+
+    radioDomain = mkOption {
+      type = types.str;
+      default = "radio.${config.networking.domain}";
+      description = "Public-facing domain for the radio player/stream pages (served by the same backend as domain)";
+    };
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 6580;
+      description = ''
+        Host and container HTTP port. AzuraCast's internal nginx listens on
+        this same port (set via AZURACAST_HTTP_PORT), so this is also the
+        reverse proxy target for Caddy.
+      '';
+    };
+
+    sftpPort = mkOption {
+      type = types.port;
+      default = 2022;
+      description = "SFTP port for station file uploads";
+    };
+
+    stationPortMin = mkOption {
+      type = types.port;
+      default = 9500;
+      description = ''
+        Lower bound of the port range auto-assigned to radio stations
+        (Icecast/Shoutcast direct-connect streaming ports). AzuraCast's own
+        default range (8000-8496) collides with Jellyfin (8096) on this host,
+        so this uses a dedicated range instead.
+      '';
+    };
+
+    stationPortMax = mkOption {
+      type = types.port;
+      default = 9599;
+      description = ''
+        Upper bound of the station port range. 100 ports supports up to ~33
+        stations (3 ports each); widen if more are needed.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/data/docker-appdata/azuracast";
+      description = "Data directory for AzuraCast (stations, database, uploads, backups)";
+    };
+
+    version = mkOption {
+      type = types.str;
+      default = "latest";
+      description = "AzuraCast image tag";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.docker = {
+      enable = true;
+      autoPrune.enable = true;
+    };
+    virtualisation.oci-containers.backend = "docker";
+
+    virtualisation.oci-containers.containers."azuracast" = {
+      image = "ghcr.io/azuracast/azuracast:${cfg.version}";
+      environment = {
+        TZ = config.time.timeZone;
+        APPLICATION_ENV = "production";
+        AZURACAST_HTTP_PORT = toString cfg.httpPort;
+        AZURACAST_SFTP_PORT = toString cfg.sftpPort;
+        AUTO_ASSIGN_PORT_MIN = toString cfg.stationPortMin;
+        AUTO_ASSIGN_PORT_MAX = toString cfg.stationPortMax;
+      };
+      volumes = [
+        "${cfg.dataDir}/stations:/var/azuracast/stations:rw"
+        "${cfg.dataDir}/backups:/var/azuracast/backups:rw"
+        "${cfg.dataDir}/db:/var/lib/mysql:rw"
+        "${cfg.dataDir}/uploads:/var/azuracast/storage/uploads:rw"
+        "${cfg.dataDir}/shoutcast2:/var/azuracast/storage/shoutcast2:rw"
+        "${cfg.dataDir}/stereo_tool:/var/azuracast/storage/stereo_tool:rw"
+        "${cfg.dataDir}/rsas:/var/azuracast/storage/rsas:rw"
+        "${cfg.dataDir}/geoip:/var/azuracast/storage/geoip:rw"
+        "${cfg.dataDir}/sftpgo:/var/azuracast/storage/sftpgo:rw"
+        "${cfg.dataDir}/acme:/var/azuracast/storage/acme:rw"
+      ];
+      ports = [
+        "${toString cfg.httpPort}:${toString cfg.httpPort}/tcp"
+        "${toString cfg.sftpPort}:${toString cfg.sftpPort}/tcp"
+      ] ++ map (p: "${toString p}:${toString p}/tcp") (range cfg.stationPortMin cfg.stationPortMax);
+      log-driver = "journald";
+      extraOptions = [
+        "--network-alias=azuracast"
+        "--network=azuracast_default"
+        "--ulimit=nofile=65536:65536"
+      ];
+    };
+
+    systemd.services."docker-azuracast" = {
+      serviceConfig = {
+        Restart = lib.mkOverride 500 "always";
+        RestartMaxDelaySec = lib.mkOverride 500 "1m";
+        RestartSec = lib.mkOverride 500 "100ms";
+        RestartSteps = lib.mkOverride 500 9;
+      };
+      after = [ "docker-network-azuracast_default.service" ];
+      requires = [ "docker-network-azuracast_default.service" ];
+      partOf = [ "docker-compose-azuracast-root.target" ];
+      wantedBy = [ "docker-compose-azuracast-root.target" ];
+    };
+
+    systemd.services."docker-network-azuracast_default" = {
+      path = [ pkgs.docker ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStop = "${pkgs.docker}/bin/docker network rm -f azuracast_default";
+      };
+      script = ''
+        docker network inspect azuracast_default || docker network create azuracast_default
+      '';
+      partOf = [ "docker-compose-azuracast-root.target" ];
+      wantedBy = [ "docker-compose-azuracast-root.target" ];
+    };
+
+    systemd.targets."docker-compose-azuracast-root" = {
+      unitConfig = {
+        Description = "AzuraCast Docker services";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    # Same backend serves both the admin UI and the public radio/player pages.
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.httpPort;
+      serverAliases = [ cfg.radioDomain ];
+      displayName = "AzuraCast";
+      category = "media";
+      icon = "azuracast";
+    };
+  };
+}

--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -2,6 +2,7 @@
 {
   # Import media service modules
   imports = [
+    ./azuracast.nix
     ./beets.nix
     ./feishin.nix
     ./immich.nix


### PR DESCRIPTION
## Summary

Adds an AzuraCast module for internet radio station hosting, integrated with the existing media stack.

- New module: `modules/services/media/azuracast.nix` (docker-based, single all-in-one image — nginx/PHP/MariaDB/Redis/streaming engines all run in one container)
- Enabled on david, claims both `azuracast.theyoder.family` (admin UI) and `radio.theyoder.family` (public player) via vHosts `serverAliases`, both proxying to the same backend
- Station streaming port range moved to 9500-9599 (AzuraCast's stock 8000-8496 default collides with Jellyfin's 8096)
- Read-only bind mounts of the existing `/data/media/{Music,Podcasts,Audiobooks}` library into the container, so stations can be pointed at it as an AzuraCast Storage Location without duplicating files or requiring separate uploads. Read-only to avoid AzuraCast's media manager reorganizing files that beets/Jellyfin already manage.

Two bugs surfaced and fixed during live testing on david (see below):
- Bundled MariaDB needs an explicit root-password env var on first boot (`MYSQL_RANDOM_ROOT_PASSWORD`) — AzuraCast's own installer sets this by default, but we're not using that installer.
- AzuraCast's startup scripts chown `/var/azuracast/storage/*` each boot but not `stations/` or `backups/`; those need to be pre-owned to the container's PUID/PGID or the app can't write to them during setup.

## Test plan

- [x] `nixos-rebuild build` against david over SSH — succeeded
- [x] `nixos-rebuild switch` on david — activated, hit the two bugs above, fixed both, re-switched clean
- [x] Confirmed Caddyfile contains `azuracast.theyoder.family radio.theyoder.family { ... reverse_proxy http://localhost:6580 }`
- [x] Confirmed the container's docker run script includes the three read-only media bind mounts
- [x] `curl -I https://azuracast.theyoder.family/` and `https://radio.theyoder.family/` both return `302 → /setup` through Caddy
- [x] MariaDB starts clean with no errors, `startup` process exits 0
- [ ] Manually complete the AzuraCast setup wizard and create Storage Locations pointing at the mounted media paths