### PR TITLE
fix: enable weekly docker auto-prune on david

### DIFF
--- a/.claude/skills/nixos-debug/references/playbooks.md
+++ b/.claude/skills/nixos-debug/references/playbooks.md
@@ -193,3 +193,34 @@ error: hash mismatch in fixed-output derivation '.../caddy-src-with-plugins-....
 `caddy.nix` — the mismatch is expected drift, not a security concern, since the fetch
 target (Go module proxy for the pinned `github.com/...@vX.Y.Z` plugin refs) is unchanged.
 Do not use `lib.fakeSha256` as a permanent value; only the real `got` hash belongs there.
+
+---
+
+## GitHub Runner Crashes: "No space left on device"
+**Host:** david
+
+Symptom: runner Worker process throws `System.IO.IOException: No space left on device`
+trying to write its own diagnostic log under `/var/lib/github-runner/<runner>/_diag/`.
+Root cause is unrelated to the runner itself — david's root filesystem (`/`, 907G) filled
+up, mostly from accumulated Docker image layers (`docker system df` showed 170GB+
+reclaimable from ~210 images, most orphaned/untagged from past builds).
+
+**Diagnosis:**
+```bash
+ssh github-actions@david.vpn.theyoder.family "df -h /"
+ssh github-actions@david.vpn.theyoder.family "sudo docker system df"
+```
+`github-actions` has passwordless sudo on david; `tristonyoder` does not — use
+`github-actions@` for any diagnostics requiring `sudo -n`.
+
+**Quick fix:**
+```bash
+ssh github-actions@david.vpn.theyoder.family "sudo docker system prune -af"
+```
+Removes stopped containers, unused networks, build cache, and — critically — all
+images not referenced by a running container (not just dangling ones). Freed ~190GB
+in the 2026-07 incident (100% full → 78% used).
+
+**Permanent fix applied:** `virtualisation.docker.autoPrune` enabled in
+`hosts/david/configuration.nix` (weekly, `--all` flag) so unused images don't
+re-accumulate silently.

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -29,6 +29,15 @@ in
   networking.hostName = "david";
   system.stateVersion = "23.11"; # Did you read the comment?
 
+  # Unused image layers accumulate across the many docker/*.nix services and the
+  # GitHub Actions runner's dockerAccess builds, filling the root disk (hit 100%
+  # full in 2026-07 and crashed the runner). Weekly prune keeps it in check.
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    dates = "weekly";
+    flags = [ "--all" ];
+  };
+
   # tristons-workstation is reachable via Tailscale but not via VLAN from david's br0.
   # Pin it to the Tailscale IP so internal service lookups (LiteLLM → Ollama) work.
   networking.hosts.${workstationIp} = [ "tristons-workstation.theyoder.family" "tristons-workstation" ];


### PR DESCRIPTION
## Summary
- Root disk on david filled to 100% (861G/907G) from ~170GB of unused docker image layers, crashing the github-actions runner mid-job with "No space left on device"
- Manually reclaimed ~190GB via `docker system prune -af`
- Enabled `virtualisation.docker.autoPrune` (weekly, `--all`) on david to prevent recurrence
- Documented the incident and fix in the nixos-debug playbook

## Test plan
- [x] Dry-run build on david via `nixos-rebuild dry-run --flake github:TristonYoder/nix-config/fix/docker-auto-prude#david --refresh` — evaluates and builds cleanly
- [ ] Merge and verify `docker-prune.timer` appears after next rebuild (`systemctl list-timers | grep docker`)