### PR TITLE
feat: wire Stage Plotifer to Pocket ID for OIDC login

### DIFF
--- a/docker/productivity/stageplotifer.nix
+++ b/docker/productivity/stageplotifer.nix
@@ -16,6 +16,12 @@
   # Container
   virtualisation.oci-containers.containers."stageplotifer" = {
     image = "ghcr.io/tristonyoder/stageplotifer:latest";
+    # OIDC_ISSUER_URL / OIDC_CLIENT_ID / OIDC_CLIENT_SECRET (Pocket ID) —
+    # all three must be set together to turn on multi-user mode; see
+    # isMultiUserModeEnabled() in server/src/lib/auth/mode.ts.
+    environmentFiles = [
+      config.age.secrets.stageplotifer-oidc-secrets.path
+    ];
     volumes = [
       "stageplotifer_data:/app/data:rw"
     ];

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -73,6 +73,9 @@ with lib;
       "pocket-id-encryption-key" = { file = ../secrets/pocket-id-encryption-key.age; owner = "root"; group = "docker"; mode = "0440"; };
       # tidarr: docker-only service (docker/media/media-aq.nix), no NixOS module enable
       "tidarr-oidc-secret" = { file = ../secrets/tidarr-oidc-secret.age; mode = "0400"; };
+      # stageplotifer: docker-only service (docker/productivity/stageplotifer.nix), no NixOS module enable.
+      # KEY=VALUE file (OIDC_ISSUER_URL/OIDC_CLIENT_ID/OIDC_CLIENT_SECRET) loaded via environmentFiles.
+      "stageplotifer-oidc-secrets" = { file = ../secrets/stageplotifer-oidc-secrets.age; mode = "0400"; };
       # hermes-agent: NixOS module loaded only on david (external flake dep), no universal enable option
       "hermes-env" = { file = ../secrets/hermes-env.age; mode = "0400"; };
       # Deploy key (write access) for the private TristonYoder/hermes-brain repo —

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -119,6 +119,9 @@ in
   # Tidarr OIDC Client Secret (Pocket ID)
   "tidarr-oidc-secret.age".publicKeys = davidKeys;
 
+  # Stage Plotifer OIDC credentials (Pocket ID) — issuer URL, client ID, client secret
+  "stageplotifer-oidc-secrets.age".publicKeys = davidKeys;
+
   # Plex token for JellyPlex-Watched
   "plex-token.age".publicKeys = davidKeys;
 

--- a/secrets/stageplotifer-oidc-secrets.age
+++ b/secrets/stageplotifer-oidc-secrets.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw FHxSVRemnaXy02yiiOviNIKJkMGsBMbb/GZ7F+nRYSM
+XesR9jHV7TY3P0Dz+Yz5CAKzFSzCPADAyXy0DTEGVrQ
+-> ssh-ed25519 G/hviA 6YHpc1u314MIdvmBWiFa2c5h06Rdkk+JugLGyAhDYks
+flm7yNpp8KVMqsCG7lf1fcMHPF9dMHPThYGeGM9FlnY
+--- PrcspncRfggbFNbgE7OgcawM3djAcTW2GzG3XioyIOA
+ª‡[µ6J	ïÒÉ6—±’v#xsp3¦/v³>›gß[Ì\v.uz5q—åFÛ¹P¨¸óÖÂ™‚¬Á(‚€ý'|Þêæœú8ÃD»Ïv«žnb˜üI…¶%Òu&ÙÖ*/p¨€:À—t³{ˆ€ØBˆTÀ,¨(XUÐø_ŽH¢yÌ›á.J\µÃùvhU¸ëÇø¯mËfœàÄ÷¥w
+£Ã',<F`ªë^Ëò>j


### PR DESCRIPTION
## Summary
- Adds `secrets/stageplotifer-oidc-secrets.age` (agenix, david-only) holding `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` for the Pocket ID client already registered at `id.theyoder.family` for `plotifer.7co.dev`.
- Declares it in `modules/secrets.nix` and loads it via `environmentFiles` on the `stageplotifer` container in `docker/productivity/stageplotifer.nix`, same pattern as `tidarr-oidc-secret`.
- Turns on the app's existing multi-user/OIDC login mode (`isMultiUserModeEnabled()` in `stagePlotifer/server/src/lib/auth/mode.ts` requires all three vars).
- Caddy already forwards `X-Forwarded-Host`/`X-Forwarded-Proto` for `plotifer.7co.dev`, so the app auto-derives the correct `https://plotifer.7co.dev/api/auth/callback` redirect URI — no `OIDC_REDIRECT_URI` override needed.

## Test plan
- [ ] `nixos-rebuild dry-run` passes in CI for `david` (this PR's test workflow)
- [ ] After merge (auto-deploys to david): visit `https://plotifer.7co.dev/`, confirm redirect to `/login`, click through to `id.theyoder.family`, confirm successful login + redirect back
- [ ] Confirm `docker logs stageplotifer` shows no OIDC discovery/config errors on container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)