### PR TITLE
feat: add apple-mail-mcp module, enable on tyoder-mbp

### DIFF
--- a/home/modules/apple-mail-mcp.nix
+++ b/home/modules/apple-mail-mcp.nix
@@ -1,0 +1,65 @@
+# Apple Mail MCP server (patrickfreyer/apple-mail-mcp)
+#
+# Registers the `mcp-apple-mail` server with the Claude desktop app so Claude
+# can read/search/send Apple Mail. The server is fetched and run on demand by
+# `uvx` (from the `uv` package) — no persistent install.
+#
+# Home Manager module. Import + enable it in a user's home config, e.g.:
+#   imports = [ ./modules/apple-mail-mcp.nix ];
+#   modules.mcp.appleMail.enable = true;
+#
+# NOTE: On first use, macOS prompts to allow Claude to control Mail.app
+# (System Settings > Privacy & Security > Automation). This grant is per-user
+# and cannot be declared in nix — approve it once when Claude first runs a tool.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.mcp.appleMail;
+in
+{
+  options.modules.mcp.appleMail = {
+    enable = mkEnableOption "Apple Mail MCP server for the Claude desktop app";
+
+    readOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Run the server in read-only mode. Claude can read and search mail but
+        cannot send, move, or delete messages.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.uv;
+      defaultText = literalExpression "pkgs.uv";
+      description = "The uv package providing `uvx`, used to fetch and run mcp-apple-mail.";
+    };
+
+    configPath = mkOption {
+      type = types.str;
+      default = "Library/Application Support/Claude/claude_desktop_config.json";
+      description = ''
+        Path (relative to the user's home) of the Claude desktop app's MCP
+        config file this module manages.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # `uvx` (from uv) fetches and runs the Python server on demand.
+    home.packages = [ cfg.package ];
+
+    # Declaratively own the Claude desktop MCP config. Use an absolute path to
+    # uvx — the app launches servers with a minimal PATH that lacks the nix
+    # profile bin dir.
+    home.file.${cfg.configPath}.text = builtins.toJSON {
+      mcpServers.apple-mail = {
+        command = "${cfg.package}/bin/uvx";
+        args = [ "mcp-apple-mail" ] ++ optional cfg.readOnly "--read-only";
+      };
+    };
+  };
+}

--- a/home/tyoder.nix
+++ b/home/tyoder.nix
@@ -7,12 +7,16 @@
     ./common.nix
     ./modules/homebrew.nix
     ./modules/mas.nix
+    ./modules/apple-mail-mcp.nix
     ./tristonyoder-darwin.nix
   ];
-  
+
   # User and home directory
   home.username = "tyoder";
   home.homeDirectory = "/Users/tyoder";
   home.stateVersion = "25.05";
+
+  # Apple Mail MCP server for the Claude desktop app (work MacBook only).
+  modules.mcp.appleMail.enable = true;
 }
 


### PR DESCRIPTION
Defines a Home Manager module for [patrickfreyer/apple-mail-mcp](https://github.com/patrickfreyer/apple-mail-mcp) and activates it on the TPCC work MacBook (tyoder-mbp).

## Changes
- **`home/modules/apple-mail-mcp.nix`** — enable-gated module `modules.mcp.appleMail`. Installs `uv` and declaratively writes the Claude desktop app's MCP config to register `apple-mail` → `uvx mcp-apple-mail`. The command uses an absolute nix-store path to `uvx` since the app launches servers with a minimal PATH. Options: `readOnly` (adds `--read-only`), `package` (defaults `pkgs.uv`), `configPath`.
- **`home/tyoder.nix`** — imports the module and sets `modules.mcp.appleMail.enable = true;`. Scoped to tyoder-mbp only (this home config isn't used by other hosts).

## Deploy notes
- The module owns `~/Library/Application Support/Claude/claude_desktop_config.json` via a read-only symlink. If a real file with other MCP servers already exists there, back it up first or the rebuild will refuse to clobber it.
- First tool use triggers a one-time macOS Automation grant (Claude → Mail.app) — per-user, can't be declared in nix.

Verified with `nix eval` of the generated config on the `tyoder-mbp` darwin config.