### PR TITLE
fix: update nixpkgs-unstable to resolve lttng-tools ABI mismatch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -452,11 +452,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- `nixos-rebuild` on david was failing: lttng-tools 2.14.1 failed to build against a mismatched lttng-ust ABI (`struct lttng_ust_abi_object_data` has no member named `handle`), which broke `libmsquic` -> `technitium-dns-server`
- Root cause: `nixpkgs-unstable` was pinned to a 2026-07-11 snapshot with the version mismatch
- Bumped `nixpkgs-unstable` to 2026-07-18, where lttng-tools/lttng-ust are both 2.15.1 (matched)

## Test plan
- [x] `nixos-rebuild dry-run --flake github:TristonYoder/nix-config/fix/nixpkgs-unstable-lttng-abi#david --refresh` on david completes with no errors; technitium-dns-server and libmsquic resolve to cached prebuilt paths