### PR TITLE
fix: apple-mail-mcp installs uv only; darwin backupFileExtension

### DIFF
--- a/common/darwin.nix
+++ b/common/darwin.nix
@@ -11,7 +11,12 @@
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
   system.stateVersion = 5;
-  
+
+  # Back up pre-existing files (e.g. brew's ~/.zprofile) instead of failing
+  # activation when Home Manager wants to manage a path that already exists.
+  # NixOS hosts already set this per-host in flake.nix; darwin hosts inherit it here.
+  home-manager.backupFileExtension = "backup";
+
   # =============================================================================
   # HOST-SPECIFIC SETTINGS
   # =============================================================================

--- a/home/modules/apple-mail-mcp.nix
+++ b/home/modules/apple-mail-mcp.nix
@@ -1,10 +1,17 @@
 # Apple Mail MCP server (patrickfreyer/apple-mail-mcp)
 #
-# Registers the `mcp-apple-mail` server with the Claude desktop app so Claude
-# can read/search/send Apple Mail. The server is fetched and run on demand by
-# `uvx` (from the `uv` package) — no persistent install.
+# Makes the `mcp-apple-mail` server runnable via `uvx` by installing `uv`.
+# It deliberately does NOT manage the Claude desktop config
+# (claude_desktop_config.json) — that file is the app's live preferences store
+# and is left entirely to the user. Register the server yourself, e.g.:
 #
-# Home Manager module. Import + enable it in a user's home config, e.g.:
+#   claude mcp add apple-mail -- uvx mcp-apple-mail
+#
+# or add this to the app's config manually:
+#
+#   "mcpServers": { "apple-mail": { "command": "uvx", "args": ["mcp-apple-mail"] } }
+#
+# Home Manager module. Import + enable it in a user's home config:
 #   imports = [ ./modules/apple-mail-mcp.nix ];
 #   modules.mcp.appleMail.enable = true;
 #
@@ -20,16 +27,7 @@ let
 in
 {
   options.modules.mcp.appleMail = {
-    enable = mkEnableOption "Apple Mail MCP server for the Claude desktop app";
-
-    readOnly = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Run the server in read-only mode. Claude can read and search mail but
-        cannot send, move, or delete messages.
-      '';
-    };
+    enable = mkEnableOption "Apple Mail MCP server runtime (uv/uvx) for the Claude desktop app";
 
     package = mkOption {
       type = types.package;
@@ -37,29 +35,12 @@ in
       defaultText = literalExpression "pkgs.uv";
       description = "The uv package providing `uvx`, used to fetch and run mcp-apple-mail.";
     };
-
-    configPath = mkOption {
-      type = types.str;
-      default = "Library/Application Support/Claude/claude_desktop_config.json";
-      description = ''
-        Path (relative to the user's home) of the Claude desktop app's MCP
-        config file this module manages.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
-    # `uvx` (from uv) fetches and runs the Python server on demand.
+    # `uvx` (from uv) fetches and runs the Python server on demand. The Claude
+    # desktop config is intentionally left untouched — register the server there
+    # manually (see the header comment).
     home.packages = [ cfg.package ];
-
-    # Declaratively own the Claude desktop MCP config. Use an absolute path to
-    # uvx — the app launches servers with a minimal PATH that lacks the nix
-    # profile bin dir.
-    home.file.${cfg.configPath}.text = builtins.toJSON {
-      mcpServers.apple-mail = {
-        command = "${cfg.package}/bin/uvx";
-        args = [ "mcp-apple-mail" ] ++ optional cfg.readOnly "--read-only";
-      };
-    };
   };
 }


### PR DESCRIPTION
Follow-up to the apple-mail-mcp module after hitting activation collisions on tyoder-mbp.

## Changes
- **apple-mail-mcp** no longer manages `claude_desktop_config.json`. That file turned out to be the Claude desktop app's full live preferences store (cowork settings, permission-mode acks, starred sessions), not an MCP-only config — managing it would wipe user settings. The module now just installs `uv`; register the server manually (`claude mcp add apple-mail -- uvx mcp-apple-mail`).
- **common/darwin.nix**: set `home-manager.backupFileExtension = "backup"` (all NixOS hosts already had it; darwin didn't). Fixes activation failing on the pre-existing `~/.zprofile` (brew shellenv) collision. Homebrew stays on PATH via `/etc/paths.d/homebrew`, so the backed-up `.zprofile` line is redundant.

Verified tyoder-mbp toplevel evaluates cleanly.