### PR TITLE
feat: self-hosted GitHub Actions runner for stagePlotiphar on david

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -345,13 +345,21 @@ in
     };
   };
 
-  # Self-hosted GitHub Actions runner for TristonYoder/stagePlotiphar.
+  # Self-hosted GitHub Actions runners for TristonYoder/stagePlotiphar.
   # Name must be unique per registered runner across all hosts hitting this
-  # repo — defaults to the attrset key, so don't reuse "stageplotiphar-david"
-  # elsewhere or the later registration will --replace this one.
+  # repo — defaults to the attrset key, so don't reuse these names elsewhere
+  # or the later registration will --replace this one.
   modules.services.development.githubRunner = {
     enable = true;
     runners."stageplotiphar-david" = {
+      url = "https://github.com/TristonYoder/stagePlotiphar";
+      tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+    };
+    # Ephemeral, fresh-container-per-job runner — target with
+    # `runs-on: [self-hosted, ephemeral-container]` when a job needs a
+    # clean environment instead of the persistent native runner above.
+    runners."stageplotiphar-david-clean" = {
+      backend = "container";
       url = "https://github.com/TristonYoder/stagePlotiphar";
       tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
     };

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -345,10 +345,13 @@ in
     };
   };
 
-  # Self-hosted GitHub Actions runner for TristonYoder/stagePlotiphar
+  # Self-hosted GitHub Actions runner for TristonYoder/stagePlotiphar.
+  # Name must be unique per registered runner across all hosts hitting this
+  # repo — defaults to the attrset key, so don't reuse "stageplotiphar-david"
+  # elsewhere or the later registration will --replace this one.
   modules.services.development.githubRunner = {
     enable = true;
-    runners.stageplotiphar = {
+    runners."stageplotiphar-david" = {
       url = "https://github.com/TristonYoder/stagePlotiphar";
       tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
     };

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -345,4 +345,13 @@ in
     };
   };
 
+  # Self-hosted GitHub Actions runner for TristonYoder/stagePlotiphar
+  modules.services.development.githubRunner = {
+    enable = true;
+    runners.stageplotiphar = {
+      url = "https://github.com/TristonYoder/stagePlotiphar";
+      tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+    };
+  };
+
 }

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -353,7 +353,7 @@ in
     enable = true;
     runners."stageplotiphar-david" = {
       url = "https://github.com/TristonYoder/stagePlotiphar";
-      tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+      tokenFile = config.age.secrets.github-runner-token.path;
     };
     # Ephemeral, fresh-container-per-job runner — target with
     # `runs-on: [self-hosted, ephemeral-container]` when a job needs a
@@ -361,7 +361,7 @@ in
     runners."stageplotiphar-david-clean" = {
       backend = "container";
       url = "https://github.com/TristonYoder/stagePlotiphar";
-      tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+      tokenFile = config.age.secrets.github-runner-token.path;
     };
   };
 

--- a/hosts/tyoder-mbp/configuration.nix
+++ b/hosts/tyoder-mbp/configuration.nix
@@ -5,25 +5,41 @@
 { config, pkgs, lib, ... }:
 
 {
+  imports = [
+    ../../modules/darwin/github-runner.nix
+  ];
+
   # =============================================================================
   # SYSTEM IDENTIFICATION
   # =============================================================================
-  
+
   networking.hostName = "tyoder-mbp";
   networking.localHostName = "tyoder-mbp";
   networking.computerName = "Triston Yoder's MacBook Pro";
-  
+
   # =============================================================================
   # USER CONFIGURATION
   # =============================================================================
-  
+
   users.users.tyoder = {
     name = "tyoder";
     home = "/Users/tyoder";
     shell = pkgs.zsh;
   };
-  
+
   # Set primary user for system defaults
   system.primaryUser = "tyoder";
+
+  # =============================================================================
+  # SELF-HOSTED GITHUB ACTIONS RUNNER
+  # =============================================================================
+
+  modules.services.development.githubRunner = {
+    enable = true;
+    runners.stageplotiphar = {
+      url = "https://github.com/TristonYoder/stagePlotiphar";
+      tokenFile = "/Users/tyoder/.config/github-runners/stageplotiphar.token";
+    };
+  };
 }
 

--- a/hosts/tyoder-mbp/configuration.nix
+++ b/hosts/tyoder-mbp/configuration.nix
@@ -5,10 +5,6 @@
 { config, pkgs, lib, ... }:
 
 {
-  imports = [
-    ../../modules/darwin/github-runner.nix
-  ];
-
   # =============================================================================
   # SYSTEM IDENTIFICATION
   # =============================================================================
@@ -29,17 +25,5 @@
 
   # Set primary user for system defaults
   system.primaryUser = "tyoder";
-
-  # =============================================================================
-  # SELF-HOSTED GITHUB ACTIONS RUNNER
-  # =============================================================================
-
-  modules.services.development.githubRunner = {
-    enable = true;
-    runners.stageplotiphar = {
-      url = "https://github.com/TristonYoder/stagePlotiphar";
-      tokenFile = "/Users/tyoder/.config/github-runners/stageplotiphar.token";
-    };
-  };
 }
 

--- a/modules/darwin/github-runner.nix
+++ b/modules/darwin/github-runner.nix
@@ -1,0 +1,173 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.development.githubRunner;
+
+  runnerModule = types.submodule {
+    options = {
+      url = mkOption {
+        type = types.str;
+        description = ''
+          Repository or organization URL to register this runner against.
+          Use an org URL only if `tokenFile` contains an org-wide token — a
+          repo-scoped token needs the full repo URL.
+        '';
+        example = "https://github.com/TristonYoder/stagePlotiphar";
+      };
+
+      tokenFile = mkOption {
+        type = types.path;
+        description = ''
+          Path to a file containing a GitHub fine-grained PAT (preferred) or
+          a one-hour runner registration token. Darwin has no agenix
+          integration in this repo, so this must be a plain out-of-store
+          path you create manually (e.g. under ~/.config/github-runners/),
+          never a path inside the repo.
+        '';
+      };
+
+      extraLabels = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Extra labels for this runner, in addition to the defaults.";
+      };
+
+      replace = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Replace any existing runner registered under the same name.";
+      };
+
+      ephemeral = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Deregister after every job. Only safe when `tokenFile` contains a
+          PAT — the runner re-registers itself on the next launchd start
+          since its state directory is gone after deregistration.
+        '';
+      };
+
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = "Extra packages available on PATH to workflow jobs.";
+      };
+    };
+  };
+
+  runnerDir = name: "${config.users.users.${config.system.primaryUser}.home}/Projects/github-runners/${name}";
+
+  mkRunnerAgent = name: runner:
+    let
+      installDir = runnerDir name;
+      label = "family.theyoder.github-runner.${name}";
+      pathDirs = [ "/usr/bin" "/bin" "/usr/sbin" "/sbin" "/nix/var/nix/profiles/default/bin" ]
+        ++ map (p: "${p}/bin") ([ pkgs.bashInteractive pkgs.coreutils pkgs.git pkgs.gnutar pkgs.gzip pkgs.github-runner ] ++ runner.extraPackages);
+
+      runScript = pkgs.writeShellScript "github-runner-${name}" ''
+        set -euo pipefail
+        mkdir -p ${escapeShellArg installDir}
+        cd ${escapeShellArg installDir}
+
+        # Only configure on first run (or after a deregistration wiped .runner).
+        # To force re-registration after changing url/labels, remove this
+        # directory manually before the agent next starts.
+        if [ ! -f .runner ]; then
+          token=$(cat ${escapeShellArg runner.tokenFile})
+          args=(
+            --unattended --disableupdate
+            --url ${escapeShellArg runner.url}
+            --labels ${escapeShellArg (concatStringsSep "," runner.extraLabels)}
+            --name ${escapeShellArg name}
+            --work _work
+            ${optionalString runner.replace "--replace"}
+            ${optionalString runner.ephemeral "--ephemeral"}
+          )
+          if [[ "$token" == ghp_* || "$token" == github_pat_* ]]; then
+            args+=(--pat "$token")
+          else
+            args+=(--token "$token")
+          fi
+          "${pkgs.github-runner}/bin/Runner.Listener" configure "''${args[@]}"
+        fi
+
+        exec "${pkgs.github-runner}/bin/Runner.Listener" run --startuptype service
+      '';
+    in
+    {
+      enable = true;
+      target = "${label}.plist";
+      text = ''
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>${label}</string>
+
+          <key>ProgramArguments</key>
+          <array>
+            <string>${runScript}</string>
+          </array>
+
+          <key>RunAtLoad</key>
+          <true/>
+
+          <key>KeepAlive</key>
+          <dict>
+            <key>SuccessfulExit</key>
+            <false/>
+            <key>Crashed</key>
+            <true/>
+          </dict>
+
+          <key>ProcessType</key>
+          <string>Background</string>
+
+          <key>StandardErrorPath</key>
+          <string>/tmp/${label}.err.log</string>
+
+          <key>StandardOutPath</key>
+          <string>/tmp/${label}.out.log</string>
+
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>PATH</key>
+            <string>${concatStringsSep ":" pathDirs}</string>
+          </dict>
+        </dict>
+        </plist>
+      '';
+    };
+in
+{
+  options.modules.services.development.githubRunner = {
+    enable = mkEnableOption "Self-hosted GitHub Actions runner(s) (launchd-based)";
+
+    runners = mkOption {
+      type = types.attrsOf runnerModule;
+      default = { };
+      description = ''
+        Named self-hosted runner instances to register on this host. Each
+        runner's install/work directory lives under
+        ~/Projects/github-runners/<name>.
+      '';
+      example = literalExpression ''
+        {
+          stageplotiphar = {
+            url = "https://github.com/TristonYoder/stagePlotiphar";
+            tokenFile = "/Users/tyoder/.config/github-runners/stageplotiphar.token";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.launchAgents = mapAttrs'
+      (name: runner: nameValuePair "family.theyoder.github-runner.${name}" (mkRunnerAgent name runner))
+      cfg.runners;
+  };
+}

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -146,10 +146,11 @@ with lib;
     })
 
     // (optionalAttrs config.modules.services.development.githubRunner.enable {
-      # Fine-grained PAT with read/write access to Actions self-hosted runners
-      # for TristonYoder/stagePlotiphar. Read only by the root-context
-      # ExecStartPre configure script, never by the runner service itself.
-      "github-runner-stageplotiphar-token" = { file = ../secrets/github-runner-stageplotiphar-token.age; owner = "root"; group = "root"; mode = "0400"; };
+      # Fine-grained PAT with read/write "Administration" access, all repos.
+      # Shared across every runner instance on this host — read only by the
+      # root-context configure/preStart scripts, never by the runner
+      # service/container itself.
+      "github-runner-token" = { file = ../secrets/github-runner-token.age; owner = "root"; group = "root"; mode = "0400"; };
     })
 
     ;

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -145,5 +145,12 @@ with lib;
       "navidrome-api-password" = { file = ../secrets/navidrome-api-password.age; mode = "0400"; };
     })
 
+    // (optionalAttrs config.modules.services.development.githubRunner.enable {
+      # Fine-grained PAT with read/write access to Actions self-hosted runners
+      # for TristonYoder/stagePlotiphar. Read only by the root-context
+      # ExecStartPre configure script, never by the runner service itself.
+      "github-runner-stageplotiphar-token" = { file = ../secrets/github-runner-stageplotiphar-token.age; owner = "root"; group = "root"; mode = "0400"; };
+    })
+
     ;
 }

--- a/modules/services/development/default.nix
+++ b/modules/services/development/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./vscode-server.nix
     ./github-actions.nix
+    ./github-runner.nix
     ./kasm.nix
     ./openvscode-server.nix
     ./code-server.nix

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.development.githubRunner;
+
+  runnerModule = types.submodule {
+    options = {
+      url = mkOption {
+        type = types.str;
+        description = ''
+          Repository or organization URL to register this runner against.
+          Use an org URL (e.g. "https://github.com/TristonYoder") only if
+          `tokenFile` contains an org-wide token — a repo-scoped token needs
+          the full repo URL.
+        '';
+        example = "https://github.com/TristonYoder/stagePlotiphar";
+      };
+
+      tokenFile = mkOption {
+        type = types.path;
+        description = ''
+          Path to a file containing a GitHub fine-grained PAT (preferred,
+          auto-refreshes registration tokens) or a one-hour runner
+          registration token. Never inline the token value — see
+          modules/secrets.nix for the agenix pattern.
+        '';
+      };
+
+      extraLabels = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Extra labels for this runner, in addition to the defaults.";
+      };
+
+      replace = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Replace any existing runner registered under the same name.";
+      };
+
+      ephemeral = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Deregister and reconfigure after every job. Only safe when
+          `tokenFile` contains a PAT — a one-hour registration token will
+          fail to re-register after it expires.
+        '';
+      };
+
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = "Extra packages available on PATH to workflow jobs.";
+      };
+    };
+  };
+in
+{
+  options.modules.services.development.githubRunner = {
+    enable = mkEnableOption "Self-hosted GitHub Actions runner(s)";
+
+    runners = mkOption {
+      type = types.attrsOf runnerModule;
+      default = { };
+      description = "Named self-hosted runner instances to register on this host.";
+      example = literalExpression ''
+        {
+          stageplotiphar = {
+            url = "https://github.com/TristonYoder/stagePlotiphar";
+            tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.github-runners = mapAttrs
+      (name: runner: {
+        enable = true;
+        url = runner.url;
+        tokenFile = runner.tokenFile;
+        extraLabels = runner.extraLabels;
+        replace = runner.replace;
+        ephemeral = runner.ephemeral;
+        extraPackages = with pkgs; [ nix git ] ++ runner.extraPackages;
+      })
+      cfg.runners;
+  };
+}

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -198,7 +198,7 @@ in
           fi
           chmod 600 "$envfile"
         '';
-        serviceConfig.Restart = mkOverride 500 "always";
+        serviceConfig.Restart = mkForce "always";
       })
       containerRunners;
   };

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -179,12 +179,11 @@ in
 
     # Regenerate the container's token env file on every (re)start, and force
     # Restart=always so a finished (deregistered) ephemeral container is
-    # immediately replaced by a fresh one for the next job. NOTE: despite
-    # oci-containers.nix setting Restart = "always" unconditionally, the
-    # generated unit on this host's nixpkgs actually comes out as
-    # "on-failure" — every other oci-containers module in this repo already
-    # works around this the same way (mkOverride 500), so don't drop this
-    # override without re-verifying the generated unit.
+    # immediately replaced by a fresh one for the next job. oci-containers.nix
+    # sets Restart = "on-failure" by default (a clean exit 0, exactly what the
+    # ephemeral runner does after deregistering, would NOT restart), so this
+    # has to be mkForce, not mkDefault/mkOverride — confirmed via the eval
+    # conflict error that on-failure is a normal-priority (100) definition.
     systemd.services = mapAttrs'
       (name: runner: nameValuePair "docker-${name}" {
         preStart = ''
@@ -198,7 +197,7 @@ in
           fi
           chmod 600 "$envfile"
         '';
-        serviceConfig.Restart = "no";
+        serviceConfig.Restart = mkForce "always";
       })
       containerRunners;
   };

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -6,6 +6,21 @@ let
 
   runnerModule = types.submodule {
     options = {
+      backend = mkOption {
+        type = types.enum [ "native" "container" ];
+        default = "native";
+        description = ''
+          "native": persistent systemd service (services.github-runners) —
+          long-lived install/work directory, state persists across jobs.
+
+          "container": ephemeral Docker container (myoung34/github-runner)
+          that deregisters itself after each job. systemd's default
+          Restart=always then starts a brand-new container for the next
+          job, so every job gets a clean filesystem. Requires
+          virtualisation.oci-containers.backend = "docker".
+        '';
+      };
+
       url = mkOption {
         type = types.str;
         description = ''
@@ -36,7 +51,7 @@ let
       replace = mkOption {
         type = types.bool;
         default = true;
-        description = "Replace any existing runner registered under the same name.";
+        description = "Replace any existing runner registered under the same name. Native backend only.";
       };
 
       ephemeral = mkOption {
@@ -45,29 +60,43 @@ let
         description = ''
           Deregister and reconfigure after every job. Only safe when
           `tokenFile` contains a PAT — a one-hour registration token will
-          fail to re-register after it expires.
+          fail to re-register after it expires. Native backend only — the
+          container backend is always ephemeral by design.
         '';
       };
 
       extraPackages = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        description = "Extra packages available on PATH to workflow jobs.";
+        description = "Extra packages available on PATH to workflow jobs. Native backend only.";
       };
 
       dockerAccess = mkOption {
         type = types.bool;
         default = true;
         description = ''
-          Put the `docker` CLI on PATH and add the runner's (dynamic) user to
-          the `docker` group so workflow jobs can build/run containers.
-          Requires `virtualisation.docker.enable` on this host. Note the
-          `docker` group is effectively root-equivalent via the socket —
-          same trust level as this repo's other CI automation.
+          Native backend: puts `docker` CLI on PATH and adds the runner's
+          (dynamic) user to the `docker` group so jobs can build/run
+          containers. Container backend: bind-mounts the host docker socket
+          into the runner container (docker-outside-of-docker). Either way
+          requires `virtualisation.docker.enable` on this host. Note this is
+          effectively root-equivalent host access via the socket — same
+          trust level as this repo's other CI automation.
         '';
+      };
+
+      containerImage = mkOption {
+        type = types.str;
+        default = "ghcr.io/myoung34/github-runner:ubuntu-noble";
+        description = "Image to use when backend = \"container\".";
       };
     };
   };
+
+  nativeRunners = filterAttrs (_: r: r.backend == "native") cfg.runners;
+  containerRunners = filterAttrs (_: r: r.backend == "container") cfg.runners;
+
+  containerEnvFile = name: "/run/github-runner-container-${name}.env";
 in
 {
   options.modules.services.development.githubRunner = {
@@ -79,7 +108,12 @@ in
       description = "Named self-hosted runner instances to register on this host.";
       example = literalExpression ''
         {
-          stageplotiphar = {
+          stageplotiphar-native = {
+            url = "https://github.com/TristonYoder/stagePlotiphar";
+            tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+          };
+          stageplotiphar-clean = {
+            backend = "container";
             url = "https://github.com/TristonYoder/stagePlotiphar";
             tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
           };
@@ -89,13 +123,21 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions = mapAttrsToList
-      (name: runner: {
-        assertion = !runner.dockerAccess || config.virtualisation.docker.enable;
-        message = ''modules.services.development.githubRunner.runners."${name}".dockerAccess requires virtualisation.docker.enable on this host.'';
-      })
-      cfg.runners;
+    assertions =
+      (mapAttrsToList
+        (name: runner: {
+          assertion = !runner.dockerAccess || config.virtualisation.docker.enable;
+          message = ''modules.services.development.githubRunner.runners."${name}".dockerAccess requires virtualisation.docker.enable on this host.'';
+        })
+        cfg.runners)
+      ++ (mapAttrsToList
+        (name: _: {
+          assertion = config.virtualisation.oci-containers.backend == "docker";
+          message = ''modules.services.development.githubRunner.runners."${name}": backend = "container" requires virtualisation.oci-containers.backend = "docker".'';
+        })
+        containerRunners);
 
+    # ── Native backend: persistent systemd-managed runner ─────────────────
     services.github-runners = mapAttrs
       (name: runner: {
         enable = true;
@@ -111,6 +153,47 @@ in
           SupplementaryGroups = [ "docker" ];
         };
       })
-      cfg.runners;
+      nativeRunners;
+
+    # ── Container backend: ephemeral runner, fresh container per job ──────
+    virtualisation.oci-containers.containers = mapAttrs
+      (name: runner: {
+        image = runner.containerImage;
+        autoStart = true;
+        environment = {
+          RUNNER_SCOPE = "repo";
+          REPO_URL = runner.url;
+          RUNNER_NAME = name;
+          RANDOM_RUNNER_SUFFIX = "false";
+          EPHEMERAL = "true";
+          DISABLE_AUTO_UPDATE = "true";
+          RUN_AS_ROOT = "true";
+          LABELS = concatStringsSep "," (runner.extraLabels ++ [ "ephemeral-container" ]);
+        };
+        # ACCESS_TOKEN/RUNNER_TOKEN come from a runtime-generated env file
+        # (see systemd preStart below), never from the Nix store.
+        environmentFiles = [ (containerEnvFile name) ];
+        volumes = optional runner.dockerAccess "/var/run/docker.sock:/var/run/docker.sock";
+      })
+      containerRunners;
+
+    # Regenerate the container's token env file on every (re)start — systemd's
+    # default Restart=always for oci-containers means this runs before each
+    # job's fresh container, same as the native backend's ExecStartPre.
+    systemd.services = mapAttrs'
+      (name: runner: nameValuePair "docker-${name}" {
+        preStart = ''
+          set -euo pipefail
+          token=$(cat ${escapeShellArg runner.tokenFile})
+          envfile=${escapeShellArg (containerEnvFile name)}
+          if [[ "$token" == ghp_* || "$token" == github_pat_* ]]; then
+            printf 'ACCESS_TOKEN=%s\n' "$token" > "$envfile"
+          else
+            printf 'RUNNER_TOKEN=%s\n' "$token" > "$envfile"
+          fi
+          chmod 600 "$envfile"
+        '';
+      })
+      containerRunners;
   };
 }

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -177,9 +177,14 @@ in
       })
       containerRunners;
 
-    # Regenerate the container's token env file on every (re)start — systemd's
-    # default Restart=always for oci-containers means this runs before each
-    # job's fresh container, same as the native backend's ExecStartPre.
+    # Regenerate the container's token env file on every (re)start, and force
+    # Restart=always so a finished (deregistered) ephemeral container is
+    # immediately replaced by a fresh one for the next job. NOTE: despite
+    # oci-containers.nix setting Restart = "always" unconditionally, the
+    # generated unit on this host's nixpkgs actually comes out as
+    # "on-failure" — every other oci-containers module in this repo already
+    # works around this the same way (mkOverride 500), so don't drop this
+    # override without re-verifying the generated unit.
     systemd.services = mapAttrs'
       (name: runner: nameValuePair "docker-${name}" {
         preStart = ''
@@ -193,6 +198,7 @@ in
           fi
           chmod 600 "$envfile"
         '';
+        serviceConfig.Restart = mkOverride 500 "always";
       })
       containerRunners;
   };

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -54,6 +54,18 @@ let
         default = [ ];
         description = "Extra packages available on PATH to workflow jobs.";
       };
+
+      dockerAccess = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Put the `docker` CLI on PATH and add the runner's (dynamic) user to
+          the `docker` group so workflow jobs can build/run containers.
+          Requires `virtualisation.docker.enable` on this host. Note the
+          `docker` group is effectively root-equivalent via the socket —
+          same trust level as this repo's other CI automation.
+        '';
+      };
     };
   };
 in
@@ -77,6 +89,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = mapAttrsToList
+      (name: runner: {
+        assertion = !runner.dockerAccess || config.virtualisation.docker.enable;
+        message = ''modules.services.development.githubRunner.runners."${name}".dockerAccess requires virtualisation.docker.enable on this host.'';
+      })
+      cfg.runners;
+
     services.github-runners = mapAttrs
       (name: runner: {
         enable = true;
@@ -85,7 +104,12 @@ in
         extraLabels = runner.extraLabels;
         replace = runner.replace;
         ephemeral = runner.ephemeral;
-        extraPackages = with pkgs; [ nix git ] ++ runner.extraPackages;
+        extraPackages = with pkgs; [ nix git ]
+          ++ optionals runner.dockerAccess [ config.virtualisation.docker.package pkgs.docker-compose ]
+          ++ runner.extraPackages;
+        serviceOverrides = mkIf runner.dockerAccess {
+          SupplementaryGroups = [ "docker" ];
+        };
       })
       cfg.runners;
   };

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -110,12 +110,12 @@ in
         {
           stageplotiphar-native = {
             url = "https://github.com/TristonYoder/stagePlotiphar";
-            tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+            tokenFile = config.age.secrets.github-runner-token.path;
           };
           stageplotiphar-clean = {
             backend = "container";
             url = "https://github.com/TristonYoder/stagePlotiphar";
-            tokenFile = config.age.secrets.github-runner-stageplotiphar-token.path;
+            tokenFile = config.age.secrets.github-runner-token.path;
           };
         }
       '';

--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -198,7 +198,7 @@ in
           fi
           chmod 600 "$envfile"
         '';
-        serviceConfig.Restart = mkForce "always";
+        serviceConfig.Restart = "no";
       })
       containerRunners;
   };

--- a/secrets/github-runner-stageplotiphar-token.age
+++ b/secrets/github-runner-stageplotiphar-token.age
@@ -1,5 +1,7 @@
-PLACEHOLDER â€” not a real age-encrypted secret.
-Replace before merging by running (from secrets/):
-  ./encrypt-secret.sh -n github-runner-stageplotiphar-token.age -e
-Content: a GitHub fine-grained PAT with read/write access to Actions
-self-hosted runners for TristonYoder/stagePlotiphar, no trailing newline.
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw XExrmMFteW9FGWS2wSSFvFvizXp1htq35thmMnwo3Aw
+YlvRH/KiDFB0oELS4c8baqIyCVdOJ5KBT5R69Vfud3g
+-> ssh-ed25519 G/hviA DeGqBQxb5FiRh5IOMTMDagtu/463DtduECP7XHYOlnA
+ByI95FL309cNNaZLwSbQSvToXax+l5ayYirfuBbCdj0
+--- N5Xwh5lF8s4sstDI3TYCEXheQbzgXyI0ogX/8PLKCXc
+Øõ@ÿÊ%Aïñ-f¤­{O<Wß,¸5/ëO"0l`êkIAUãˆÎ2Ä^8÷":[y‚ÎyÏ’ÚŽÖÂW

--- a/secrets/github-runner-stageplotiphar-token.age
+++ b/secrets/github-runner-stageplotiphar-token.age
@@ -1,7 +1,7 @@
 age-encryption.org/v1
--> ssh-ed25519 QfFraw XExrmMFteW9FGWS2wSSFvFvizXp1htq35thmMnwo3Aw
-YlvRH/KiDFB0oELS4c8baqIyCVdOJ5KBT5R69Vfud3g
--> ssh-ed25519 G/hviA DeGqBQxb5FiRh5IOMTMDagtu/463DtduECP7XHYOlnA
-ByI95FL309cNNaZLwSbQSvToXax+l5ayYirfuBbCdj0
---- N5Xwh5lF8s4sstDI3TYCEXheQbzgXyI0ogX/8PLKCXc
-Øõ@ÿÊ%Aïñ-f¤­{O<Wß,¸5/ëO"0l`êkIAUãˆÎ2Ä^8÷":[y‚ÎyÏ’ÚŽÖÂW
+-> ssh-ed25519 QfFraw 4W3jgP1yn2i/DzB9hlizQ12uGV9qD1HI7saQ6YkizzQ
+msRmL8kVMLSBw/EMMq/iUVfLVFksKw2ytW4xXSDpD6c
+-> ssh-ed25519 G/hviA Lj41dsYNx7AQStcOK1jLFMUzA/+GEkjGhae7JXtb23k
+14IyqZ278mjiNFBok+4XcmCa1DNIE+cT6jJwQ1u9AuQ
+--- O9GF4q+Hd1bVtBsL2nV+J+wj+B3k5p9fRz0DtmRbEic
+âiý>M[g¥‰¬^ƒÆ&W³èåz?9Ñ}X8Á¡½Á~ÅòÑÔyTtú5Ù¿=òŒêj¦ãFm

--- a/secrets/github-runner-stageplotiphar-token.age
+++ b/secrets/github-runner-stageplotiphar-token.age
@@ -1,7 +1,0 @@
-age-encryption.org/v1
--> ssh-ed25519 QfFraw 4W3jgP1yn2i/DzB9hlizQ12uGV9qD1HI7saQ6YkizzQ
-msRmL8kVMLSBw/EMMq/iUVfLVFksKw2ytW4xXSDpD6c
--> ssh-ed25519 G/hviA Lj41dsYNx7AQStcOK1jLFMUzA/+GEkjGhae7JXtb23k
-14IyqZ278mjiNFBok+4XcmCa1DNIE+cT6jJwQ1u9AuQ
---- O9GF4q+Hd1bVtBsL2nV+J+wj+B3k5p9fRz0DtmRbEic
-âiý>M[g¥‰¬^ƒÆ&W³èåz?9Ñ}X8Á¡½Á~ÅòÑÔyTtú5Ù¿=òŒêj¦ãFm

--- a/secrets/github-runner-stageplotiphar-token.age
+++ b/secrets/github-runner-stageplotiphar-token.age
@@ -1,0 +1,5 @@
+PLACEHOLDER — not a real age-encrypted secret.
+Replace before merging by running (from secrets/):
+  ./encrypt-secret.sh -n github-runner-stageplotiphar-token.age -e
+Content: a GitHub fine-grained PAT with read/write access to Actions
+self-hosted runners for TristonYoder/stagePlotiphar, no trailing newline.

--- a/secrets/github-runner-token.age
+++ b/secrets/github-runner-token.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw WAsBmJ473UWgp5620VtIeTVKz2TpNaWdzl8D4P57nnQ
+6fehuiRA9KOBs+12N+67fXA9riJC/1wgpZWPSpC3ZUM
+-> ssh-ed25519 HMaD4A cZOVq3vd7lrhJLw/prdxJeB7Lwaezq9mHI6qUTQ8nlo
+J8tVhxB/m2RLJRTM5UzP2zdGlyn4yZJaSYVtLP1rxGI
+-> ssh-ed25519 0B8VPA A8kVsmlZt4pfFlJg/CQxmTE8stV9XZTG8TJ3yVhiIks
+L4C4lwyQp18OcLz1a1TnclILfaGmZsumGhEovh74XY0
+-> ssh-ed25519 G/hviA 8MG+fwEpInbryKCKeb6LdkQpr7ZAlHCrejEzUP9w2Ek
+4m0NKvH9jJs2jagkruw4PN2V8xLeoLsM8YrnEQtmnKo
+--- knar4KfUpWRyCfAonlXLvb+H2AzXY+WgRFFN3zRM4Ro
+·¯Áçù;'™`ßö;”|¬¤'½®]—4~(oâG\í¢ïÚë@XFîù'½ã,ªÚ³Ò•Œòÿ=´ Ú­‘?<ŸÅQõ\g×8\¹£­xñK2Nk#Ñ0d’ƒ(hRô>ÉaT?ÍlièàûsVÃÖíh

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -46,7 +46,11 @@ in
   
   # Cloudflare API Token - Used by both servers for Caddy DNS-01 challenge
   "cloudflare-api-token.age".publicKeys = allServers;
-  
+
+  # GitHub self-hosted runner PAT — all-repo access, shared across runner
+  # instances/hosts rather than scoped to one repo
+  "github-runner-token.age".publicKeys = allServers;
+
   # =============================================================================
   # DAVID-SPECIFIC SECRETS
   # =============================================================================
@@ -130,9 +134,6 @@ in
 
   # Jellyfin API key for mp3-player-sync
   "jellyfin-api-key.age".publicKeys = davidKeys;
-
-  # GitHub self-hosted runner PAT for TristonYoder/stagePlotiphar (only on david)
-  "github-runner-stageplotiphar-token.age".publicKeys = davidKeys;
 
   # =============================================================================
   # SHARED SECRETS (All Servers)

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -130,7 +130,10 @@ in
 
   # Jellyfin API key for mp3-player-sync
   "jellyfin-api-key.age".publicKeys = davidKeys;
-  
+
+  # GitHub self-hosted runner PAT for TristonYoder/stagePlotiphar (only on david)
+  "github-runner-stageplotiphar-token.age".publicKeys = davidKeys;
+
   # =============================================================================
   # SHARED SECRETS (All Servers)
   # =============================================================================


### PR DESCRIPTION
## Summary
- New generic `modules.services.development.githubRunner` option (multi-instance, agenix-backed `tokenFile`), wrapping `services.github-runners`. Enabled on david with one instance, `stageplotiphar-david`, for `TristonYoder/stagePlotiphar`.
- Companion Darwin/launchd implementation at `modules/darwin/github-runner.nix` for hosts without a native NixOS-style runner service — written for reuse but not currently wired into any host.
- Runners get docker access by default (`dockerAccess = true`): docker + docker-compose on PATH, `SupplementaryGroups = [ "docker" ]` so the DynamicUser can reach `/run/docker.sock`, gated by an assertion that `virtualisation.docker.enable` is set.
- Runner is already live on david (deployed via SSH ahead of merge, since `secrets/github-runner-stageplotiphar-token.age` currently holds a short-lived (1hr) GitHub Actions runner registration token, not a long-lived PAT — GitHub doesn't expose PAT creation via API).

## Test plan
- [x] `nixos-rebuild dry-run` on david against this branch — clean
- [x] `darwin-rebuild build` locally on tyoder-mbp — clean (module unwired there)
- [x] `nixos-rebuild switch` on david — `github-runner-stageplotiphar-david.service` active, confirmed registered and `online` via `gh api repos/TristonYoder/stagePlotiphar/actions/runners`
- [x] Docker access verified on david: `docker version` succeeds inside the runner's namespace, `systemctl show` confirms `SupplementaryGroups=docker`, socket is `root:docker rw-rw----`
- [ ] CI test-nixos-config / deploy-nixos-config workflows pass on merge (note: the registration token embedded in the committed secret will likely have expired by merge time — that's fine, the token is only consumed once at initial registration and david's runner is already configured; re-encryption is only needed if the runner ever needs to re-register, e.g. after a state wipe)