### PR TITLE
fix: correct ghcr.io image path for ephemeral github runner

### DIFF
--- a/modules/services/development/github-runner.nix
+++ b/modules/services/development/github-runner.nix
@@ -87,7 +87,7 @@ let
 
       containerImage = mkOption {
         type = types.str;
-        default = "ghcr.io/myoung34/github-runner:ubuntu-noble";
+        default = "ghcr.io/myoung34/docker-github-actions-runner:ubuntu-noble";
         description = "Image to use when backend = \"container\".";
       };
     };


### PR DESCRIPTION
Fixes the image pull error in the ephemeral container runner by pointing to the correct ghcr.io repository name.