### PR TITLE
stageplotiphar: private admin server port + token

### DIFF
--- a/docker/productivity/stageplotiphar.nix
+++ b/docker/productivity/stageplotiphar.nix
@@ -40,6 +40,12 @@
       # inert unless the deployed image was built with the private billing
       # submodule.
       config.age.secrets.stageplotiphar-stripe-secrets.path
+      # ADMIN_TOKEN for the private admin server (see ADMIN_PORT below) —
+      # only present in images built with the private billing submodule.
+      # The app is fail-closed: it refuses to start the admin server without
+      # a token of at least 24 chars, so a missing/short secret here just
+      # keeps it disabled rather than exposing an unauthenticated port.
+      config.age.secrets.stageplotiphar-admin-secrets.path
     ];
     environment = {
       # Public URL the app stamps into PCO plan attachment links (stage plot
@@ -66,12 +72,33 @@
       # the deployed image was built with the private billing submodule.
       STRIPE_PRICE_MONTHLY = "price_1Tte2NDsDKkan45SGIAzSc3z";
       STRIPE_PRICE_YEARLY = "price_1Tte2NDsDKkan45Ss0vFKWd7";
+
+      # Private admin server (billing add-on) — listens on a second port
+      # inside the same container, separate from the public app on 1395.
+      # Setting ADMIN_PORT is what turns the admin server on at all; leaving
+      # it unset disables it entirely. ADMIN_HOST is intentionally left
+      # unset so the app defaults to 0.0.0.0 inside the container — the
+      # container's own network namespace already isolates it, and the real
+      # privacy boundary is the host port publishing below (127.0.0.1 only)
+      # plus the ADMIN_TOKEN gate from the secret file above. This port is
+      # deliberately NOT proxied by Caddy and NOT routed through the
+      # Cloudflare tunnel (see the Caddy block at the bottom of this file) —
+      # it must only ever be reachable privately (localhost / SSH tunnel /
+      # Tailscale), never from the public internet.
+      ADMIN_PORT = "1396";
     };
     volumes = [
       "stageplotiphar_data:/app/data:rw"
     ];
     ports = [
       "1395:1395/tcp"
+      # Admin server: bound to loopback only, matching this repo's
+      # established pattern for host-private docker services (see
+      # modules/services/productivity/stirling-pdf.nix,
+      # modules/services/storage/nextcloud/{onlyoffice,collabora}.nix). No
+      # 0.0.0.0 publish, no Caddy vhost, no tunnel route. Reachable from
+      # david itself or via `ssh -L 1396:localhost:1396 david`.
+      "127.0.0.1:1396:1396/tcp"
     ];
     log-driver = "journald";
     labels = {

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -84,6 +84,11 @@ with lib;
       # STRIPE_WEBHOOK_SECRET) loaded via environmentFiles. Test-mode demo
       # credentials, rotated before real launch.
       "stageplotiphar-stripe-secrets" = { file = ../secrets/stageplotiphar-stripe-secrets.age; mode = "0400"; };
+      # stageplotiphar admin server: KEY=VALUE file (ADMIN_TOKEN) loaded via
+      # environmentFiles. Only present in images built with the private
+      # billing submodule; the app disables the admin server entirely if
+      # ADMIN_PORT is unset and refuses to start it without this token.
+      "stageplotiphar-admin-secrets" = { file = ../secrets/stageplotiphar-admin-secrets.age; mode = "0400"; };
       # hermes-agent: NixOS module loaded only on david (external flake dep), no universal enable option
       "hermes-env" = { file = ../secrets/hermes-env.age; mode = "0400"; };
       # Deploy key (write access) for the private TristonYoder/hermes-brain repo —

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -136,6 +136,11 @@ in
   # keys, rotated before real launch. See docker/productivity/stageplotiphar.nix.
   "stageplotiphar-stripe-secrets.age".publicKeys = davidKeys;
 
+  # Stage Plotiphar admin server token — ADMIN_TOKEN gating the private,
+  # localhost-only admin port (billing add-on). Fail-closed: the app refuses
+  # to start the admin server without it. See docker/productivity/stageplotiphar.nix.
+  "stageplotiphar-admin-secrets.age".publicKeys = davidKeys;
+
   # Plex token for JellyPlex-Watched
   "plex-token.age".publicKeys = davidKeys;
 

--- a/secrets/stageplotiphar-admin-secrets.age
+++ b/secrets/stageplotiphar-admin-secrets.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw s7oiR3FXVc4MaHOSkNZW91/hD9X8CX+9wuiqaXWObjE
+K+EYJhqFz4iMIUJIOu3k70aw8KWOqQc/cNqVyL5iD0k
+-> ssh-ed25519 G/hviA EgXwBwlJNb5LBlLBTNUA5ykK8S30CmzD65Plb8be6hk
+p0PK0G7WTtHJaxMUjglzkMG/TYr+mHYEOSZyRfa5Wmo
+--- DcAy2H2hF084uB4EBRYN8Zfl5MgVLur53aG3RO/04Ms
+iô¹3®¾pôd††è³z¢É³t·†‚MÊkT• ?MÂäÛäî¼Ÿ7ªõO¤&ëÆZura#ŽS`½·G;e6“)j¿˜<,™_¬2Þ }ÆéMUx†ô|#¢ñäõ


### PR DESCRIPTION
## Summary

Wires the new Stage Plotiphar admin server (private billing add-on) into the existing `stageplotiphar` container:

- `ADMIN_PORT = "1396"` added to the container's `environment` — this is what turns the admin server on inside the image at all; unset means disabled.
- New agenix secret `secrets/stageplotiphar-admin-secrets.age` (`ADMIN_TOKEN=...`, freshly generated, 24+ chars) added to `environmentFiles`, registered in `secrets/secrets.nix` (`davidKeys`, mirroring `stageplotiphar-postgres-secrets`), and declared in `modules/secrets.nix` (mirroring the same entry).
- `ADMIN_HOST` intentionally left unset (defaults to `0.0.0.0` inside the container's own network namespace — isolation comes from host port publishing + the token, not from binding inside the container).
- Comment block in `docker/productivity/stageplotiphar.nix` documents what the admin server is, why it's private-only, and that the token lives in agenix.

This stacks logically on #283 (Stripe billing env), which is still open — both touch the same container for the private billing add-on, no direct file conflicts expected.

## Exposure decision

**Publishes `127.0.0.1:1396:1396` on the host — loopback only.**

I grepped this repo for its established pattern for host-private docker services before choosing this. There is no Tailscale-interface-IP binding pattern for docker container ports anywhere in the repo (checked `tailscale.nix`, `profiles/server.nix`, all docker modules) — Tailscale CIDRs only show up as Caddy `trustedProxies` entries, not as bind addresses. The actual established pattern for "private-only" docker services is binding the host port to `127.0.0.1`:

- `modules/services/productivity/stirling-pdf.nix`: `"127.0.0.1:${port}:8080"`
- `modules/services/storage/nextcloud/onlyoffice.nix`: `"127.0.0.1:${port}:80/tcp"`
- `modules/services/storage/nextcloud/collabora.nix`: `"127.0.0.1:${port}:9980/tcp"`
- `modules/services/media/feishin.nix`: `"127.0.0.1:${port}:9180/tcp"`

So I followed that pattern rather than inventing a new one. Reachable from david itself or via `ssh -L 1396:localhost:1396 david`. **No Caddy vhost and no Cloudflare tunnel route were added or touched** — the existing `plotiphar.com` vhost still only proxies port 1395.

If you'd rather bind to david's Tailscale IP instead of `127.0.0.1` (e.g. to reach it from other tailnet devices without an SSH tunnel), that's a one-line change to the `ports` entry — flagging it here since there's no existing precedent in the repo either way.

## Notes

- The admin server only exists in images built with the private billing submodule; on other builds `ADMIN_PORT` being set is harmless (the binary just won't have that code path) and the token being absent doesn't matter for those builds either way.
- Fail-closed by design: the app refuses to start the admin server without `ADMIN_TOKEN` (min 24 chars), so a missing/short secret just keeps it disabled rather than exposing an unauthenticated port.
- **Merging this PR auto-deploys to david — please don't merge until you're ready to roll it out.**

## Verification

- `nix-instantiate --parse` passed on all three changed `.nix` files.
- `nix flake check --no-build` passed for all systems it could evaluate (`aarch64-darwin`) — "all checks passed!". Only pre-existing, unrelated evaluation warnings appeared (logind option renames, ssh default-config deprecation, Kasm default password, ZFS `forceImportRoot`, scripted-initrd deprecation, isoImage rename) — none touch this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)