### PR TITLE
Set PUBLIC_BASE_URL for Stage Plotifer PCO attachment links

### DIFF
--- a/docker/productivity/stageplotifer.nix
+++ b/docker/productivity/stageplotifer.nix
@@ -22,6 +22,16 @@
     environmentFiles = [
       config.age.secrets.stageplotifer-oidc-secrets.path
     ];
+    environment = {
+      # Public URL the app stamps into PCO plan attachment links (stage plot
+      # PDF exports) — used both by the manual "Send to PCO" button and the
+      # auto-plot scheduler's auto-send toggle. The scheduler runs on a timer
+      # with no incoming request to derive this from Caddy's X-Forwarded-Host,
+      # so unlike the request-driven path it has no fallback: without this
+      # set, auto-send silently no-ops (logs and skips) instead of crashing.
+      # Not a secret — same hostname already appears in the Caddy block below.
+      PUBLIC_BASE_URL = "https://plotifer.7co.dev";
+    };
     volumes = [
       "stageplotifer_data:/app/data:rw"
     ];


### PR DESCRIPTION
## Summary
- Adds `PUBLIC_BASE_URL=https://plotifer.7co.dev` to the Stage Plotifer container's environment.
- Stage Plotifer now posts a stage-plot PDF link to a PCO plan's attachments — a manual "Send to PCO" button and a new auto-plot scheduler toggle.
- The manual path derives the public origin from Caddy's `X-Forwarded-Host` on each request. The scheduler runs on a timer with no request to derive that from, so it needs this env var explicitly — without it, auto-send just logs and skips rather than crashing.

## Test plan
- [x] Verified `plotifer.7co.dev` is live and publicly reachable (`curl https://plotifer.7co.dev/api/status` → `{"ready":true}`) — confirms the URL this env var sets is actually correct and resolvable, despite this file's header comment still saying "VPN/LAN-only" (worth updating separately, not part of this change).
- [ ] After merge/deploy, confirm the container picks up the new env var (`docker exec stageplotifer env | grep PUBLIC_BASE_URL` on `david`).
- [ ] Toggle "Automatically send to PCO" on a venue in the app and confirm a real PCO plan attachment appears with a working `https://plotifer.7co.dev/...` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)