### PR TITLE
fix: Syncthing launchd agent crash-loops on macOS (missing HOME)

### DIFF
--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -86,7 +86,12 @@
   
   # Configure Syncthing to start automatically at login using launchd
   # This ensures Syncthing runs in the background after user login
-  # Launch agents run in the user's context, so HOME is automatically set
+  #
+  # environment.launchAgents installs into /Library/LaunchAgents (system-wide,
+  # root-owned). Despite running in the logged-in user's GUI session, launchd
+  # does NOT populate $HOME for these — syncthing panics on startup
+  # ("Failed to get user home dir") and crash-loops indefinitely under
+  # KeepAlive without it. HOME/USER must be set explicitly per primary user.
   environment.launchAgents."com.syncthing.syncthing" = {
     enable = true;
     target = "com.syncthing.syncthing.plist";
@@ -129,6 +134,10 @@
   <dict>
     <key>PATH</key>
     <string>${lib.concatStringsSep ":" [ "/usr/bin" "/bin" "/usr/sbin" "/sbin" "${pkgs.syncthing}/bin" ]}</string>
+    <key>HOME</key>
+    <string>${config.users.users.${config.system.primaryUser}.home}</string>
+    <key>USER</key>
+    <string>${config.system.primaryUser}</string>
   </dict>
 </dict>
 </plist>

--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -92,6 +92,11 @@
   # does NOT populate $HOME for these — syncthing panics on startup
   # ("Failed to get user home dir") and crash-loops indefinitely under
   # KeepAlive without it. HOME/USER must be set explicitly per primary user.
+  #
+  # syncthing 2.x also moved to a subcommand CLI (kong-based) — the old
+  # single-dash flags with no subcommand ("-no-browser", "-logflags=0") no
+  # longer parse at all ("unknown flag -n"). Needs the explicit "serve"
+  # subcommand and double-dash long flags; "-logflags" has no 2.x equivalent.
   environment.launchAgents."com.syncthing.syncthing" = {
     enable = true;
     target = "com.syncthing.syncthing.plist";
@@ -105,9 +110,9 @@
   <key>ProgramArguments</key>
   <array>
     <string>${pkgs.syncthing}/bin/syncthing</string>
-    <string>-no-browser</string>
-    <string>-no-restart</string>
-    <string>-logflags=0</string>
+    <string>serve</string>
+    <string>--no-browser</string>
+    <string>--no-restart</string>
   </array>
 
   <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary
- `environment.launchAgents.\"com.syncthing.syncthing\"` in `profiles/darwin.nix` installs a system LaunchAgent that assumed `$HOME` would be populated automatically since it runs in the user's GUI session. It isn't — syncthing panics immediately (`Failed to get user home dir`) and, under `KeepAlive.Crashed = true`, crash-loops indefinitely with no visible symptom besides an idle process count.
- Discovered on tyoder-mbp while investigating why `~/Documents/Obsidian Vault` was never reaching david via the existing `tristonyoder` Syncthing folder — the device was correctly paired, but Syncthing had never actually been running client-side to push anything.
- Fix: set `HOME`/`USER` explicitly in the plist's `EnvironmentVariables`, derived from `config.system.primaryUser` (`tyoder` on tyoder-mbp, `tristonyoder` on Tristons-MacBook-Pro) so it resolves correctly per host.

## Test plan
- [x] `sudo darwin-rebuild build --flake .#tyoder-mbp` succeeds
- [x] Inspected the built derivation output: `HOME=/Users/tyoder`, `USER=tyoder` present in the generated plist
- [ ] After merge, `darwin-rebuild switch` on tyoder-mbp and confirm `launchctl kickstart -k gui/$(id -u)/com.syncthing.syncthing` starts cleanly (no more `$HOME is not defined` in `/tmp/syncthing.out.log`)
- [ ] Confirm Tristons-MacBook-Pro also picks this up correctly on its own next rebuild