### PR TITLE
feat: add My Daily Discovery AzuraCast station and playlist sync

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -87,6 +87,17 @@ in
   # AzuraCast - Internet radio station management (azuracast.* admin, radio.* public player)
   modules.services.media.azuracast.enable = true;
 
+  # AzuraCast "My Daily Discovery" playlist sync - the source M3U regenerates daily,
+  # so re-import it into the station playlist every morning after it's refreshed.
+  modules.services.media.azuracastPlaylistSync = {
+    enable = true;
+    apiKeyFile = config.age.secrets.azuracast-api-key.path;
+    stationShortName = "my_daily_discovery";
+    playlistName = "Daily Discovery";
+    m3uFile = "/data/media/Music/m3u/playlist/My Daily Discovery.m3u";
+    schedule = "04:00";
+  };
+
   # Beets - Auto-organize music library from Downloads into Music
   modules.services.media.beets.enable = true;
 

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -128,5 +128,10 @@ with lib;
       "jellyfin-api-key" = { file = ../secrets/jellyfin-api-key.age; mode = "0400"; };
     })
 
+    // (optionalAttrs config.modules.services.media.azuracastPlaylistSync.enable {
+      # Encrypted to davidKeys only
+      "azuracast-api-key" = { file = ../secrets/azuracast-api-key.age; mode = "0400"; };
+    })
+
     ;
 }

--- a/modules/services/media/azuracast-playlist-sync.nix
+++ b/modules/services/media/azuracast-playlist-sync.nix
@@ -1,0 +1,112 @@
+# Keeps an AzuraCast "songs" playlist in sync with a daily-regenerated M3U file
+# (e.g. a Plexamp/Jellyfin "Daily Discovery" mix). AzuraCast's own playlist
+# import matches files by path relative to the station's media storage root,
+# so the M3U (which contains absolute host paths under musicLibrary) has its
+# prefix stripped before being uploaded.
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.azuracastPlaylistSync;
+in
+{
+  options.modules.services.media.azuracastPlaylistSync = {
+    enable = mkEnableOption "Daily AzuraCast playlist sync from an M3U file";
+
+    azuracastUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:${toString config.modules.services.media.azuracast.httpPort}";
+      description = "Base URL of the AzuraCast API";
+    };
+
+    apiKeyFile = mkOption {
+      type = types.str;
+      description = "Path to a file containing the AzuraCast API key";
+    };
+
+    stationShortName = mkOption {
+      type = types.str;
+      description = "Short name (shortcode) of the AzuraCast station to update";
+    };
+
+    playlistName = mkOption {
+      type = types.str;
+      description = "Name of the station playlist to replace with the M3U's contents";
+    };
+
+    m3uFile = mkOption {
+      type = types.str;
+      description = "Path to the source M3U file (updated externally, e.g. daily by Plexamp/Jellyfin)";
+    };
+
+    musicLibrary = mkOption {
+      type = types.str;
+      default = "/data/media/Music";
+      description = ''
+        Root of the music library as referenced by paths inside m3uFile. Stripped
+        from each entry so the remainder matches the path relative to the
+        station's media storage location root.
+      '';
+    };
+
+    schedule = mkOption {
+      type = types.str;
+      default = "04:00";
+      description = "systemd OnCalendar expression for when to run the sync";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.azuracast-playlist-sync = {
+      description = "Sync AzuraCast playlist '${cfg.playlistName}' from ${cfg.m3uFile}";
+      after = [ "network-online.target" "docker-azuracast.service" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "azuracast-playlist-sync" ''
+          set -euo pipefail
+          URL="${cfg.azuracastUrl}"
+          API_KEY=$(cat "${cfg.apiKeyFile}")
+          RELATIVE_M3U=$(mktemp)
+          trap 'rm -f "$RELATIVE_M3U"' EXIT
+
+          STATION_ID=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $API_KEY" "$URL/api/admin/stations" \
+            | ${pkgs.jq}/bin/jq -r --arg name "${cfg.stationShortName}" '.[] | select(.short_name == $name) | .id')
+          if [ -z "$STATION_ID" ]; then
+            echo "Error: station '${cfg.stationShortName}' not found" >&2
+            exit 1
+          fi
+
+          PLAYLIST_ID=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $API_KEY" "$URL/api/station/$STATION_ID/playlists" \
+            | ${pkgs.jq}/bin/jq -r --arg name "${cfg.playlistName}" '.[] | select(.name == $name) | .id')
+          if [ -z "$PLAYLIST_ID" ]; then
+            echo "Error: playlist '${cfg.playlistName}' not found on station ${cfg.stationShortName}" >&2
+            exit 1
+          fi
+
+          ${pkgs.gnused}/bin/sed "s|^${cfg.musicLibrary}/||" "${cfg.m3uFile}" > "$RELATIVE_M3U"
+
+          echo "Emptying playlist $PLAYLIST_ID..."
+          ${pkgs.curl}/bin/curl -sf -X PUT -H "X-API-Key: $API_KEY" \
+            "$URL/api/station/$STATION_ID/playlist/$PLAYLIST_ID/empty" > /dev/null
+
+          echo "Importing ${cfg.m3uFile}..."
+          RESULT=$(${pkgs.curl}/bin/curl -sf -X POST -H "X-API-Key: $API_KEY" \
+            -F "playlist_file=@$RELATIVE_M3U" \
+            "$URL/api/station/$STATION_ID/playlist/$PLAYLIST_ID/import")
+          echo "$RESULT" | ${pkgs.jq}/bin/jq -r '.formatted_message // .message'
+        '';
+      };
+    };
+
+    systemd.timers.azuracast-playlist-sync = {
+      description = "Daily AzuraCast playlist sync from ${cfg.m3uFile}";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.schedule;
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -3,6 +3,7 @@
   # Import media service modules
   imports = [
     ./azuracast.nix
+    ./azuracast-playlist-sync.nix
     ./beets.nix
     ./feishin.nix
     ./immich.nix

--- a/secrets/azuracast-api-key.age
+++ b/secrets/azuracast-api-key.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw QxSLoaUfAu/B8EXdgJ+BJ/cHSDSvoTiLdVWcPjs2WR0
+PGfZJTkpQbSlYoXL0r0Qx1Pv9bh9uQixKoPsjsQWcSc
+-> ssh-ed25519 G/hviA x/nmje1lx8CboVALxj2rKpgFUI4gVhiTpg2qBlZyrH4
+zhvGU1ZftId4H9T/jvU7RR86L5DbJgep448OhVpmQpg
+--- QTZlDkWCjoS6OYfS+loPB/18sNuqYzwHv08bBCjBJ58
+ี0ฯqั|ดrชาGไu4๕QVyIถ?ฦฅNฌ{ํำ^ ]๓ดÞ3ข+0ฎ€มGmÛ eต.ุF-ฝ ขcุÜ๑Q


### PR DESCRIPTION
## Summary
- Creates a station_media storage location and station in AzuraCast pointing at the shared Music library (done live via the AzuraCast API, not part of this diff)
- Adds modules/services/media/azuracast-playlist-sync.nix: daily systemd timer that empties and re-imports the "Daily Discovery" playlist from the source M3U file
- Wires the module into hosts/david/configuration.nix with an agenix-encrypted API key

## Test plan
- [ ] CI test-nixos-config passes for david
- [ ] After merge + rebuild on david, confirm azuracast-playlist-sync.timer is active and the playlist populates once AzuraCast finishes its background media backlog