### PR TITLE
stageplotiphar: set SYNC_ENABLED=1 for offline-first replicas

### DIFF
--- a/docker/productivity/stageplotiphar.nix
+++ b/docker/productivity/stageplotiphar.nix
@@ -66,6 +66,25 @@
       # Postgres password.
       DATABASE_TYPE = "postgres";
 
+      # Makes deletes soft (sets a `deleted_at` tombstone) for the entities
+      # the offline-first Mac app replicates, so a deletion made here in the
+      # web UI actually propagates to those replicas. Without it a delete is
+      # a hard row removal, the delta feed has nothing to report, and every
+      # offline client keeps the deleted item forever.
+      #
+      # Deliberately NOT `SYNC_MODE=cloud` — that is the *replica* mode. It
+      # additionally enables a client-side outbox whose table only exists in
+      # the app's SQLite schema, so setting it on this Postgres-backed server
+      # would break on the first write. The two gates are separate for
+      # exactly this reason: `SYNC_ENABLED` = "produce tombstones others can
+      # sync", `SYNC_MODE=cloud` = "be a replica that syncs".
+      #
+      # Low blast radius on its own: it only changes delete semantics, and
+      # the tombstoned rows are filtered out of every normal read, so the UI
+      # behaves identically. The /api/sync/* endpoints it feeds resolve
+      # through the same per-org auth as every other route.
+      SYNC_ENABLED = "1";
+
       # Stripe price IDs for the optional billing add-on — not secret (price
       # IDs, unlike the API key/webhook secret above). Stripe test-mode
       # ("demo") prices, rotated before real launch. Billing is inert unless


### PR DESCRIPTION
## What

Adds `SYNC_ENABLED = "1"` to the stageplotiphar container's environment.

## Why

The offline-first Mac app (Stage Plotiphar Cloud) keeps a local replica of an org's data and syncs deltas back. For a **deletion made in the web UI** to reach those replicas, the server has to leave a **tombstone** (`deleted_at`) instead of hard-deleting the row. That's what this flag turns on.

Without it, a delete removes the row outright, the delta feed has nothing to report, and every offline client keeps the deleted item indefinitely.

## Why not `SYNC_MODE=cloud`

That's the *replica-side* gate — it also enables a client-side outbox whose table exists only in the app's SQLite schema, so setting it on this Postgres-backed server would fail on the first write. The two gates are intentionally separate:

| Gate | Meaning |
|---|---|
| `SYNC_ENABLED=1` | produce tombstones others can sync (this server) |
| `SYNC_MODE=cloud` | be a replica that syncs (the Mac app) |
| *neither* | unchanged legacy behavior |

## Blast radius

Low. It only changes delete semantics; tombstoned rows are filtered out of every normal read, so the UI behaves identically. The `/api/sync/*` endpoints it feeds resolve through the same per-org auth as every other route.

## Dependency / ordering

Needs the sync endpoints, which are on `stagePlotiphar` `main` (PRs #107–#129). Migration `0005_sync_foundation` adds the nullable `updated_at`/`deleted_at` columns — additive and backward-compatible.

Since the container tracks `:latest` and watchtower is running, the **image side arrives on its own**; this PR just flips the delete semantics once it does. Safe to merge before or after the image lands — the flag is inert until the app understands it.

## Verification

`nix-instantiate --parse` clean. Not merged — merging deploys live to `david`, so that's your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)