### PR TITLE
Switch Stage Plotifer's public domain to plotiphar.com

### DIFF
--- a/docker/productivity/stageplotifer.nix
+++ b/docker/productivity/stageplotifer.nix
@@ -1,8 +1,10 @@
 # Stage Plotifer - Stage plot & mic assignment planning tool for PCO-integrated churches
 # Image is built and published by the app's own repo CI (Nix-built,
 # ghcr.io/tristonyoder/stageplotifer) — see TristonYoder/stagePlotifer.
-# VPN/LAN-only for now: no Cloudflare Tunnel/pits routing, point
-# plotifer.7co.dev's DNS at david's Tailscale or LAN IP, not a public one.
+# Public at plotiphar.com via david's Cloudflare Tunnel (profiles/server.nix
+# enables modules.services.infrastructure.cloudflared) — the tunnel's public
+# hostname mapping lives in the Cloudflare dashboard, not in this repo, so
+# switching this domain also requires updating that mapping there.
 { config, pkgs, lib, ... }:
 
 {
@@ -30,7 +32,7 @@
       # so unlike the request-driven path it has no fallback: without this
       # set, auto-send silently no-ops (logs and skips) instead of crashing.
       # Not a secret — same hostname already appears in the Caddy block below.
-      PUBLIC_BASE_URL = "https://plotifer.7co.dev";
+      PUBLIC_BASE_URL = "https://plotiphar.com";
     };
     volumes = [
       "stageplotifer_data:/app/data:rw"
@@ -157,7 +159,7 @@
   };
 
   # Caddy reverse proxy
-  services.caddy.virtualHosts."plotifer.7co.dev" = {
+  services.caddy.virtualHosts."plotiphar.com" = {
     extraConfig = ''
       reverse_proxy http://localhost:1395 {
         header_up X-Real-IP {remote_host}

--- a/docker/productivity/stageplotifer.nix
+++ b/docker/productivity/stageplotifer.nix
@@ -22,6 +22,16 @@
     environmentFiles = [
       config.age.secrets.stageplotifer-oidc-secrets.path
     ];
+    environment = {
+      # Public URL the app stamps into PCO plan attachment links (stage plot
+      # PDF exports) — used both by the manual "Send to PCO" button and the
+      # auto-plot scheduler's auto-send toggle. The scheduler runs on a timer
+      # with no incoming request to derive this from Caddy's X-Forwarded-Host,
+      # so unlike the request-driven path it has no fallback: without this
+      # set, auto-send silently no-ops (logs and skips) instead of crashing.
+      # Not a secret — same hostname already appears in the Caddy block below.
+      PUBLIC_BASE_URL = "https://plotifer.7co.dev";
+    };
     volumes = [
       "stageplotifer_data:/app/data:rw"
     ];


### PR DESCRIPTION
## Summary
- Replaces the `plotifer.7co.dev` Caddy virtualHost with `plotiphar.com`.
- Updates `PUBLIC_BASE_URL` to `https://plotiphar.com` so PCO plan attachment links (manual "Send to PCO" button + auto-send toggle) point at the new domain.
- Once merged, `david`'s Caddy will only match `plotiphar.com` for this service — `plotifer.7co.dev` requests will no longer be served here.

## Heads-up: Cloudflare Tunnel dashboard
`david` reaches the internet via a Cloudflare Tunnel (`profiles/server.nix`), whose public-hostname → local-port mapping lives in the Cloudflare Zero Trust dashboard, not in this repo. This PR only changes what Caddy matches on the origin side — it doesn't touch that mapping. `plotiphar.com` already resolves publicly and currently serves what looks like this same app (its `/login?returnTo=%2F` redirect matches Stage Plotifer's own auth-gate format exactly), so the tunnel side may already be pointed correctly — but I can't verify that from here. Worth confirming before merge, since if the tunnel doesn't route `plotiphar.com` to `david`'s Caddy, this would just orphan `plotifer.7co.dev` without actually making `plotiphar.com` work.

## Test plan
- [x] CI (flake syntax + dry-run on all hosts)
- [ ] After deploy, confirm `plotiphar.com` serves Stage Plotifer via `david` (not whatever currently answers)
- [ ] Confirm `PUBLIC_BASE_URL` landed: `docker exec stageplotifer env | grep PUBLIC_BASE_URL`
- [ ] Send a real event to PCO and confirm the attachment link uses `plotiphar.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)