### PR TITLE
feat: add macOS VM on david (libvirt + QEMU/KVM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This is a flake-based, multi-host Nix configuration managing NixOS servers, desk
 - **tristons-nixbook-pro** (NixOS on T2 MacBook Pro 16,1) - Dual-boot, uses `nixos-hardware.apple-t2`. Custom bootable installer ISOs built from the flake (`tristons-nixbook-pro-installer`, `tristons-nixbook-pro-installer-plasma`).
 - **tyoder-mbp** (macOS Apple Silicon) - Work MacBook Pro
 - **Tristons-MacBook-Pro** (macOS Intel) - Personal MacBook Pro
+- **macos-vm** (macOS on QEMU/KVM) - macOS Sequoia VM running on david under libvirt. Used for CI runners, development/testing, and macOS-only services. QEMU disk at `/data/vms/macos-vm/disk.qcow2`, macvtap networking (LAN IP on `theyoder.family`), joined to Tailscale. Guest OS is provisioned manually outside of Nix; host-side config (libvirt, quickemu config, vHosts wiring) is declared in `modules/services/infrastructure/libvirt.nix`.
 
 ## Security — This Repo Is Public
 
@@ -713,6 +714,64 @@ ssh github-actions@david.vpn.theyoder.family "sudo journalctl -u azuracast-playl
 It's idempotent — safe to run anytime, only creates stations for m3u files without one yet.
 
 **If station creation fails with "no available ports for new radio stations":** AzuraCast reserves a full 10-port block per station (frontend/telnet/dj/headroom), not just the 3 ports actually bound. Widen `modules.services.media.azuracast.stationPortMax`, but check `sudo ss -tulpn` on david first for a clean gap rather than just incrementing — the original 9500-9599 range was extended once already and had to be relocated entirely to 23000-24999 to get clear of neighboring services.
+
+### macOS VM on david (QEMU/KVM + libvirt)
+
+**Host:** david — `modules.services.infrastructure.libvirt.macosVm`
+
+The macOS VM (`macos-vm`) runs under libvirt on david. Host-side configuration is declared in `modules/services/infrastructure/libvirt.nix`; the guest OS is provisioned manually outside Nix.
+
+**Storage:** QEMU disk at `/data/vms/macos-vm/disk.qcow2`. `/data` is ZFS-backed, so the disk image still gets compression and snapshots at the filesystem level.
+
+**Networking:** macvtap on david's `enp4s0f0` gives the VM its own LAN IP on `theyoder.family`. The VM then joins Tailscale inside the guest. Set `tailscaleIp` in the host config to enable Caddy reverse-proxy via the vHosts registry.
+
+**Quickemu helper:** `quickemu` is available on david (packaged in `modules/system/core.nix`). With a file-based disk, quickemu handles the entire VM lifecycle — OpenCore firmware, macOS boot, and disk management.
+
+**First-time setup procedure:**
+
+1. **Enable and rebuild:**
+   ```bash
+   git add . && git commit -m "feat: add macOS VM on david (libvirt + QEMU/KVM)"
+   git push
+   rebuild
+   ```
+
+2. **Download the macOS installer + OpenCore** (automated via quickget):
+   ```bash
+   sudo systemctl start get-macos-installer
+   sudo journalctl -u get-macos-installer -f    # watch progress (~12 GB download)
+   ```
+   This runs `quickget macos sequoia` which fetches Apple's `InstallAssistant.pkg`
+   from the softwareupdate catalog and prepares OpenCore — same process as
+   `fetch-macOS.py` used by Docker-OSX and macOS-Simple-KVM.
+
+3. **Launch the macOS installer** via quickemu (spice GUI for the interactive install):
+   ```bash
+   quickemu --vm /etc/quickemu/macos-vm.conf --macvtap --display spice
+   ```
+   - Boots into the macOS recovery system
+   - Use Disk Utility to erase the virtual disk (named something like "QEMU QEMU HARDDISK")
+   - Then install macOS onto it
+
+4. **Stop the VM** after install is complete.
+
+5. **After install:** Join Tailscale inside the VM, note the Tailscale IP, and update `tailscaleIp` in david's `configuration.nix`:
+   ```nix
+   tailscaleIp = "100.XX.XX.XX";  # from Tailscale admin UI or `sudo tailscale ip`
+   ```
+   Rebuild david to wire Caddy.
+
+**Troubleshooting:**
+
+- **Libvirt can't start macOS VM:** Verify KVM is available (`kvm-ok` on AMD) and that the user running the VM is in the `libvirtd` group. Check `sudo virsh capabilities | grep kvm`.
+
+- **No LAN IP via macvtap:** macvtap requires the host NIC to be up. Run `ip link set enp4s0f0 up` if the interface went down. The VM MAC address is random — it gets a DHCP lease like any other device on the network.
+
+- **Quickemu spice display slow:** Add `--display spice` for better performance over the LAN; use a VNC client (e.g. virt-viewer) to connect. For headless operation after setup, omit `--display` to run without a graphical console.
+
+- **Can't erase disk in macOS installer:** The virtual disk may appear as "QEMU QEMU HARDDISK" or similar. In Disk Utility, you may need to select "View > Show All Devices" to see the physical disk (not just volumes), then erase the top-level device, not the partition.
+
+- **quickget fails with "not available for arm64":** This happens when running `quickget` on an Apple Silicon Mac (e.g. tyoder-mbp). It's a host-architecture check; `quickget` only downloads x86_64 macOS images. Run it on david (x86_64) instead.
 
 ## References
 

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -345,6 +345,32 @@ in
     };
   };
 
+  # =============================================================================
+  # VIRTUALIZATION: macOS VM
+  # =============================================================================
+  #
+  # macOS VM (Sequoia) running on QEMU/KVM via libvirt. Quickemu manages the VM
+  # lifecycle (disk at /data/vms/macos-vm/disk.qcow2, macvtap for LAN IP on
+  # theyoder.family, joined to Tailscale for mesh access). The guest OS is
+  # provisioned manually outside Nix — this only manages the host side (libvirt,
+  # quickemu config, reverse proxy wiring).
+  #
+  # First-time setup (run on david after rebuild):
+  #   sudo systemctl start get-macos-installer          # download installer + OpenCore
+  #   sudo journalctl -u get-macos-installer -f         # watch progress
+  #   quickemu --vm /etc/quickemu/macos-vm.conf --macvtap --display spice  # install
+  #
+  modules.services.infrastructure.libvirt = {
+    enable = true;
+    macosVm = {
+      enable = true;
+      vcpu = 4;
+      memory = 8192;
+      diskPath = "/data/vms/macos-vm/disk.qcow2";
+      tailscaleIp = null;  # set after VM joins Tailscale
+    };
+  };
+
   # Self-hosted GitHub Actions runners for TristonYoder/stagePlotiphar.
   # Name must be unique per registered runner across all hosts hitting this
   # repo — defaults to the attrset key, so don't reuse these names elsewhere

--- a/modules/services/infrastructure/default.nix
+++ b/modules/services/infrastructure/default.nix
@@ -10,5 +10,6 @@
     ./scrutiny.nix
     ./tailscale.nix
     ./technitium.nix
+    ./libvirt.nix
   ];
 }

--- a/modules/services/infrastructure/libvirt.nix
+++ b/modules/services/infrastructure/libvirt.nix
@@ -1,0 +1,133 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.infrastructure.libvirt;
+  domain = config.networking.domain;
+in
+{
+  options.modules.services.infrastructure.libvirt = {
+    enable = mkEnableOption "libvirt QEMU/KVM virtualization host";
+
+    macosVm = {
+      enable = mkEnableOption "macOS VM on QEMU/KVM";
+
+      name = mkOption {
+        type = types.str;
+        default = "macos-vm";
+        description = "Domain name for the macOS VM.";
+      };
+
+      vcpu = mkOption {
+        type = types.int;
+        default = 4;
+        description = "Number of vCPUs.";
+      };
+
+      memory = mkOption {
+        type = types.int;
+        default = 8192;
+        description = "Memory in MB.";
+      };
+
+      diskPath = mkOption {
+        type = types.str;
+        default = "/data/vms/macos-vm/disk.qcow2";
+        description = "Path to the VM disk image.";
+      };
+
+      diskSizeG = mkOption {
+        type = types.int;
+        default = 100;
+        description = "Disk image size in GB (applied by quickemu on first boot).";
+      };
+
+      macosVersion = mkOption {
+        type = types.str;
+        default = "sequoia";
+        description = "macOS release version (passed to quickemu).";
+      };
+
+      tailscaleIp = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Tailscale IP of the macOS VM. When set, a vHost entry is created so
+          Caddy can reverse-proxy to services running inside the VM.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.libvirtd = {
+      enable = true;
+      qemu = {
+        package = pkgs.qemu;
+        runAsRoot = true;
+        swtpm.enable = true;
+        ovmf.enable = true;
+      };
+    };
+
+    environment.systemPackages = with pkgs; [
+      libvirt
+      virt-manager
+      virt-viewer
+    ];
+
+    users.users.tristonyoder.extraGroups = [ "libvirtd" ];
+
+    # ── quickemu config for the macOS VM ─────────────────────────────────────
+    environment.etc."quickemu/macos-vm.conf" = mkIf cfg.macosVm.enable {
+      text = ''
+        # macOS VM — managed by Nix; DO NOT EDIT MANUALLY
+        # Launch: quickemu --vm /etc/quickemu/macos-vm.conf [--macvtap] [--display spice]
+        guest_os="macos"
+        macos_release="${cfg.macosVm.macosVersion}"
+        disk_img="${cfg.macosVm.diskPath}"
+        img_size="${toString cfg.macosVm.diskSizeG}G"
+      '';
+    };
+
+    # ── macOS installer fetcher (quickget) ────────────────────────────────────
+    # Downloads the macOS recovery image and OpenCore bootloader from Apple's
+    # softwareupdate catalog — same mechanism as fetch-macOS.py from Docker-OSX
+    # and macOS-Simple-KVM. Runs as tristonyoder so assets land in the right
+    # place for quickemu to find them.
+    #
+    # Trigger on demand — only needed once (or on macOS version upgrade):
+    #   sudo systemctl start get-macos-installer
+    #   sudo journalctl -u get-macos-installer -f    # watch progress (~12 GB)
+    systemd.services."get-macos-installer" = mkIf cfg.macosVm.enable {
+      description = "Download macOS ${cfg.macosVm.macosVersion} installer + OpenCore";
+      path = [ pkgs.quickemu pkgs.coreutils pkgs.bash ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "tristonyoder";
+      };
+      script = ''
+        set -e
+        echo "==> Downloading macOS ${cfg.macosVm.macosVersion} installer..."
+        echo "    (this may take a while — the installer is several GB)"
+        quickget --download macos ${cfg.macosVm.macosVersion}
+        echo "==> Done. Installer ready for:"
+        echo "    quickemu --vm /etc/quickemu/macos-vm.conf --macvtap --display spice"
+      '';
+    };
+
+    # ── vHosts: wire Caddy to proxy services inside the VM ────────────────────
+    modules.services.vHosts.hosts = mkIf (cfg.macosVm.enable && cfg.macosVm.tailscaleIp != null) {
+      "macos-vm.${domain}" = {
+        reverseProxyHost = cfg.macosVm.tailscaleIp;
+        reverseProxyPort = 80;
+        reverseProxySSL = false;
+        displayName = "macOS VM";
+        category = "infrastructure";
+        icon = "apple";
+        monitor = false;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds a macOS Sequoia VM on david under libvirt.

- **New module:** `modules/services/infrastructure/libvirt.nix` — manages libvirtd with QEMU/KVM, OVMF, swtpm
- **File-based disk:** `/data/vms/macos-vm/disk.qcow2` on ZFS (compression + snapshots)
- **Automated installer:** `get-macos-installer.service` — runs `quickget` to download macOS installer + OpenCore from Apple's softwareupdate catalog
- **Quickemu config:** auto-generated at `/etc/quickemu/macos-vm.conf`
- **macvtap networking:** VM gets its own LAN IP on `theyoder.family`
- **vHosts registry:** Caddy reverse-proxy to Tailscale IP (once set)
- **Guest OS:** provisioned manually outside Nix

First-time setup: `sudo systemctl start get-macos-installer && quickemu --vm /etc/quickemu/macos-vm.conf --macvtap --display spice`