### PR TITLE
feat: add passwordless guest kiosk account

### DIFF
--- a/hosts/tristons-nixbook-pro/configuration.nix
+++ b/hosts/tristons-nixbook-pro/configuration.nix
@@ -127,4 +127,7 @@
   ];
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
+
+  # Passwordless guest account -> locked-down kiosk browser at apps.theyoder.family
+  modules.system.guestKiosk.enable = true;
 }

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -88,4 +88,7 @@
   ];
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
+
+  # Passwordless guest account -> locked-down kiosk browser at apps.theyoder.family
+  modules.system.guestKiosk.enable = true;
 }

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -345,4 +345,7 @@
     # KDE/udisks auto-mounts the iPod; no manual mount needed
     autoMount = false;
   };
+
+  # Passwordless guest account -> locked-down kiosk browser at apps.theyoder.family
+  modules.system.guestKiosk.enable = true;
 }

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -8,6 +8,7 @@
     ./networking.nix
     ./users.nix
     ./desktop.nix
+    ./guest-kiosk.nix
     ./nix-cache.nix
   ];
 }

--- a/modules/system/guest-kiosk.nix
+++ b/modules/system/guest-kiosk.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.system.guestKiosk;
+
+  # cage is a Wayland compositor that runs a single fullscreen app with no
+  # window manager chrome and nothing else reachable -- exactly what a kiosk
+  # session needs. Firefox --kiosk hides the toolbar/tab bar/address bar.
+  kioskScript = pkgs.writeShellScript "guest-kiosk-start" ''
+    exec ${pkgs.cage}/bin/cage -- ${pkgs.firefox}/bin/firefox --kiosk "${cfg.url}"
+  '';
+
+  # Custom SDDM session, selectable from the greeter's session dropdown.
+  # providedSessions must list the .desktop basename -- required by the
+  # display-manager module to validate/link the session in.
+  kioskSessionPackage = pkgs.writeTextFile {
+    name = "guest-kiosk-session";
+    destination = "/share/wayland-sessions/guest-kiosk.desktop";
+    text = ''
+      [Desktop Entry]
+      Name=Guest (Kiosk)
+      Comment=Locked-down browser session for guests
+      Exec=${kioskScript}
+      Type=Application
+    '';
+  } // {
+    providedSessions = [ "guest-kiosk" ];
+  };
+in
+{
+  options.modules.system.guestKiosk = {
+    enable = mkEnableOption "Passwordless guest account that logs into a locked-down kiosk browser session";
+
+    url = mkOption {
+      type = types.str;
+      default = "https://apps.theyoder.family";
+      description = "URL the kiosk browser opens to on login.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.modules.system.desktop.enable;
+        message = "modules.system.guestKiosk.enable requires modules.system.desktop.enable (SDDM).";
+      }
+    ];
+
+    users.users.guest = {
+      isNormalUser = true;
+      description = "Guest";
+      hashedPassword = "";
+      createHome = true;
+      home = "/home/guest";
+    };
+
+    # Accounts with an empty password hash can log in with no password at the
+    # SDDM greeter / local console. Only "guest" (above) has an empty hash --
+    # every other account keeps a real password hash, so this doesn't weaken
+    # login for anyone else.
+    security.pam.services.login.allowNullPassword = true;
+
+    services.displayManager.sessionPackages = [ kioskSessionPackage ];
+  };
+}


### PR DESCRIPTION
## Summary
- New `guest` account with an empty password hash, selectable at the SDDM greeter with no password prompt
- Custom "Guest (Kiosk)" SDDM session running `cage` + `firefox --kiosk https://apps.theyoder.family` -- fullscreen browser, no desktop chrome, nothing else reachable
- `security.pam.services.login.allowNullPassword = true` scoped to accounts with an empty hash only; every other account keeps a real password, so this doesn't weaken login for anyone else
- Enabled on tristons-workstation, tristons-nixbook, and tristons-nixbook-pro

## Test plan
- [x] Dry-run verified clean on david for all three hosts (tristons-workstation, tristons-nixbook, tristons-nixbook-pro)
- [ ] CI matrix build
- [ ] After merge: pick guest account at SDDM greeter on one host, confirm kiosk session launches to apps.theyoder.family