### PR TITLE
feat: auto-create AzuraCast stations from m3u files

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -87,6 +87,13 @@ in
   # AzuraCast - Internet radio station management (azuracast.* admin, radio.* public player)
   modules.services.media.azuracast.enable = true;
 
+  # Auto-create an AzuraCast station for each m3u file (Plexamp/Jellyfin mixes)
+  # dropped into the shared m3u/playlist folder
+  modules.services.media.azuracastPlaylistStations = {
+    enable = true;
+    apiKeyFile = config.age.secrets.azuracast-api-key.path;
+  };
+
   # Beets - Auto-organize music library from Downloads into Music
   modules.services.media.beets.enable = true;
 

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -128,5 +128,10 @@ with lib;
       "jellyfin-api-key" = { file = ../secrets/jellyfin-api-key.age; mode = "0400"; };
     })
 
+    // (optionalAttrs config.modules.services.media.azuracastPlaylistStations.enable {
+      # Encrypted to davidKeys only
+      "azuracast-api-key" = { file = ../secrets/azuracast-api-key.age; mode = "0400"; };
+    })
+
     ;
 }

--- a/modules/services/media/azuracast-playlist-stations.nix
+++ b/modules/services/media/azuracast-playlist-stations.nix
@@ -1,0 +1,130 @@
+# Auto-provisions an AzuraCast station for every m3u file in a directory
+# (e.g. Plexamp/Jellyfin-generated mixes). Each station's auto-created
+# "default" playlist is switched to a remote_url/playlist source pointing
+# straight at the m3u file, so Liquidsoap streams it directly - no AzuraCast
+# media-library scan involved, and it picks up daily file regeneration on its
+# own via Liquidsoap's file-watch reload. See azuracast.nix for why the
+# container mounts each library at the same absolute path as the host (so
+# these paths resolve with no rewriting).
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.media.azuracastPlaylistStations;
+in
+{
+  options.modules.services.media.azuracastPlaylistStations = {
+    enable = mkEnableOption "Auto-create AzuraCast stations from m3u files in a directory";
+
+    azuracastUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:${toString config.modules.services.media.azuracast.httpPort}";
+      description = "Base URL of the AzuraCast API";
+    };
+
+    apiKeyFile = mkOption {
+      type = types.str;
+      description = "Path to a file containing the AzuraCast API key";
+    };
+
+    m3uDir = mkOption {
+      type = types.str;
+      default = "/data/media/Music/m3u/playlist";
+      description = "Directory scanned for m3u files. Each one becomes its own station.";
+    };
+
+    excludeFiles = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "m3u file names (as they appear in m3uDir, including .m3u extension) to skip.";
+    };
+
+    schedule = mkOption {
+      type = types.str;
+      default = "hourly";
+      description = "systemd OnCalendar expression for how often to scan for new m3u files";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.azuracast-playlist-stations = {
+      description = "Create AzuraCast stations for any new m3u file in ${cfg.m3uDir}";
+      after = [ "network-online.target" "docker-azuracast.service" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "azuracast-playlist-stations" ''
+          set -euo pipefail
+          URL="${cfg.azuracastUrl}"
+          API_KEY=$(cat "${cfg.apiKeyFile}")
+
+          existing_shortnames=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $API_KEY" "$URL/api/admin/stations" \
+            | ${pkgs.jq}/bin/jq -r '.[].short_name')
+
+          shopt -s nullglob
+          for file in "${cfg.m3uDir}"/*.m3u "${cfg.m3uDir}"/*.M3U; do
+            base="$(basename "$file")"
+
+            skip=false
+            for excl in ${concatStringsSep " " (map lib.escapeShellArg cfg.excludeFiles)}; do
+              if [ "$base" = "$excl" ]; then
+                skip=true
+                break
+              fi
+            done
+            if [ "$skip" = true ]; then
+              continue
+            fi
+
+            name="''${base%.*}"
+            shortname=$(echo "$name" | ${pkgs.coreutils}/bin/tr '[:upper:]' '[:lower:]' \
+              | ${pkgs.gnused}/bin/sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//')
+
+            if echo "$existing_shortnames" | grep -qxF "$shortname"; then
+              continue
+            fi
+
+            echo "Creating AzuraCast station for new playlist: $name ($shortname)"
+
+            station_json=$(${pkgs.jq}/bin/jq -n --arg name "$name" --arg short_name "$shortname" \
+              '{name: $name, short_name: $short_name, frontend_type: "icecast", backend_type: "liquidsoap", is_enabled: true, enable_public_page: true}')
+
+            station_id=$(${pkgs.curl}/bin/curl -sf -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+              -d "$station_json" "$URL/api/admin/stations" | ${pkgs.jq}/bin/jq -r '.id')
+
+            if [ -z "$station_id" ] || [ "$station_id" = "null" ]; then
+              echo "Error: failed to create station for $name" >&2
+              continue
+            fi
+
+            playlist_id=$(${pkgs.curl}/bin/curl -sf -H "X-API-Key: $API_KEY" "$URL/api/station/$station_id/playlists" \
+              | ${pkgs.jq}/bin/jq -r '.[] | select(.name == "default") | .id')
+
+            playlist_json=$(${pkgs.jq}/bin/jq -n --arg url "$file" \
+              '{source: "remote_url", remote_type: "playlist", remote_url: $url}')
+
+            ${pkgs.curl}/bin/curl -sf -X PUT -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+              -d "$playlist_json" "$URL/api/station/$station_id/playlist/$playlist_id" > /dev/null
+
+            ${pkgs.curl}/bin/curl -sf -X POST -H "X-API-Key: $API_KEY" "$URL/api/station/$station_id/restart" > /dev/null
+
+            echo "Station '$name' created and streaming from $file"
+
+            existing_shortnames="$existing_shortnames"$'\n'"$shortname"
+          done
+        '';
+      };
+    };
+
+    systemd.timers.azuracast-playlist-stations = {
+      description = "Periodic scan for new m3u files in ${cfg.m3uDir}";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.schedule;
+        OnBootSec = "5m";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/modules/services/media/default.nix
+++ b/modules/services/media/default.nix
@@ -3,6 +3,7 @@
   # Import media service modules
   imports = [
     ./azuracast.nix
+    ./azuracast-playlist-stations.nix
     ./beets.nix
     ./feishin.nix
     ./immich.nix

--- a/secrets/azuracast-api-key.age
+++ b/secrets/azuracast-api-key.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw ZeRjV+VCJRr/11igv0fSQpgasT1dUnNbB+UMUFhCOTg
+lnK9jU2XCu5sqkeD2ASTW7lD0WYwlGgTpRsyqT8hx3U
+-> ssh-ed25519 G/hviA 6IMBV2ioBB/Up7w+eiXhgRyibfHXRmEnCXw+WyQ3eT8
+KBK+ui7ee+Z4HqLGDhuBwmIB44nsU+cWQqOGw84BUo8
+--- SUnrGAxH4iCvQXbRpHyE6PFge0Ei60XKXwYJmOr11BM
+E¤Έ`‚azΟ®ϋf§o(΅ƒε;7(ÿL”ήM‹Η_[a_Ή°H—†«Ν>ασEνθϋχsΨZΜYΫ°AυYώziσ
+‚Β;ΛΎr0¶„


### PR DESCRIPTION
## Summary
- Adds `modules/services/media/azuracast-playlist-stations.nix`: an hourly systemd timer that scans `/data/media/Music/m3u/playlist/` and creates a new AzuraCast station for any m3u file that doesn't already have one (matched by slugified filename against existing station short_names).
- Each new station's auto-created "default" playlist is switched to `remote_url`/`playlist` source pointing directly at the m3u file - same approach validated for the Daily Discovery station in #262, so no AzuraCast media-library scan involved and it auto-refreshes on file changes.
- Idempotent - re-running only touches files without a matching station yet, so it's safe to run hourly indefinitely.
- First run will create ~9 new stations for the m3u files already in the folder (My Mix 1-8, Soundcheck), per user confirmation.

## Test plan
- [x] `nixos-rebuild dry-run` against this branch on david - only the new `azuracast-playlist-stations` service/timer units appear
- [ ] After merge + deploy, manually trigger `azuracast-playlist-stations.service` once and confirm all 9 remaining m3u files get stations