### PR TITLE
fix: trigger ipod-sync on block device event, not raw USB device event

### DIFF
--- a/modules/services/storage/ipod-sync.nix
+++ b/modules/services/storage/ipod-sync.nix
@@ -101,7 +101,7 @@ in
             MOUNT="${cfg.mountPoint}"
 
             DEVICE=$(${pkgs.util-linux}/bin/lsblk -ndo NAME,VENDOR \
-              | ${pkgs.gnugrep}/bin/grep -i "apple" \
+              | { ${pkgs.gnugrep}/bin/grep -i "apple" || true; } \
               | ${pkgs.gawk}/bin/awk '{print "/dev/" $1}' \
               | head -1)
 
@@ -150,8 +150,12 @@ in
       };
     };
 
+    # Triggered on the block/disk uevent (not the raw USB device uevent) so that
+    # /dev/sdX already exists by the time the service runs. Triggering on the USB
+    # device add event instead races the kernel's SCSI probe: the service can start
+    # and run lsblk before the block device is enumerated, finding nothing.
     services.udev.extraRules = ''
-      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[0-9a-f][0-9a-f]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ipod-sync.service"
+      ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="12[0-9a-f][0-9a-f]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ipod-sync.service"
     '';
   };
 }


### PR DESCRIPTION
## Summary
- iPod auto-sync on tristons-workstation stopped triggering automatically; manual `systemctl restart ipod-sync` always worked.
- Root cause: the udev rule fired on the raw USB device's `add` event, which happens during enumeration, before the kernel finishes SCSI-probing and creating `/dev/sdX`. The service would start and run `lsblk` before the block device existed.
- Under `set -euo pipefail`, the failed `grep` (no match) in the `DEVICE=$(...)` pipeline aborted the script silently before it could reach the intended "No Apple USB storage device found" message — confirmed live: a triggered run exited in ~13ms with no output and exit code 1.
- Fix: trigger the udev rule off the `block`/`disk` uevent instead, which only fires once `/dev/sdX` actually exists. Also hardened the `lsblk | grep` pipeline so a genuine no-device case degrades gracefully instead of hitting the same pipefail trap.

## Test plan
- [x] Deployed to tristons-workstation via `rebuild -b fix/ipod-udev-race test`
- [x] Confirmed new udev rule present in `/etc/udev/rules.d/99-local.rules`
- [x] Replugged iPod, watched `journalctl -f -u ipod-sync` live — service triggered automatically and completed a full sync