### PR TITLE
fix: pull-based daily-brief audio publish (no SSH push from sandbox)

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -312,6 +312,7 @@ in
   modules.services.media.dailyBriefPodcast = {
     enable = true;
     owner = "tristonyoder";
+    audioScriptDir = "/data/tristonyoder/home/Documents/Obsidian Vault/AIOS/history/daily-briefs";
   };
 
   modules.services.storage.mp3PlayerSync = {

--- a/modules/services/media/daily-brief-podcast.nix
+++ b/modules/services/media/daily-brief-podcast.nix
@@ -113,6 +113,48 @@ let
       fi
     '';
   };
+
+  # Watches the Syncthing-synced vault copy of AIOS/history/daily-briefs/ for
+  # new spoken-word scripts and publishes each one exactly once. Runs
+  # entirely on david's own pull; nothing outbound from wherever the script
+  # is written reaches this host directly.
+  #
+  # Publish markers are kept in a separate stateDir, not alongside the
+  # scripts themselves — the scripts directory is bidirectionally synced by
+  # Syncthing, so a marker written there would propagate back out to every
+  # other paired device as vault noise.
+  watchScript = pkgs.writeShellApplication {
+    name = "daily-brief-podcast-watch";
+    runtimeInputs = [ publishScript pkgs.coreutils ];
+    text = ''
+      WATCH_DIR="${cfg.audioScriptDir}"
+      STATE_DIR="${cfg.stateDir}/published"
+      mkdir -p "$STATE_DIR"
+
+      shopt -s nullglob
+      for f in "$WATCH_DIR"/*.audio.txt; do
+        base="$(basename "$f" .audio.txt)"
+
+        if ! [[ "$base" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+          echo "skipping $f: expected filename format YYYY-MM-DD.audio.txt" >&2
+          continue
+        fi
+
+        marker="$STATE_DIR/$base"
+        if [ -e "$marker" ]; then
+          continue
+        fi
+
+        echo "publishing daily brief audio for $base"
+        if daily-brief-podcast publish --title "Daily Brief - $base" --text-file "$f" --date "$base"; then
+          touch "$marker"
+          echo "published $base"
+        else
+          echo "failed to publish $base -- will retry next tick" >&2
+        fi
+      done
+    '';
+  };
 in
 {
   options.modules.services.media.dailyBriefPodcast = {
@@ -152,14 +194,61 @@ in
       default = "A daily audio rundown of the day ahead.";
       description = "Podcast feed description.";
     };
+
+    audioScriptDir = mkOption {
+      type = types.str;
+      description = ''
+        Directory scanned for spoken-word scripts to publish, synced in from
+        the Obsidian vault (e.g. via Syncthing). Filenames must be
+        YYYY-MM-DD.audio.txt; anything else is skipped and logged.
+      '';
+      example = "/data/tristonyoder/home/Documents/Obsidian Vault/AIOS/history/daily-briefs";
+    };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "/var/lib/daily-brief-podcast";
+      description = "Directory holding publish markers, kept outside audioScriptDir so they don't sync back out as vault noise.";
+    };
+
+    watchInterval = mkOption {
+      type = types.str;
+      default = "*:0/15";
+      description = "systemd OnCalendar expression for how often to scan audioScriptDir for new scripts.";
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ publishScript ];
+    environment.systemPackages = [ publishScript watchScript ];
 
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0755 ${cfg.owner} ${cfg.owner} -"
+      "d ${cfg.stateDir} 0755 ${cfg.owner} ${cfg.owner} -"
+      "d ${cfg.stateDir}/published 0755 ${cfg.owner} ${cfg.owner} -"
     ];
+
+    systemd.services.daily-brief-podcast-watch = {
+      description = "Scan for new daily-brief audio scripts and publish them as podcast episodes";
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.owner;
+        StandardOutput = "journal";
+        StandardError = "journal";
+        SyslogIdentifier = "daily-brief-podcast-watch";
+        ExecStart = "${watchScript}/bin/daily-brief-podcast-watch";
+      };
+    };
+
+    systemd.timers.daily-brief-podcast-watch = {
+      description = "Periodically scan for new daily-brief audio scripts";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.watchInterval;
+        Persistent = true;
+        RandomizedDelaySec = "1min";
+      };
+    };
 
     modules.services.vHosts.hosts."brief" = {
       virtualHost = cfg.domain;


### PR DESCRIPTION
## Summary
- The Cowork `daily-brief` task runs in a network-isolated sandbox: outbound is restricted to an HTTP CONNECT proxy that 403s even public hosts, `getent` can't resolve, and there's no route to the Tailscale/headscale VPN. Raw SSH from the sandbox to david is a non-starter, and the allowlist is Anthropic-side — not something fixable from the vault or homelab.
- Converts the publish flow from push to pull: the Cowork skill (edited separately, in the vault) just writes `AIOS/history/daily-briefs/YYYY-MM-DD.audio.txt`, which reaches david on its own via the existing Syncthing `tristonyoder` folder (see #299 — that folder was silently broken client-side until the launchd fix landed, now confirmed syncing).
- Adds `daily-brief-podcast-watch`: a systemd timer (every 15 min, `Persistent`, 1 min jitter) + oneshot service that scans `audioScriptDir` for `*.audio.txt` files with no publish marker yet, publishes each via the existing `daily-brief-podcast publish` CLI, and marks it done.
- Idempotent by design: markers are separate per-date empty files in a `stateDir` outside `audioScriptDir` — kept out of the synced vault folder specifically because that folder is bidirectional (`sendreceive`); a marker written next to the scripts would propagate back out to every other paired Syncthing device as vault noise.
- Malformed or oddly-named files (anything not `YYYY-MM-DD.audio.txt`) are skipped with a journal log line, not an error — one bad file never blocks the rest of the batch or fails the unit.
- No SSH-push glue existed on the nix-config side to retire — the push lived entirely in the Cowork skill prompt (vault-side, handled separately).

## Test plan
- [x] `nixos-rebuild build` against this branch succeeds on david (verified over SSH)
- [x] Smoke-tested the watcher logic end-to-end in an isolated scratch directory (not the real vault, to avoid polluting synced content): valid `YYYY-MM-DD.audio.txt` published correctly, non-matching extension invisible to the glob, malformed `garbage.audio.txt` skipped with a log line and no unit failure
- [x] Re-ran against the same scratch dir: already-published date correctly skipped (idempotency), marker persisted
- [x] Confirmed the real `audioScriptDir` on david currently has zero `*.audio.txt` files (expected — the vault-side skill change lands separately) so enabling this is a no-op until that lands
- [ ] After merge + rebuild, confirm the timer is enabled and fires on schedule (`systemctl list-timers daily-brief-podcast-watch.timer`)