### PR TITLE
fix: add npm to n8n systemd PATH for community node installs

### DIFF
--- a/modules/services/productivity/n8n.nix
+++ b/modules/services/productivity/n8n.nix
@@ -43,6 +43,12 @@ in
       environment.WEBHOOK_URL = "https://${cfg.domain}";
     };
 
+    # Community node installs shell out to `npm install`. The systemd unit's
+    # PATH otherwise has no npm/node, so that install fails with
+    # "spawn npm ENOENT". Use nodejs from the same channel as n8n itself
+    # to avoid a node/npm version mismatch against n8n's bundled node_modules.
+    systemd.services.n8n.path = [ unstable.nodejs ];
+
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = 5678;


### PR DESCRIPTION
## Summary
- n8n's "install community node" UI feature shells out to `npm install`, but the systemd unit's PATH has no npm/node, causing `spawn npm ENOENT`
- Adds `unstable.nodejs` (same channel n8n is built from) to `systemd.services.n8n.path` so npm is resolvable

## Test plan
- [ ] CI dry-run passes for david
- [ ] After merge + rebuild, retry installing a community node (e.g. @renebello/n8n-nodes-azuracast) from the n8n UI