### PR TITLE
fix: n8n community node install needs tar in PATH

### DIFF
--- a/modules/services/productivity/n8n.nix
+++ b/modules/services/productivity/n8n.nix
@@ -43,11 +43,12 @@ in
       environment.WEBHOOK_URL = "https://${cfg.domain}";
     };
 
-    # Community node installs shell out to `npm install`. The systemd unit's
-    # PATH otherwise has no npm/node, so that install fails with
-    # "spawn npm ENOENT". Use nodejs from the same channel as n8n itself
-    # to avoid a node/npm version mismatch against n8n's bundled node_modules.
-    systemd.services.n8n.path = [ unstable.nodejs ];
+    # Community node installs shell out to `npm install`, which in turn
+    # spawns `tar` to unpack the downloaded package. The systemd unit's PATH
+    # otherwise has neither, causing "spawn npm ENOENT" then "spawn tar ENOENT".
+    # Use nodejs from the same channel as n8n itself to avoid a node/npm
+    # version mismatch against n8n's bundled node_modules.
+    systemd.services.n8n.path = [ unstable.nodejs pkgs.gnutar ];
 
     # Caddy virtual host
     modules.services.vHosts.hosts.${cfg.domain} = {


### PR DESCRIPTION
Follow-up to #263. After fixing the npm ENOENT issue, installing `@renebello/n8n-nodes-azuracast` now fails with `spawn tar ENOENT` — npm shells out to tar to unpack the package. Add gnutar to the same systemd path list.

Verified n8n was crash-looping in production from a leftover empty directory left by the prior failed install; that was cleaned up manually. This PR prevents the tar failure on retry.