### PR TITLE
feat: mirror AzuraCast stations into Navidrome as Internet Radio Stations

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -88,10 +88,17 @@ in
   modules.services.media.azuracast.enable = true;
 
   # Auto-create an AzuraCast station for each m3u file (Plexamp/Jellyfin mixes)
-  # dropped into the shared m3u/playlist folder
+  # dropped into the shared m3u/playlist folder, and mirror every station into
+  # Navidrome as an Internet Radio Station
   modules.services.media.azuracastPlaylistStations = {
     enable = true;
     apiKeyFile = config.age.secrets.azuracast-api-key.path;
+
+    navidromeSync = {
+      enable = true;
+      user = "jonathan";
+      passwordFile = config.age.secrets.navidrome-api-password.path;
+    };
   };
 
   # Beets - Auto-organize music library from Downloads into Music

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -133,5 +133,10 @@ with lib;
       "azuracast-api-key" = { file = ../secrets/azuracast-api-key.age; mode = "0400"; };
     })
 
+    // (optionalAttrs config.modules.services.media.azuracastPlaylistStations.navidromeSync.enable {
+      # Encrypted to davidKeys only
+      "navidrome-api-password" = { file = ../secrets/navidrome-api-password.age; mode = "0400"; };
+    })
+
     ;
 }

--- a/modules/services/media/azuracast-playlist-stations.nix
+++ b/modules/services/media/azuracast-playlist-stations.nix
@@ -6,6 +6,10 @@
 # own via Liquidsoap's file-watch reload. See azuracast.nix for why the
 # container mounts each library at the same absolute path as the host (so
 # these paths resolve with no rewriting).
+#
+# Optionally also mirrors every AzuraCast station into Navidrome as an
+# Internet Radio Station (Subsonic API), matched by stream URL so it never
+# touches entries added/renamed by hand - it only fills in the ones missing.
 { config, lib, pkgs, ... }:
 
 with lib;
@@ -44,17 +48,38 @@ in
       default = "hourly";
       description = "systemd OnCalendar expression for how often to scan for new m3u files";
     };
+
+    navidromeSync = {
+      enable = mkEnableOption "Mirror every AzuraCast station into Navidrome as an Internet Radio Station";
+
+      url = mkOption {
+        type = types.str;
+        default = "http://localhost:${toString config.modules.services.media.navidrome.port}";
+        description = "Base URL of the Navidrome Subsonic API";
+      };
+
+      user = mkOption {
+        type = types.str;
+        description = "Navidrome username used to manage Internet Radio Stations. Must have the admin role.";
+      };
+
+      passwordFile = mkOption {
+        type = types.str;
+        description = "Path to a file containing that Navidrome user's password";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
     systemd.services.azuracast-playlist-stations = {
       description = "Create AzuraCast stations for any new m3u file in ${cfg.m3uDir}";
-      after = [ "network-online.target" "docker-azuracast.service" ];
+      after = [ "network-online.target" "docker-azuracast.service" ]
+        ++ optional cfg.navidromeSync.enable "navidrome.service";
       wants = [ "network-online.target" ];
 
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = pkgs.writeShellScript "azuracast-playlist-stations" ''
+        ExecStart = pkgs.writeShellScript "azuracast-playlist-stations" (''
           set -euo pipefail
           URL="${cfg.azuracastUrl}"
           API_KEY=$(cat "${cfg.apiKeyFile}")
@@ -113,7 +138,38 @@ in
 
             existing_shortnames="$existing_shortnames"$'\n'"$shortname"
           done
-        '';
+        ''
+        + optionalString cfg.navidromeSync.enable ''
+          NAV_URL="${cfg.navidromeSync.url}"
+          NAV_USER="${cfg.navidromeSync.user}"
+          NAV_PASS=$(cat "${cfg.navidromeSync.passwordFile}")
+          NAV_SALT=$(${pkgs.openssl}/bin/openssl rand -hex 6)
+          NAV_TOKEN=$(printf '%s%s' "$NAV_PASS" "$NAV_SALT" | ${pkgs.coreutils}/bin/md5sum | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+          nav_curl() {
+            ${pkgs.curl}/bin/curl -sf -G "$@" \
+              --data-urlencode "u=$NAV_USER" --data-urlencode "t=$NAV_TOKEN" --data-urlencode "s=$NAV_SALT" \
+              --data-urlencode "v=1.16.1" --data-urlencode "c=nix-config" --data-urlencode "f=json"
+          }
+
+          navidrome_stream_urls=$(nav_curl "$NAV_URL/rest/getInternetRadioStations.view" \
+            | ${pkgs.jq}/bin/jq -r '.["subsonic-response"].internetRadioStations.internetRadioStation[]?.streamUrl')
+
+          ${pkgs.curl}/bin/curl -sf "$URL/api/stations" | ${pkgs.jq}/bin/jq -c '.[]' | while read -r station; do
+            station_name=$(echo "$station" | ${pkgs.jq}/bin/jq -r '.name')
+            listen_url=$(echo "$station" | ${pkgs.jq}/bin/jq -r '.listen_url')
+
+            if [ -z "$listen_url" ] || [ "$listen_url" = "null" ]; then
+              continue
+            fi
+            if echo "$navidrome_stream_urls" | grep -qxF "$listen_url"; then
+              continue
+            fi
+
+            echo "Registering '$station_name' in Navidrome..."
+            nav_curl "$NAV_URL/rest/createInternetRadioStation.view" \
+              --data-urlencode "name=$station_name" --data-urlencode "streamUrl=$listen_url" > /dev/null
+          done
+        '');
       };
     };
 

--- a/secrets/navidrome-api-password.age
+++ b/secrets/navidrome-api-password.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw j1+QHMhRb25C06psJKOT6r4vi7iXt69TX/S5t3lk7n0
+hNGtsJkmBBkNIz+bzrS0FsnWHZqprmRKpK8fMnQwenM
+-> ssh-ed25519 G/hviA dQXI9RhDbomAkqIC/iM9dC2+k0rFH6WPaqF7q9lHsgs
+A/YUMqnDbicSU6DlCYrzccUc3H/sOZntf681or+/QcQ
+--- egp2Koi84hjupHq3aqJMerKqrWF/rrK082vTRkCpiJI
+»B)!ö˚Û–:Å•UÍG§v~œ∫¶akô<£c•ﬂ`Ú1PËÜd:˘às-1ÏH–


### PR DESCRIPTION
## Summary
- Extends `azuracast-playlist-stations` (from #264) with an optional `navidromeSync` step: after each scan, fetch AzuraCast's public station list and Navidrome's existing Internet Radio Stations via the Subsonic API, then create an entry for any AzuraCast station not already registered - matched by stream URL, so entries added or renamed by hand in Navidrome are left untouched.
- Uses the `jonathan` Navidrome account (confirmed admin role, required by the Subsonic `createInternetRadioStation` endpoint) - password encrypted to `secrets/navidrome-api-password.age` (david-only).
- Verified against production: `jonathan`'s Subsonic auth and admin role check out, and the existing 3 manually-added radio stations in Navidrome (2 of which are already our AzuraCast stations under different display names) confirm the URL-matching approach won't create duplicates.

## Test plan
- [x] `nixos-rebuild dry-run` against this branch on david - only the `azuracast-playlist-stations` service unit changes, docker-azuracast untouched
- [ ] After merge + deploy, trigger `azuracast-playlist-stations.service` and confirm the 9 stations missing from Navidrome (My Mix 1-8, Soundcheck) get added, and the 3 existing entries are left alone