### PR TITLE
fix: daily-brief-podcast tmpfiles rules used wrong group

### DIFF
--- a/modules/services/media/daily-brief-podcast.nix
+++ b/modules/services/media/daily-brief-podcast.nix
@@ -221,10 +221,14 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ publishScript watchScript ];
 
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0755 ${cfg.owner} ${cfg.owner} -"
-      "d ${cfg.stateDir} 0755 ${cfg.owner} ${cfg.owner} -"
-      "d ${cfg.stateDir}/published 0755 ${cfg.owner} ${cfg.owner} -"
+    # owner's primary group isn't necessarily a group of the same name (e.g.
+    # tristonyoder's is "users", gid 100) — derive it rather than assume.
+    systemd.tmpfiles.rules = let
+      ownerGroup = config.users.users.${cfg.owner}.group;
+    in [
+      "d ${cfg.dataDir} 0755 ${cfg.owner} ${ownerGroup} -"
+      "d ${cfg.stateDir} 0755 ${cfg.owner} ${ownerGroup} -"
+      "d ${cfg.stateDir}/published 0755 ${cfg.owner} ${ownerGroup} -"
     ];
 
     systemd.services.daily-brief-podcast-watch = {


### PR DESCRIPTION
## Summary
- Found while doing a real end-to-end test of #300's watcher: `daily-brief-podcast-watch.service` failed every run with `mkdir: cannot create directory '/var/lib/daily-brief-podcast': Permission denied`.
- Root cause: the tmpfiles rules for `dataDir`/`stateDir` used `${cfg.owner} ${cfg.owner}` for both user and group, assuming a group of the same name exists. On david, `tristonyoder`'s primary group is `users` (gid 100) — there's no `tristonyoder` group at all. `systemd-tmpfiles` logged `Failed to resolve group 'tristonyoder': Unknown group` and silently skipped those lines.
- This bug shipped in #297 too, undetected — `dataDir` happened to already exist from a directory I created manually during that PR's smoke test, masking the same failure.
- Fix: derive the owner's actual primary group via `config.users.users.${cfg.owner}.group` instead of assuming it matches the username.

## Test plan
- [x] Deployed to david, confirmed the tmpfiles rule now resolves (`/etc/tmpfiles.d/00-nixos.conf` shows `... tristonyoder users -`) and both directories exist
- [x] Ran a real end-to-end test: dropped `2026-07-24.audio.txt` in the actual synced vault path, manually triggered `daily-brief-podcast-watch.service`, confirmed it published `daily-brief-2026-07-24.mp3` and a valid `feed.xml` at `brief.theyoder.family`
- [x] Ran the service again immediately after: correctly no-op (marker present), no republish, finished in under a second