### PR TITLE
fix: widen AzuraCast station port range (10 ports/station, not 3)

### DIFF
--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -53,10 +53,16 @@ in
 
     stationPortMax = mkOption {
       type = types.port;
-      default = 9599;
+      default = 9689;
       description = ''
-        Upper bound of the station port range. 100 ports supports up to ~33
-        stations (3 ports each); widen if more are needed.
+        Upper bound of the station port range. AzuraCast reserves a full
+        10-port block per station (frontend/telnet/dj/headroom), not just the
+        3 ports actually bound - confirmed empirically once 10 stations
+        exhausted a 100-port range. Capped at 9689 (rather than rounding up
+        to 9699+) because 9696 and 9980 are already bound by an unrelated
+        docker-proxy on this host; going past 9689 would eventually collide
+        with the 9690-9699 block. Widen further only after checking
+        `ss -tulpn` for occupied ports first.
       '';
     };
 

--- a/modules/services/media/azuracast.nix
+++ b/modules/services/media/azuracast.nix
@@ -42,27 +42,27 @@ in
 
     stationPortMin = mkOption {
       type = types.port;
-      default = 9500;
+      default = 23000;
       description = ''
         Lower bound of the port range auto-assigned to radio stations
         (Icecast/Shoutcast direct-connect streaming ports). AzuraCast's own
-        default range (8000-8496) collides with Jellyfin (8096) on this host,
-        so this uses a dedicated range instead.
+        default range (8000-8496) collides with Jellyfin (8096) on this host.
+        23000-24999 sits in a large confirmed-empty gap on david (nothing
+        bound between 22000 and 28492 per `ss -tulpn`), well clear of every
+        other service's port range instead of just squeezed next to them.
       '';
     };
 
     stationPortMax = mkOption {
       type = types.port;
-      default = 9689;
+      default = 24999;
       description = ''
         Upper bound of the station port range. AzuraCast reserves a full
         10-port block per station (frontend/telnet/dj/headroom), not just the
-        3 ports actually bound - confirmed empirically once 10 stations
-        exhausted a 100-port range. Capped at 9689 (rather than rounding up
-        to 9699+) because 9696 and 9980 are already bound by an unrelated
-        docker-proxy on this host; going past 9689 would eventually collide
-        with the 9690-9699 block. Widen further only after checking
-        `ss -tulpn` for occupied ports first.
+        3 ports actually bound - confirmed empirically when 10 stations
+        exhausted the previous 100-port range. 2000 ports here supports 200
+        stations. Widen further only after checking `ss -tulpn` for occupied
+        ports first - don't just round up blindly.
       '';
     };
 


### PR DESCRIPTION
## Summary
- Testing the m3u-station autosync from #264 found AzuraCast reserves a full 10-port block per station (frontend/telnet/dj/headroom), not 3 as the original comment assumed. 10 stations exactly filled the 100-port 9500-9599 range, so the 11th (Soundcheck) failed with "no available ports for new radio stations."
- Moves the whole range to 23000-24999 rather than just widening next to the old one - `ss -tulpn` showed nothing bound between 22000 and 28492 on david, a clean gap far from every other service instead of squeezed next to 9696/9980.
- Note: the 10 already-created stations keep their existing 9500s-range ports in AzuraCast's own DB; only *new* stations going forward get ports from 23000-24999. The old direct-connect icecast ports for those stations won't be Docker-published anymore, but nothing here uses direct source/icecast connections (no live streamers enabled) - public listening goes through Caddy -> AzuraCast's own httpPort regardless of station, so this doesn't affect listening.

## Test plan
- [x] `nixos-rebuild dry-run` against this branch on david - only `docker-azuracast` changes
- [ ] After merge + deploy, confirm the azuracast-playlist-stations timer successfully creates the Soundcheck station on its next run, with a port in 23000-24999