### PR TITLE
feat: add Tidal music client for macOS and Linux desktop hosts

### DIFF
--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -11,6 +11,7 @@
   # macOS system packages
   environment.systemPackages = with pkgs; [
     feishin
+    tidal
     # Development tools
     git
     gh

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -34,7 +34,7 @@
   
   modules.services.infrastructure.tailscale.enable = lib.mkDefault true;
 
-  environment.systemPackages = [ pkgs.feishin pkgs.nmap ];
+  environment.systemPackages = [ pkgs.feishin pkgs.nmap pkgs.tidal-hifi ];
 
   # =============================================================================
   # BOOT SPLASH (desktop only - servers/edge are headless)


### PR DESCRIPTION
## Summary
- Add `pkgs.tidal` to profiles/darwin.nix (all macOS hosts) — darwin-only package
- Add `pkgs.tidal-hifi` to profiles/desktop.nix (Linux desktop/laptop hosts) — x86_64-linux only, all Linux hosts here are x86_64-linux

## Test plan
- [x] Parsed both files with nix-instantiate --parse
- [x] Confirmed pkgs.tidal supports x86_64-darwin/aarch64-darwin and pkgs.tidal-hifi supports x86_64-linux in the pinned nixos-26.05 nixpkgs