### PR TITLE
fix: bump feishin insecure electron pin to 40.10.5

### DIFF
--- a/common/system.nix
+++ b/common/system.nix
@@ -38,7 +38,7 @@ in
   # Allow insecure packages for specific applications
   nixpkgs.config.permittedInsecurePackages = [
     "electron-35.7.5"  # Required for gfn-electron (GeForce Now)
-    "electron-39.8.10" # Required for feishin (upgraded from electron-36 in 26.05)
+    "electron-40.10.5" # Required for feishin (bumped from electron-39 in nixpkgs-unstable)
     "olm-3.2.16"       # Required for Matrix communication bridges
     "pnpm-10.29.2"     # Required for cherry-studio (pnpm 10.29.3+ breaks its electron-builder step)
   ];


### PR DESCRIPTION
nixpkgs-unstable bumped feishin to `electron-40.10.5`, but `common/system.nix` still permitted `electron-39.8.10`, so every darwin rebuild failed evaluation:

```
error: Refusing to evaluate package 'electron-40.10.5' … because it is marked as insecure
```

Updates the pin in `nixpkgs.config.permittedInsecurePackages`. Verified `tyoder-mbp` toplevel evaluates cleanly with no `NIXPKGS_ALLOW_INSECURE` override — confirming no other insecure package is behind it.

Surfaced while deploying the apple-mail-mcp module; unrelated pre-existing breakage from an inputs bump.