### PR TITLE
feat: DNS-only A records for Home Assistant / Music Assistant

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -181,6 +181,26 @@ in
     monitor = false; # runs on workstation, not always reachable
   };
 
+  # Home Assistant - runs on a separate device on the LAN.
+  # DNS-only (A record); no Caddy reverse proxy, so casting/discovery/local
+  # network features keep working and outages here can't take david's proxy down.
+  modules.services.vHosts.hosts."home.${config.networking.domain}" = {
+    ipAddress = "10.150.2.117";
+    serverAliases = [ "ha.${config.networking.domain}" "house.${config.networking.domain}" ];
+    displayName = "Home Assistant";
+    category = "home-automation";
+    icon = "home-assistant";
+  };
+
+  # Music Assistant - runs on the same device as Home Assistant. DNS-only, no reverse proxy.
+  modules.services.vHosts.hosts."ma.${config.networking.domain}" = {
+    ipAddress = "10.150.2.117";
+    serverAliases = [ "musicassistant.${config.networking.domain}" ];
+    displayName = "Music Assistant";
+    category = "media";
+    icon = "music-assistant";
+  };
+
   # =============================================================================
   # AI — each service enabled via profiles/server.nix (mkDefault true)
   # =============================================================================

--- a/modules/services/infrastructure/caddy.nix
+++ b/modules/services/infrastructure/caddy.nix
@@ -97,7 +97,8 @@ in
             else
               "${if hostCfg.reverseProxySSL then "https" else "http"}://${hostCfg.reverseProxyHost}:${toString hostCfg.reverseProxyPort}";
         in
-        mkIf hostCfg.enable {
+        # ipAddress vHosts are DNS-only (device handles its own TLS/serving); skip Caddy entirely
+        mkIf (hostCfg.enable && hostCfg.ipAddress == null) {
           "${hostCfg.virtualHost}" = {
             serverAliases = hostCfg.serverAliases;
             extraConfig =

--- a/modules/services/providers/dns-technitium.nix
+++ b/modules/services/providers/dns-technitium.nix
@@ -55,9 +55,17 @@ in
       # Collect vHosts from service modules — filter to DNS-enabled, active hosts
       # Include serverAliases so every domain served gets a record
       allVHosts       = filter (h: h.enable && h.dnsRecord) (attrValues config.modules.services.vHosts.hosts);
-      internalDomains = concatMap (h: normalizeDomains h.virtualHost ++ h.serverAliases) (filter (h: !h.public) allVHosts);
-      publicDomains   = concatMap (h: normalizeDomains h.virtualHost ++ h.serverAliases) (filter (h:  h.public) allVHosts);
+      cnameVHosts     = filter (h: h.ipAddress == null) allVHosts;
+      aRecordVHosts   = filter (h: h.ipAddress != null) allVHosts;
+
+      internalDomains = concatMap (h: normalizeDomains h.virtualHost ++ h.serverAliases) (filter (h: !h.public) cnameVHosts);
+      publicDomains   = concatMap (h: normalizeDomains h.virtualHost ++ h.serverAliases) (filter (h:  h.public) cnameVHosts);
       allDomains      = internalDomains ++ publicDomains;
+
+      # domain|ip pairs for vHosts that point directly at an external IP
+      aRecordEntries  = concatMap
+        (h: map (d: "${d}|${h.ipAddress}") (normalizeDomains h.virtualHost ++ h.serverAliases))
+        aRecordVHosts;
 
       # Generate a bash array body from a list of domain strings
       toBashArray = domains:
@@ -162,6 +170,41 @@ in
           fi
         }
 
+        technitium_add_a() {
+          local domain="$1" ip="$2" zone
+          zone=$(find_zone "$domain")
+          if [ -z "$zone" ]; then
+            echo "  + $domain -> $ip (no zone found — creating)"
+            zone=$(create_zone "$domain")
+          else
+            echo "  + $domain -> $ip"
+          fi
+          $CURL --retry 5 --retry-delay 3 --retry-connrefused -sfG \
+            --data-urlencode "token=$TOKEN" \
+            --data-urlencode "domain=$domain" \
+            --data-urlencode "zone=$zone" \
+            --data-urlencode "type=A" \
+            --data-urlencode "ipAddress=$ip" \
+            --data-urlencode "overwrite=true" \
+            --data-urlencode "comments=$COMMENT" \
+            "$TECHNITIUM_URL/api/zones/records/add" \
+            | $JQ -r 'if .status == "ok" then "    ok (A)" else "    error: \(.errorMessage)" end' || true
+        }
+
+        technitium_delete_a() {
+          local domain="$1" zone
+          zone=$(find_zone "$domain")
+          [ -z "$zone" ] && return
+          echo "  - $domain (stale A record)"
+          $CURL --retry 3 --retry-delay 2 -sfG \
+            --data-urlencode "token=$TOKEN" \
+            --data-urlencode "domain=$domain" \
+            --data-urlencode "zone=$zone" \
+            --data-urlencode "type=A" \
+            "$TECHNITIUM_URL/api/zones/records/delete" \
+            | $JQ -r 'if .status == "ok" then "    removed" else "    error: \(.errorMessage)" end' || true
+        }
+
         technitium_delete() {
           local domain="$1" zone record_type
           zone=$(find_zone "$domain")
@@ -192,15 +235,36 @@ in
         ${toBashArray publicDomains}
         )
 
+        # "domain|ip" pairs for vHosts pointing directly at an external IP
+        A_RECORD_PAIRS=(
+        ${toBashArray aRecordEntries}
+        )
+
         ALL_DOMAINS=()
         for d in "''${INTERNAL_DOMAINS[@]-}"; do [ -n "$d" ] && ALL_DOMAINS+=("$d"); done
         for d in "''${PUBLIC_DOMAINS[@]-}" ; do [ -n "$d" ] && ALL_DOMAINS+=("$d"); done
 
-        # --- Level 1: Register CNAMEs in Technitium ---
+        # "domain|kind" entries actually registered this run, for stale-cleanup diffing
+        REGISTERED=()
+
+        # --- Level 1: Register CNAME/ANAME records in Technitium ---
 
         echo "=== dns-sync: registering records -> $TARGET ==="
         for d in "''${ALL_DOMAINS[@]-}"; do
-          [ -n "$d" ] && technitium_add "$d"
+          [ -z "$d" ] && continue
+          technitium_add "$d"
+          REGISTERED+=("$d|cname")
+        done
+
+        # --- Level 1b: Register direct A records ---
+
+        echo "=== dns-sync: registering direct A records ==="
+        for pair in "''${A_RECORD_PAIRS[@]-}"; do
+          [ -z "$pair" ] && continue
+          domain="''${pair%%|*}"
+          ip="''${pair#*|}"
+          technitium_add_a "$domain" "$ip"
+          REGISTERED+=("$domain|a")
         done
 
         # --- Level 2: Declarative removal of stale records ---
@@ -208,14 +272,22 @@ in
         mkdir -p "$(dirname "$STATE_FILE")"
         if [ -f "$STATE_FILE" ]; then
           echo "=== dns-sync: checking for stale records ==="
-          while IFS= read -r d; do
-            [ -z "$d" ] && continue
-            if ! printf '%s\n' "''${ALL_DOMAINS[@]-}" | grep -qxF "$d"; then
-              technitium_delete "$d"
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            domain="''${line%%|*}"
+            kind="''${line#*|}"
+            # legacy state file entries have no "|kind" suffix — they're all cname
+            [ "$kind" = "$line" ] && kind="cname"
+            if ! printf '%s\n' "''${REGISTERED[@]-}" | grep -qxF "$domain|$kind"; then
+              if [ "$kind" = "a" ]; then
+                technitium_delete_a "$domain"
+              else
+                technitium_delete "$domain"
+              fi
             fi
           done < "$STATE_FILE"
         fi
-        printf '%s\n' "''${ALL_DOMAINS[@]-}" > "$STATE_FILE"
+        printf '%s\n' "''${REGISTERED[@]-}" > "$STATE_FILE"
 
         echo "=== dns-sync: complete ==="
       '';

--- a/modules/services/providers/monitoring.nix
+++ b/modules/services/providers/monitoring.nix
@@ -20,9 +20,13 @@ let
     ];
   }) monitoredHosts;
 
-  # /etc/hosts entries so Gatus resolves internal vHost domains to localhost
-  # (Caddy listens on 0.0.0.0:443 with per-domain TLS, so this works for all)
-  extraHostsEntries = concatMapStrings (h: "127.0.0.1 ${h.virtualHost}\n") monitoredHosts;
+  # /etc/hosts entries so Gatus can resolve vHost domains without relying on
+  # Technitium as the system resolver (david's system resolver stays 1.1.1.1).
+  # Caddy-managed vHosts resolve to localhost; ipAddress vHosts resolve straight
+  # to the external device so the check hits it, not this host.
+  extraHostsEntries = concatMapStrings
+    (h: "${if h.ipAddress != null then h.ipAddress else "127.0.0.1"} ${h.virtualHost}\n")
+    monitoredHosts;
 in
 {
   options.modules.services.providers.monitoring = {

--- a/modules/services/vhosts.nix
+++ b/modules/services/vhosts.nix
@@ -29,12 +29,24 @@ in
 
   options.modules.services.vHosts = {
     hosts = mkOption {
-      type = types.attrsOf (types.submodule ({ name, ... }: {
+      type = types.attrsOf (types.submodule ({ name, config, ... }: {
         options = {
           enable = mkOption {
             type = types.bool;
             default = true;
             description = "Whether to create this virtual host.";
+          };
+
+          ipAddress = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              External IP address this vHost's DNS records should point to
+              directly (A record), instead of a CNAME/ANAME to this host.
+              When set, this vHost is DNS-only: Caddy does not create a
+              reverse proxy or manage TLS for it (the device at this IP is
+              expected to handle its own requests/TLS).
+            '';
           };
 
           virtualHost = mkOption {
@@ -145,7 +157,7 @@ in
 
           localHostsEntry = mkOption {
             type = types.bool;
-            default = true;
+            default = config.ipAddress == null;
             description = "Whether to add a 127.0.0.1 /etc/hosts entry for this virtual host so on-host services can resolve it without Technitium.";
           };
         };


### PR DESCRIPTION
## Summary
- Adds an `ipAddress` option to the vHosts schema for entries that should get a direct A record instead of a CNAME/ANAME to this host — Caddy skips reverse-proxying these entirely.
- Registers `home`/`ha`/`house` (Home Assistant) and `ma`/`musicassistant` (Music Assistant), all pointing at 10.150.2.117.
- Monitoring's `/etc/hosts` mapping now points `ipAddress` vHosts at the real device instead of localhost, so Gatus checks actually hit the device.

## Test plan
- [ ] CI matrix passes (dry-run against all hosts)
- [ ] After merge, verify Technitium creates A records for home/ha/house/ma/musicassistant -> 10.150.2.117
- [ ] Verify Home Assistant / Music Assistant dashboard tiles + Gatus checks come up green