### PR TITLE
fix: drop dolphin-emu from darwin packages

### DIFF
--- a/home/tristonyoder-darwin.nix
+++ b/home/tristonyoder-darwin.nix
@@ -12,9 +12,6 @@
     # macOS-specific tools
     syncthing
     dockutil
-
-    # Emulators
-    dolphin-emu  # GameCube and Wii emulator
   ];
   
   # =============================================================================


### PR DESCRIPTION
`sfml-3.0.2` (a `dolphin-emu` dependency) fails to link on darwin after a nixpkgs-unstable bump — `ld` SIGTRAPs with exit 133 while linking `libsfml-window.dylib`, which fails **every** darwin rebuild (tyoder-mbp and Tristons-MacBook-Pro).

Removes the GameCube/Wii emulator from the shared `home/tristonyoder-darwin.nix` package list to unblock builds. Verified `tyoder-mbp` toplevel evaluates cleanly with `sfml`/`dolphin-emu` gone from the closure.

Surfaced while deploying the apple-mail-mcp module (#291) — unrelated pre-existing breakage.