### PR TITLE
fix: authenticate to GHCR so david can pull stageplotifer's private image

### DIFF
--- a/docker/productivity/stageplotifer.nix
+++ b/docker/productivity/stageplotifer.nix
@@ -45,10 +45,12 @@
     after = [
       "docker-network-stageplotifer_default.service"
       "docker-volume-stageplotifer_data.service"
+      "docker-login-ghcr-stageplotifer.service"
     ];
     requires = [
       "docker-network-stageplotifer_default.service"
       "docker-volume-stageplotifer_data.service"
+      "docker-login-ghcr-stageplotifer.service"
     ];
     partOf = [
       "docker-compose-stageplotifer-root.target"
@@ -56,6 +58,23 @@
     wantedBy = [
       "docker-compose-stageplotifer-root.target"
     ];
+  };
+
+  # Logs the host's root docker client in to GHCR before anything tries to
+  # pull the (private) image — both the `docker run` this generates and
+  # watchtower-stageplotifer (via the mounted config.json below) rely on
+  # the resulting /root/.docker/config.json.
+  systemd.services."docker-login-ghcr-stageplotifer" = {
+    path = [ pkgs.docker ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      docker login ghcr.io -u tristonyoder --password-stdin < ${config.age.secrets.ghcr-pull-token.path}
+    '';
+    partOf = [ "docker-compose-stageplotifer-root.target" ];
+    wantedBy = [ "docker-compose-stageplotifer-root.target" ];
   };
 
   # Network
@@ -104,12 +123,21 @@
     image = "nickfedor/watchtower";
     volumes = [
       "/var/run/docker.sock:/var/run/docker.sock"
+      # Reuses the same GHCR login docker-login-ghcr-stageplotifer.service
+      # produces — watchtower needs its own read access to pull-check a
+      # private image, separate from the host docker CLI's own credential use.
+      "/root/.docker/config.json:/config.json:ro"
     ];
     environment = {
       WATCHTOWER_LABEL_ENABLE = "true";
       WATCHTOWER_POLL_INTERVAL = "300"; # 5 minutes
       WATCHTOWER_CLEANUP = "true";
     };
+  };
+
+  systemd.services."docker-watchtower-stageplotifer" = {
+    after = [ "docker-login-ghcr-stageplotifer.service" ];
+    requires = [ "docker-login-ghcr-stageplotifer.service" ];
   };
 
   # Caddy reverse proxy

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -66,6 +66,10 @@ with lib;
       "wordpress-carolineyoder-wp" = { file = ../secrets/wordpress-carolineyoder-wp.age; owner = "root"; group = "docker"; mode = "0440"; };
       "outline-secrets" = { file = ../secrets/outline-secrets.age; owner = "root"; group = "docker"; mode = "0440"; };
       "nextdns-link" = { file = ../secrets/nextdns-link.age; owner = "root"; group = "root"; mode = "0400"; };
+      # Classic PAT, read:packages only — lets david's docker daemon pull the
+      # private ghcr.io/tristonyoder/stageplotifer image (repo is private,
+      # staying that way for now). Raw token value only, no KEY=VALUE wrapping.
+      "ghcr-pull-token" = { file = ../secrets/ghcr-pull-token.age; owner = "root"; group = "root"; mode = "0400"; };
       "pocket-id-encryption-key" = { file = ../secrets/pocket-id-encryption-key.age; owner = "root"; group = "docker"; mode = "0440"; };
       # tidarr: docker-only service (docker/media/media-aq.nix), no NixOS module enable
       "tidarr-oidc-secret" = { file = ../secrets/tidarr-oidc-secret.age; mode = "0400"; };

--- a/secrets/ghcr-pull-token.age
+++ b/secrets/ghcr-pull-token.age
@@ -1,0 +1,12 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw 1vL731okquepJHwLatX17PhaXMuzkvBGg+KcAUI4ryA
+qcxWZ3mHXlAE2ohBnnIuISG872G0qjg6DZ0ZKPOB06U
+-> ssh-ed25519 HMaD4A P8C+2Zqakidl9wEz7gd6UwcYWOjNlipkIfjlJcV6cmI
+aSt4rYVg+WTJDZ9zJncUlTmEkbW0M4X9xD34241Ox0Y
+-> ssh-ed25519 0B8VPA TnW5SNDb8tincZ6pUTz2onAZeAsiLg9kJCma/0xHhV4
+4/5RGkjUmhNU5ZPKr6f9rYzE536uihkqlc3GoTZUQ8c
+-> ssh-ed25519 G/hviA SpFxX5T10v9qPEns4Q+rHu+IphzBMO9zMvjw3s+ALzQ
+rcjTJUI1DX1yC7rx+2pN6YM1J8O1mObuREpKhIfF9fs
+--- 6qDq6NIAqMrR/rWASwsoXebCdiBIu5G7uFLibzdxoSg
+|þº±J‰¥Í¨=VªÄÌg•Á²uVã”—íçÕöÖ•ù|Á‰‘Ôç«²±pI
+L“x…ÉeQmLÿŽXÞ‰…’¯Õ•·H¬äæ


### PR DESCRIPTION
## Summary
- `docker-stageplotifer.service` was crash-looping — confirmed via `docker pull ghcr.io/tristonyoder/stageplotifer:latest` on david returning `unauthorized`. The image is private (repo stays private for now), and nothing authenticated david's docker daemon to GHCR.
- New `docker-login-ghcr-stageplotifer.service` (oneshot, root) logs in with a `read:packages`-only classic PAT before `docker-stageplotifer.service` starts.
- `secrets/ghcr-pull-token.age` encrypted for all hosts (not just david) — reusable for future private-image pulls elsewhere.
- The fast-poll watchtower gets the same credentials via a read-only mount of the resulting `/root/.docker/config.json`.

## Test plan
- [x] `nix flake check` passes locally for all NixOS hosts
- [x] `./encrypt-secret.sh -v ghcr-pull-token.age` confirms correct ssh-ed25519 format, 4 recipients
- [ ] CI dry-run on david (this PR)
- [ ] Manual: `sudo systemctl restart docker-stageplotifer` on david after merge, confirm it stays up