### PR TITLE
feat: barebones Tailscale/SSH installer ISO

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,6 +79,21 @@ All tests are parallel. One failing host doesn't stop others.
 - `david`, `pits` — must succeed (blocks deployment if either fails)
 - `tristons-workstation`, `tristons-nixbook`, `tristons-nixbook-pro` — best-effort (logged but non-blocking)
 
+### build-installer-iso.yml
+
+**Triggers:**
+- Push to `main` touching `hosts/installer/**`, `modules/system/users.nix`, `flake.nix`, or the workflow file itself — nothing else re-triggers it
+- Manual trigger (`workflow_dispatch`)
+
+**Jobs:**
+1. `build-and-publish` — SSHes to david and builds both installer ISO
+   flake outputs (`nixosConfigurations.installer`, `.installer-aarch64`;
+   aarch64 cross-builds via `boot.binfmt.emulatedSystems` on david), then
+   publishes each as `/data/nix-iso/nixos-installer-<arch>.iso` (owned by
+   `caddy:caddy`, written under a `.new` suffix and renamed into place so
+   Caddy never serves a partial file). Served at
+   `nix-iso.theyoder.family` — see `hosts/installer/README.md`.
+
 ## Usage
 
 ### Automatic Deployment

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -37,7 +37,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          🔵 Building installer ISOs (x86_64 + aarch64) on david
+          🔵 Building installer images (x86_64 + aarch64 + rpi5) on david
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -53,10 +53,13 @@ jobs:
     - name: Wait for Tailscale connection
       run: sleep 10
 
-    # Both ISOs are built and published to /data/nix-iso on david — x86_64
-    # natively, aarch64 via david's QEMU binfmt emulation
-    # (boot.binfmt.emulatedSystems in hosts/david/configuration.nix).
-    - name: Build and publish ISOs
+    # All three images are built and published to /data/nix-iso on david:
+    # x86_64 natively, aarch64 and rpi5 via david's QEMU binfmt emulation
+    # (boot.binfmt.emulatedSystems in hosts/david/configuration.nix). rpi5's
+    # kernel doesn't build under emulation (a HOSTCC/target-binary mismatch
+    # in its kconfig step) — it's fetched pre-built from
+    # nixos-raspberrypi.cachix.org instead (also configured on david).
+    - name: Build and publish images
       run: |
         mkdir -p ~/.ssh
         echo "Host *" >> ~/.ssh/config
@@ -71,25 +74,31 @@ jobs:
 
           build_and_publish() {
             local attr="$1"
-            echo "--- Building nixosConfigurations.$attr ---"
-            local out_link="/tmp/installer-iso-$attr"
+            local build_attr="$2"  # isoImage or sdImage
+            echo "--- Building nixosConfigurations.$attr.config.system.build.$build_attr ---"
+            local out_link="/tmp/installer-image-$attr"
             sudo nix build \
-              "github:TristonYoder/nix-config#nixosConfigurations.$attr.config.system.build.isoImage" \
+              "github:TristonYoder/nix-config#nixosConfigurations.$attr.config.system.build.$build_attr" \
               --refresh --out-link "$out_link"
 
-            iso_path=$(find "$out_link/iso" -maxdepth 1 -name '*.iso')
-            iso_name=$(basename "$iso_path")
+            # isoImage lands under $out_link/iso/, sdImage under
+            # $out_link/sd-image/ — search rather than hardcode the subdir.
+            # Trailing slash matters: find only descends into a symlinked
+            # directory given as its starting path if it's slash-terminated.
+            image_path=$(find "$out_link/" -maxdepth 2 -type f \( -name '*.iso' -o -name '*.img.zst' \) | head -n1)
+            image_name=$(basename "$image_path")
 
             # Write under a temp name and rename into place — mv is atomic on
             # the same filesystem, so Caddy never serves a partially-written file.
-            sudo install -m 644 -o caddy -g caddy "$iso_path" "/data/nix-iso/${iso_name}.new"
-            sudo mv "/data/nix-iso/${iso_name}.new" "/data/nix-iso/${iso_name}"
+            sudo install -m 644 -o caddy -g caddy "$image_path" "/data/nix-iso/${image_name}.new"
+            sudo mv "/data/nix-iso/${image_name}.new" "/data/nix-iso/${image_name}"
             sudo rm -f "$out_link"
-            echo "✅ Published $iso_name"
+            echo "✅ Published $image_name"
           }
 
-          build_and_publish installer
-          build_and_publish installer-aarch64
+          build_and_publish installer isoImage
+          build_and_publish installer-aarch64 isoImage
+          build_and_publish installer-rpi5 sdImage
         EOF
 
     - name: Notify success
@@ -98,7 +107,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ✅ Installer ISOs published to https://nix-iso.theyoder.family/
+          ✅ Installer images published to https://nix-iso.theyoder.family/
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -110,7 +119,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ❌ Installer ISO build failed
+          ❌ Installer image build failed
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}

--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -1,0 +1,118 @@
+name: Build Installer ISOs
+
+# Only runs when something that actually changes the installer ISO's
+# contents changes — the installer config itself, the SSH key baked into
+# it (modules/system/users.nix), or the flake outputs that define it.
+# Everything else on main is a no-op for this workflow.
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'hosts/installer/**'
+      - 'modules/system/users.nix'
+      - 'flake.nix'
+      - '.github/workflows/build-installer-iso.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-installer-iso
+  cancel-in-progress: false
+
+env:
+  MATRIX_HOMESERVER_URL: ${{ secrets.MATRIX_HOMESERVER_URL }}
+  MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
+  MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Notify start
+      id: notify-start
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          🔵 Building installer ISOs (x86_64 + aarch64) on david
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+
+    - name: Setup Tailscale (Headscale)
+      uses: tailscale/github-action@v2
+      with:
+        authkey: ${{ secrets.HEADSCALE_AUTHKEY }}
+        tags: tag:github-actions
+        version: 1.78.1
+        args: --login-server ${{ secrets.HEADSCALE_LOGIN_SERVER }}
+
+    - name: Wait for Tailscale connection
+      run: sleep 10
+
+    # Both ISOs are built and published to /data/nix-iso on david — x86_64
+    # natively, aarch64 via david's QEMU binfmt emulation
+    # (boot.binfmt.emulatedSystems in hosts/david/configuration.nix).
+    - name: Build and publish ISOs
+      run: |
+        mkdir -p ~/.ssh
+        echo "Host *" >> ~/.ssh/config
+        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+        chmod 600 ~/.ssh/config
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+
+        ssh ${{ secrets.NIXOS_SERVER_USER }}@david.vpn.theyoder.family << 'EOF'
+          set -e
+
+          build_and_publish() {
+            local attr="$1"
+            echo "--- Building nixosConfigurations.$attr ---"
+            local out_link="/tmp/installer-iso-$attr"
+            sudo nix build \
+              "github:TristonYoder/nix-config#nixosConfigurations.$attr.config.system.build.isoImage" \
+              --refresh --out-link "$out_link"
+
+            iso_path=$(find "$out_link/iso" -maxdepth 1 -name '*.iso')
+            iso_name=$(basename "$iso_path")
+
+            # Write under a temp name and rename into place — mv is atomic on
+            # the same filesystem, so Caddy never serves a partially-written file.
+            sudo install -m 644 -o caddy -g caddy "$iso_path" "/data/nix-iso/${iso_name}.new"
+            sudo mv "/data/nix-iso/${iso_name}.new" "/data/nix-iso/${iso_name}"
+            sudo rm -f "$out_link"
+            echo "✅ Published $iso_name"
+          }
+
+          build_and_publish installer
+          build_and_publish installer-aarch64
+        EOF
+
+    - name: Notify success
+      if: success()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ✅ Installer ISOs published to https://nix-iso.theyoder.family/
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ steps.notify-start.outputs.event_id }}
+
+    - name: Notify failure
+      if: failure()
+      continue-on-error: true
+      uses: ./.github/actions/matrix-notification
+      with:
+        message: |
+          ❌ Installer ISO build failed
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        room_id: ${{ secrets.MATRIX_ROOM_ID }}
+        homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
+        access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+        thread_id: ${{ steps.notify-start.outputs.event_id }}

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,22 @@
         "type": "github"
       }
     },
+    "argononed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729566243,
+        "narHash": "sha256-DPNI0Dpk5aym3Baf5UbEe5GENDrSmmXVdriRSWE+rgk=",
+        "owner": "nvmd",
+        "repo": "argononed",
+        "rev": "16dbee54d49b66d5654d228d1061246b440ef7cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "repo": "argononed",
+        "type": "github"
+      }
+    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -83,6 +99,21 @@
         "owner": "erikarvstedt",
         "ref": "0.13",
         "repo": "extra-container",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -399,10 +430,57 @@
         "type": "github"
       }
     },
+    "nixos-images": {
+      "inputs": {
+        "nixos-stable": [
+          "nixos-raspberrypi",
+          "nixpkgs"
+        ],
+        "nixos-unstable": [
+          "nixos-raspberrypi",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747747741,
+        "narHash": "sha256-LUOH27unNWbGTvZFitHonraNx0JF/55h30r9WxqrznM=",
+        "owner": "nvmd",
+        "repo": "nixos-images",
+        "rev": "cbbd6db325775096680b65e2a32fb6187c09bbb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "ref": "sdimage-installer",
+        "repo": "nixos-images",
+        "type": "github"
+      }
+    },
+    "nixos-raspberrypi": {
+      "inputs": {
+        "argononed": "argononed",
+        "flake-compat": "flake-compat",
+        "nixos-images": "nixos-images",
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1784434257,
+        "narHash": "sha256-Feyvs5OkNaiG2ymUdOxWirTy9/HPJopywhnwlBIAPiY=",
+        "owner": "nvmd",
+        "repo": "nixos-raspberrypi",
+        "rev": "2bbb6ee54ed431a59b38d8aa1e254a9e848b7f2b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "repo": "nixos-raspberrypi",
+        "type": "github"
+      }
+    },
     "nixos-vscode-server": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1770124655,
@@ -545,6 +623,22 @@
     },
     "nixpkgs_7": {
       "locked": {
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
         "lastModified": 1682134069,
         "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
         "owner": "NixOS",
@@ -557,7 +651,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1783703440,
         "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
@@ -657,8 +751,9 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixos-hardware": "nixos-hardware",
+        "nixos-raspberrypi": "nixos-raspberrypi",
         "nixos-vscode-server": "nixos-vscode-server",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -318,6 +318,24 @@
           };
         };
 
+        # Same installer config, built for aarch64 (Raspberry Pi / ARM boards).
+        # Building this requires an aarch64-linux builder — either a native ARM
+        # machine or `boot.binfmt.emulatedSystems = [ "aarch64-linux" ];` on an
+        # x86_64 builder host. Neither is currently set up on any host in this
+        # fleet (david included) — building this output will fail with
+        # "don't know how to build for system aarch64-linux" until one is.
+        installer-aarch64 = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+
+          modules = [
+            ./hosts/installer/configuration.nix
+          ];
+
+          specialArgs = {
+            inherit nixpkgs;
+          };
+        };
+
         # -----------------------------------------------------------------------------
         # pits - Pi in the Sky - Edge Server (Cloud VPS)
         # -----------------------------------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -304,6 +304,21 @@
         };
 
         # -----------------------------------------------------------------------------
+        # installer - Barebones installer ISO (generic hardware, Tailscale + SSH)
+        # -----------------------------------------------------------------------------
+        installer = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+
+          modules = [
+            ./hosts/installer/configuration.nix
+          ];
+
+          specialArgs = {
+            inherit nixpkgs;
+          };
+        };
+
+        # -----------------------------------------------------------------------------
         # pits - Pi in the Sky - Edge Server (Cloud VPS)
         # -----------------------------------------------------------------------------
         pits = nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
     # NixOS hardware support modules (T2, Raspberry Pi, etc.)
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
 
+    # Raspberry Pi 5 firmware/bootloader/kernel support (also used by the
+    # stage-plotiphar kiosk host on the host/plotiphar branch) — vanilla
+    # nixpkgs sdImage doesn't support the Pi 5's boot process.
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi";
+
     # External modules
     nix-bitcoin.url = "github:fort-nix/nix-bitcoin/v0.0.117";
     nixos-vscode-server.url = "github:nix-community/nixos-vscode-server";
@@ -48,7 +53,7 @@
     hermes-agent.url = "github:NousResearch/hermes-agent";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, flake-utils, iopenpod-flake, iopodcli, hermes-agent, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, nixos-raspberrypi, flake-utils, iopenpod-flake, iopodcli, hermes-agent, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -334,6 +339,23 @@
           specialArgs = {
             inherit nixpkgs;
           };
+        };
+
+        # Barebones installer for Raspberry Pi 5 (CM5/Pi 5) specifically —
+        # generic aarch64-linux UEFI ISOs don't boot on the Pi 5, it needs
+        # its own firmware/bootloader/kernel handling. Uses the same
+        # nixos-raspberrypi flake (and raspberry-pi-5.base module) as the
+        # stage-plotiphar kiosk host on the host/plotiphar branch, so this
+        # is a proven-working pattern, not a first attempt.
+        installer-rpi5 = nixos-raspberrypi.lib.nixosInstaller {
+          modules = [
+            {
+              imports = with nixos-raspberrypi.nixosModules; [
+                raspberry-pi-5.base
+              ];
+            }
+            ./hosts/installer/rpi5.nix
+          ];
         };
 
         # -----------------------------------------------------------------------------

--- a/hosts/README.md
+++ b/hosts/README.md
@@ -45,6 +45,14 @@ Per-host NixOS and macOS configurations managed through this flake.
 - **Auto-Deploy:** ✅ GitHub Actions enabled
 - **Services:** Minimal desktop (KDE Plasma, development tools)
 
+#### installer (Barebones Tailscale/SSH Installer ISO)
+- **Profile:** none (`installation-cd-minimal.nix` base, no host-specific hardware)
+- **Architecture:** x86_64-linux (`installer`) and aarch64-linux (`installer-aarch64`)
+- **User:** root (key-only SSH, no password)
+- **Auto-Deploy:** ➖ Not a deployed host — build the ISO and boot it manually
+- **Purpose:** Generic live ISO for remote `nixos-install` — auto-joins the headscale tailnet on boot (QR code + login URL, no embedded authkey)
+- **Documentation:** [installer/README.md](installer/README.md)
+
 ### macOS Hosts
 
 #### tyoder-mbp (Triston's TPCC MacBook Pro - Work)

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -46,6 +46,20 @@ in
   # build both installer ISO architectures without a native ARM builder.
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
+  # nixos-raspberrypi's binary cache — required for nixosConfigurations.
+  # installer-rpi5 (and the stage-plotiphar host). Their custom Pi 5 kernel
+  # build fails under QEMU emulation (a HOSTCC-vs-target-binary mismatch in
+  # the kernel's kconfig tooling — confirmed: "Exec format error" trying to
+  # build linux_rpi-bcm2712 via boot.binfmt above). Trusting this cache
+  # means david fetches the prebuilt kernel instead of compiling it —
+  # strictly less rebuilding, not more.
+  nix.settings = {
+    substituters = lib.mkAfter [ "https://nixos-raspberrypi.cachix.org" ];
+    trusted-public-keys = lib.mkAfter [
+      "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+    ];
+  };
+
   # =============================================================================
   # HOST-SPECIFIC SETTINGS
   # =============================================================================

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -198,6 +198,20 @@ in
     monitor = false; # runs on workstation, not always reachable
   };
 
+  # Nix installer ISOs - static file server over /data/nix-iso (ZFS dataset).
+  # Internal-only (public defaults false) — these are install media, no
+  # secrets, but no reason to expose them to the open internet either.
+  modules.services.vHosts.hosts."nix-iso.${config.networking.domain}" = {
+    rawConfig = true;
+    displayName = "Nix ISOs";
+    category = "infrastructure";
+    monitor = false; # directory listing, not a service with a stable 200
+    extraConfig = ''
+      root * /data/nix-iso
+      file_server browse
+    '';
+  };
+
   # Home Assistant - runs on a separate device on the LAN.
   # DNS-only (A record); no Caddy reverse proxy, so casting/discovery/local
   # network features keep working and outages here can't take david's proxy down.

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -40,6 +40,12 @@ in
   # which drops postDeviceCommands support.
   boot.initrd.systemd.enable = lib.mkForce false;
 
+  # QEMU user-mode emulation for aarch64-linux — lets `nix build` cross-build
+  # ARM outputs (e.g. nixosConfigurations.installer-aarch64) directly on this
+  # x86_64 host, so CI (which only reaches david, not a personal Mac) can
+  # build both installer ISO architectures without a native ARM builder.
+  boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+
   # =============================================================================
   # HOST-SPECIFIC SETTINGS
   # =============================================================================

--- a/hosts/installer/README.md
+++ b/hosts/installer/README.md
@@ -1,9 +1,9 @@
-# installer - Barebones Tailscale/SSH Installer ISO
+# installer - Barebones Tailscale/SSH Installer Images
 
-Generic, hardware-agnostic NixOS live ISO for remotely installing new hosts. No
-authkey or hardware drivers are baked in — it boots, joins your headscale
-tailnet, and gives you a key-only SSH shell to drive `nixos-install` from
-anywhere.
+Generic NixOS live install media (x86_64/aarch64 ISOs, plus a Raspberry Pi 5
+sdImage) for remotely installing new hosts. No authkey or host-specific
+drivers are baked in — it boots, joins your headscale tailnet, and gives you
+a key-only SSH shell to drive `nixos-install` from anywhere.
 
 ## Overview
 
@@ -22,34 +22,47 @@ anywhere.
 
 ## Flake outputs
 
-There are two flake outputs today, each producing a clearly-labeled ISO
-(`nixos-installer-<arch>.iso`, via the `archLabel` let-binding in
-`configuration.nix`):
+Three flake outputs today, each producing a clearly-labeled image:
 
-| Output | Architecture | ISO filename |
-|---|---|---|
-| `nixosConfigurations.installer` | x86_64-linux | `nixos-installer-x86_64.iso` |
-| `nixosConfigurations.installer-aarch64` | aarch64-linux | `nixos-installer-aarch64.iso` |
+| Output | Architecture | Filename | Base |
+|---|---|---|---|
+| `nixosConfigurations.installer` | x86_64-linux | `nixos-installer-x86_64.iso` | `installation-cd-minimal.nix` |
+| `nixosConfigurations.installer-aarch64` | aarch64-linux | `nixos-installer-aarch64.iso` | `installation-cd-minimal.nix` |
+| `nixosConfigurations.installer-rpi5` | aarch64-linux (Raspberry Pi 5 / CM5) | `nixos-installer-rpi5.img.zst` | `nixos-raspberrypi` flake (`raspberry-pi-5.base`) |
 
-A future Raspberry Pi target would need a separate `sdImage`-based output
-(RPi boots from an SD card image via U-Boot, not a generic UEFI ISO — a
-materially different build, not just a rename) — e.g.
-`nixosConfigurations.installer-rpi` producing `nixos-installer-rpi.img`,
-following the same naming convention.
+`installer-rpi5` needs its own base — generic aarch64 UEFI ISOs don't boot on
+the Pi 5, it needs Pi-specific firmware/bootloader/kernel handling. See
+[rpi5.nix](rpi5.nix) and [common.nix](common.nix) (the Tailscale/SSH/QR logic
+all three variants share).
+
+**Naming gotcha (cost real debugging time, documented so it doesn't happen
+again):** `isoImage.isoName` / `image.fileName` do **not** control the real
+output filename for the `cd-dvd`-based ISO builder in this nixpkgs snapshot —
+setting them has zero effect on the actual file under
+`system.build.isoImage`'s `iso/` subdir, confirmed by building both ways. The
+option that's actually load-bearing is `isoImage.isoBaseName` (used in
+`configuration.nix`). The Pi 5 sdImage builder doesn't have this problem —
+`sdImage.imageBaseName` (in `rpi5.nix`) works as documented.
 
 ## CI: automatic rebuilds
 
 [`.github/workflows/build-installer-iso.yml`](../../.github/workflows/build-installer-iso.yml)
-builds and publishes both ISOs to `/data/nix-iso` on david whenever something
-that actually changes their contents lands on `main`: `hosts/installer/**`,
-`modules/system/users.nix` (the baked-in SSH key), or `flake.nix`. Every
-other push is a no-op for this workflow — it doesn't run on a schedule or on
-every commit.
+builds and publishes all three images to `/data/nix-iso` on david whenever
+something that actually changes their contents lands on `main`:
+`hosts/installer/**`, `modules/system/users.nix` (the baked-in SSH key), or
+`flake.nix`. Every other push is a no-op for this workflow — it doesn't run
+on a schedule or on every commit.
 
-It builds x86_64 natively and aarch64 via QEMU emulation
+It builds x86_64 natively; aarch64 and rpi5 via QEMU emulation
 (`boot.binfmt.emulatedSystems = [ "aarch64-linux" ];` in
 `hosts/david/configuration.nix` — added specifically so CI, which can only
-reach david, doesn't depend on a personal Mac being online). Each ISO is
+reach david, doesn't depend on a personal Mac being online). rpi5's custom
+kernel (`linux_rpi-bcm2712`) doesn't build under emulation — a
+HOSTCC-vs-target-binary mismatch in its kconfig step (confirmed:
+`Exec format error` trying to run the emulated `rm`/`sed` as native
+build-time tools) — so david also trusts `nixos-raspberrypi`'s own binary
+cache (`nixos-raspberrypi.cachix.org`, also in `hosts/david/configuration.nix`)
+and fetches the prebuilt kernel instead of compiling it. Each image is
 written under a `.new` suffix and `mv`'d into place, so Caddy never serves a
 half-written file mid-build.
 
@@ -105,9 +118,21 @@ Two options:
   path (`/etc/nix/builder_ed25519`). Nix automatically dispatches the build to
   the VM via `/etc/nix/machines` — no `--builders` flag needed.
 
-## Downloading a pre-built ISO
+### Raspberry Pi 5
 
-Both variants are hosted on david at **https://nix-iso.theyoder.family/**
+```bash
+nix build '.#nixosConfigurations.installer-rpi5.config.system.build.sdImage' --refresh
+```
+
+Works the same way from david (emulation + `nixos-raspberrypi.cachix.org` for
+the kernel — see CI section above) or from `tyoder-mbp`'s native
+`linux-builder` (no cache dependency, but slower to iterate since nothing's
+pre-built). The result is a directory; the actual `.img.zst` file is under
+`<out-link>/sd-image/`.
+
+## Downloading a pre-built image
+
+All three variants are hosted on david at **https://nix-iso.theyoder.family/**
 (internal-only — LAN/tailnet, per Caddy's default `@internal` restriction; not
 reachable from the public internet) — a plain directory listing served
 straight out of `/data/nix-iso`, a ZFS dataset (`data/nix-iso`) created for
@@ -116,11 +141,14 @@ rebuild/upload needed unless you're testing an unmerged change.
 
 ## Using it
 
-1. Flash the ISO to a USB drive and boot the target machine from it.
+1. Flash the image to a USB drive (`installer`/`installer-aarch64`) or SD
+   card/NVMe (`installer-rpi5`, e.g. via `dd` or Raspberry Pi Imager's
+   "custom image" option) and boot the target machine from it.
 2. Watch the console (or `ssh` in once you know the tailnet IP/hostname) for
    the QR code / login URL, and authorize the node from another device.
 3. Once it shows up in the tailnet (`ssh admin@ts.theyoder.family` or the
-   headscale admin UI), SSH in: `ssh root@nixos-installer.<tailnet-domain>`.
+   headscale admin UI), SSH in: `ssh root@nixos-installer.<tailnet-domain>`
+   (`nixos-installer-rpi5` for the Pi 5 variant).
 4. From there, drive the install remotely — partition, format,
    `nixos-generate-config`, `nixos-install --flake
    github:TristonYoder/nix-config#<hostname>` — per the remote-install

--- a/hosts/installer/README.md
+++ b/hosts/installer/README.md
@@ -1,0 +1,81 @@
+# installer - Barebones Tailscale/SSH Installer ISO
+
+Generic, hardware-agnostic NixOS live ISO for remotely installing new hosts. No
+authkey or hardware drivers are baked in — it boots, joins your headscale
+tailnet, and gives you a key-only SSH shell to drive `nixos-install` from
+anywhere.
+
+## Overview
+
+- **Config**: [`configuration.nix`](configuration.nix)
+- **Base**: `installation-cd-minimal.nix` (no GUI, no host-specific hardware modules)
+- **Auth**: key-only SSH (root, `PasswordAuthentication = false`) using the
+  same public key committed in [`modules/system/users.nix`](../../modules/system/users.nix)
+- **Networking**: `tailscale-autoconnect` runs `tailscale up
+  --login-server=https://ts.theyoder.family --ssh` on boot. Since no authkey
+  is embedded (this repo is public), it prints the headscale login URL as
+  text and as a scannable QR code — open/scan it on another device to
+  authorize the node into the tailnet. That output is cached to
+  `/run/tailscale-qr.txt` and re-printed on every shell start
+  (`environment.interactiveShellInit`), so it's still visible once the boot
+  log has scrolled past and you're sitting at the console prompt.
+
+## Building
+
+There are two flake outputs — build the one matching the target machine's CPU:
+
+| Output | Architecture | Builder |
+|---|---|---|
+| `nixosConfigurations.installer` | x86_64-linux | any x86_64-linux host (e.g. david) |
+| `nixosConfigurations.installer-aarch64` | aarch64-linux | needs an aarch64-linux builder (see below) |
+
+### x86_64 (from any NixOS x86_64-linux host, e.g. david)
+
+```bash
+nix build '.#nixosConfigurations.installer.config.system.build.isoImage' --refresh
+```
+
+Or remotely from macOS, without SSHing in first:
+
+```bash
+ssh github-actions@david.vpn.theyoder.family \
+  "nix build 'github:TristonYoder/nix-config#nixosConfigurations.installer.config.system.build.isoImage' --refresh --out-link /tmp/installer-iso-result --print-out-paths"
+```
+
+The result is a directory; the actual `.iso` file is under `<out-link>/iso/`.
+
+### aarch64 (Raspberry Pi / ARM boards)
+
+No host in the fleet is natively aarch64-linux, and david has no QEMU binfmt
+emulation configured. The supported path is nix-darwin's built-in
+`linux-builder` VM, enabled on `tyoder-mbp` (Apple Silicon) — it builds
+`aarch64-linux` **natively**, no emulation needed:
+
+```nix
+# hosts/tyoder-mbp/configuration.nix
+nix.linux-builder.enable = true;
+```
+
+After a `darwin-rebuild switch` picks that up (first boot spins up the VM,
+which takes a minute or two — check with `sudo launchctl list | grep
+linux-builder`), build from that Mac:
+
+```bash
+sudo nix build '.#nixosConfigurations.installer-aarch64.config.system.build.isoImage' --refresh
+```
+
+`sudo` is required because the linux-builder SSH key lives in a root-only
+path (`/etc/nix/builder_ed25519`). Nix automatically dispatches the build to
+the VM via `/etc/nix/machines` — no `--builders` flag needed.
+
+## Using it
+
+1. Flash the ISO to a USB drive and boot the target machine from it.
+2. Watch the console (or `ssh` in once you know the tailnet IP/hostname) for
+   the QR code / login URL, and authorize the node from another device.
+3. Once it shows up in the tailnet (`ssh admin@ts.theyoder.family` or the
+   headscale admin UI), SSH in: `ssh root@nixos-installer.<tailnet-domain>`.
+4. From there, drive the install remotely — partition, format,
+   `nixos-generate-config`, `nixos-install --flake
+   github:TristonYoder/nix-config#<hostname>` — per the remote-install
+   workflow in the `host-provisioner` skill.

--- a/hosts/installer/README.md
+++ b/hosts/installer/README.md
@@ -20,14 +20,47 @@ anywhere.
   (`environment.interactiveShellInit`), so it's still visible once the boot
   log has scrolled past and you're sitting at the console prompt.
 
-## Building
+## Flake outputs
 
-There are two flake outputs — build the one matching the target machine's CPU:
+There are two flake outputs today, each producing a clearly-labeled ISO
+(`nixos-installer-<arch>.iso`, via the `archLabel` let-binding in
+`configuration.nix`):
 
-| Output | Architecture | Builder |
+| Output | Architecture | ISO filename |
 |---|---|---|
-| `nixosConfigurations.installer` | x86_64-linux | any x86_64-linux host (e.g. david) |
-| `nixosConfigurations.installer-aarch64` | aarch64-linux | needs an aarch64-linux builder (see below) |
+| `nixosConfigurations.installer` | x86_64-linux | `nixos-installer-x86_64.iso` |
+| `nixosConfigurations.installer-aarch64` | aarch64-linux | `nixos-installer-aarch64.iso` |
+
+A future Raspberry Pi target would need a separate `sdImage`-based output
+(RPi boots from an SD card image via U-Boot, not a generic UEFI ISO — a
+materially different build, not just a rename) — e.g.
+`nixosConfigurations.installer-rpi` producing `nixos-installer-rpi.img`,
+following the same naming convention.
+
+## CI: automatic rebuilds
+
+[`.github/workflows/build-installer-iso.yml`](../../.github/workflows/build-installer-iso.yml)
+builds and publishes both ISOs to `/data/nix-iso` on david whenever something
+that actually changes their contents lands on `main`: `hosts/installer/**`,
+`modules/system/users.nix` (the baked-in SSH key), or `flake.nix`. Every
+other push is a no-op for this workflow — it doesn't run on a schedule or on
+every commit.
+
+It builds x86_64 natively and aarch64 via QEMU emulation
+(`boot.binfmt.emulatedSystems = [ "aarch64-linux" ];` in
+`hosts/david/configuration.nix` — added specifically so CI, which can only
+reach david, doesn't depend on a personal Mac being online). Each ISO is
+written under a `.new` suffix and `mv`'d into place, so Caddy never serves a
+half-written file mid-build.
+
+Trigger a manual rebuild any time from the Actions tab ("Build Installer
+ISOs" → Run workflow), or:
+
+```bash
+gh workflow run build-installer-iso.yml
+```
+
+## Building manually
 
 ### x86_64 (from any NixOS x86_64-linux host, e.g. david)
 
@@ -46,36 +79,40 @@ The result is a directory; the actual `.iso` file is under `<out-link>/iso/`.
 
 ### aarch64 (Raspberry Pi / ARM boards)
 
-No host in the fleet is natively aarch64-linux, and david has no QEMU binfmt
-emulation configured. The supported path is nix-darwin's built-in
-`linux-builder` VM, enabled on `tyoder-mbp` (Apple Silicon) — it builds
-`aarch64-linux` **natively**, no emulation needed:
+Two options:
 
-```nix
-# hosts/tyoder-mbp/configuration.nix
-nix.linux-builder.enable = true;
-```
+- **On david** (same path CI uses): `boot.binfmt.emulatedSystems` makes it a
+  normal cross-build via QEMU emulation —
+  `nix build '.#nixosConfigurations.installer-aarch64.config.system.build.isoImage' --refresh`.
+  Slower than native (emulated), but needs nothing extra set up.
+- **On `tyoder-mbp`** (Apple Silicon): nix-darwin's built-in `linux-builder`
+  VM builds `aarch64-linux` **natively**, no emulation:
 
-After a `darwin-rebuild switch` picks that up (first boot spins up the VM,
-which takes a minute or two — check with `sudo launchctl list | grep
-linux-builder`), build from that Mac:
+  ```nix
+  # hosts/tyoder-mbp/configuration.nix
+  nix.linux-builder.enable = true;
+  ```
 
-```bash
-sudo nix build '.#nixosConfigurations.installer-aarch64.config.system.build.isoImage' --refresh
-```
+  After a `darwin-rebuild switch` picks that up (first boot spins up the VM,
+  which takes a minute or two — check with `sudo launchctl list | grep
+  linux-builder`), build from that Mac:
 
-`sudo` is required because the linux-builder SSH key lives in a root-only
-path (`/etc/nix/builder_ed25519`). Nix automatically dispatches the build to
-the VM via `/etc/nix/machines` — no `--builders` flag needed.
+  ```bash
+  sudo nix build '.#nixosConfigurations.installer-aarch64.config.system.build.isoImage' --refresh
+  ```
+
+  `sudo` is required because the linux-builder SSH key lives in a root-only
+  path (`/etc/nix/builder_ed25519`). Nix automatically dispatches the build to
+  the VM via `/etc/nix/machines` — no `--builders` flag needed.
 
 ## Downloading a pre-built ISO
 
-Both variants are also hosted on david at **https://nix-iso.theyoder.family/**
+Both variants are hosted on david at **https://nix-iso.theyoder.family/**
 (internal-only — LAN/tailnet, per Caddy's default `@internal` restriction; not
 reachable from the public internet) — a plain directory listing served
 straight out of `/data/nix-iso`, a ZFS dataset (`data/nix-iso`) created for
-this purpose. Rebuild and re-upload after any change to
-`hosts/installer/configuration.nix`; nothing regenerates this automatically.
+this purpose. CI keeps this current automatically (see above) — no manual
+rebuild/upload needed unless you're testing an unmerged change.
 
 ## Using it
 

--- a/hosts/installer/README.md
+++ b/hosts/installer/README.md
@@ -68,6 +68,15 @@ sudo nix build '.#nixosConfigurations.installer-aarch64.config.system.build.isoI
 path (`/etc/nix/builder_ed25519`). Nix automatically dispatches the build to
 the VM via `/etc/nix/machines` — no `--builders` flag needed.
 
+## Downloading a pre-built ISO
+
+Both variants are also hosted on david at **https://nix-iso.theyoder.family/**
+(internal-only — LAN/tailnet, per Caddy's default `@internal` restriction; not
+reachable from the public internet) — a plain directory listing served
+straight out of `/data/nix-iso`, a ZFS dataset (`data/nix-iso`) created for
+this purpose. Rebuild and re-upload after any change to
+`hosts/installer/configuration.nix`; nothing regenerates this automatically.
+
 ## Using it
 
 1. Flash the ISO to a USB drive and boot the target machine from it.

--- a/hosts/installer/common.nix
+++ b/hosts/installer/common.nix
@@ -1,0 +1,90 @@
+# Shared logic for every barebones installer variant (x86_64/aarch64 ISO,
+# Raspberry Pi 5 sdImage): key-only SSH and Tailscale (headscale) auto-join
+# with a boot-time QR code. See configuration.nix for the x86_64/aarch64 ISO
+# entry point and rpi5.nix for the Pi 5 sdImage entry point — both import
+# this file rather than duplicating it.
+{ lib, pkgs, ... }:
+let
+  # Cached here so it survives past the scrolling boot log — printed again
+  # by environment.interactiveShellInit below every time a shell/terminal
+  # starts, not just once during the systemd unit's boot-time output.
+  qrCacheFile = "/run/tailscale-qr.txt";
+
+  tailscaleUp = pkgs.writeShellScript "tailscale-autoconnect" ''
+    set -eu
+
+    urlFile=$(mktemp)
+    trap 'rm -f "$urlFile"' EXIT
+
+    # Run `tailscale up` in the background and tee its output so we can
+    # grab the headscale login URL as soon as it's printed, without
+    # blocking on the auth wait before we've shown the QR code.
+    ${lib.getExe' pkgs.tailscale "tailscale"} up \
+      --login-server=https://ts.theyoder.family \
+      --ssh \
+      --hostname=nixos-installer \
+      2>&1 | tee "$urlFile" &
+    tsPid=$!
+
+    url=""
+    for _ in $(seq 1 30); do
+      url=$(grep -oE 'https://[^ ]+' "$urlFile" | head -n1 || true)
+      [ -n "$url" ] && break
+      sleep 1
+    done
+
+    if [ -n "$url" ]; then
+      {
+        echo ""
+        echo "Scan to join the tailnet: $url"
+        echo ""
+        ${lib.getExe pkgs.qrencode} -t ANSIUTF8 "$url"
+      } | tee ${qrCacheFile}
+    fi
+
+    wait "$tsPid"
+  '';
+in
+{
+  networking.hostName = lib.mkDefault "nixos-installer";
+
+  # Key-only SSH — no passwords baked into a public image.
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+    };
+  };
+
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK5JWm3A5tXTCPq8YTua30QH2+Pa/Mz96QC5KJZKdEsz"
+  ];
+
+  services.tailscale.enable = true;
+
+  # Re-print the cached QR code/URL (see qrCacheFile above) whenever a shell
+  # starts — the autologin console shell on boot, or reconnecting to tty1 —
+  # so it's still there once the terminal has settled, not just a one-shot
+  # flash buried in the scrolling boot log.
+  environment.interactiveShellInit = ''
+    cat ${qrCacheFile} 2>/dev/null || true
+  '';
+
+  # No authkey embedded (public repo). tailscale-autoconnect prints the
+  # headscale login URL (and a QR code) to the console on boot — open it,
+  # or scan it, on another device to authorize the node, then SSH to it
+  # over the tailnet.
+  systemd.services.tailscale-autoconnect = {
+    description = "Join the Tailscale (headscale) tailnet on boot";
+    after = [ "network-online.target" "tailscaled.service" ];
+    wants = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      StandardOutput = "journal+console";
+      StandardError = "journal+console";
+      ExecStart = "${tailscaleUp}";
+    };
+  };
+}

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -17,6 +17,11 @@
 #   ssh root@<hostname>.<tailnet-domain>
 { lib, pkgs, modulesPath, ... }:
 let
+  # Cached here so it survives past the scrolling boot log — printed again
+  # by environment.interactiveShellInit below every time a shell/terminal
+  # starts, not just once during the systemd unit's boot-time output.
+  qrCacheFile = "/run/tailscale-qr.txt";
+
   tailscaleUp = pkgs.writeShellScript "tailscale-autoconnect" ''
     set -eu
 
@@ -41,10 +46,12 @@ let
     done
 
     if [ -n "$url" ]; then
-      echo ""
-      echo "Scan to join the tailnet: $url"
-      echo ""
-      ${lib.getExe pkgs.qrencode} -t ANSIUTF8 "$url"
+      {
+        echo ""
+        echo "Scan to join the tailnet: $url"
+        echo ""
+        ${lib.getExe pkgs.qrencode} -t ANSIUTF8 "$url"
+      } | tee ${qrCacheFile}
     fi
 
     wait "$tsPid"
@@ -74,6 +81,14 @@ in
   ];
 
   services.tailscale.enable = true;
+
+  # Re-print the cached QR code/URL (see qrCacheFile above) whenever a shell
+  # starts — the autologin console shell on boot, or reconnecting to tty1 —
+  # so it's still there once the terminal has settled, not just a one-shot
+  # flash buried in the scrolling boot log.
+  environment.interactiveShellInit = ''
+    cat ${qrCacheFile} 2>/dev/null || true
+  '';
 
   # No authkey embedded (public repo). tailscale-autoconnect prints the
   # headscale login URL (and a QR code) to the console on boot — open it,

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -17,6 +17,15 @@
 #   ssh root@<hostname>.<tailnet-domain>
 { lib, pkgs, modulesPath, ... }:
 let
+  # Clear per-architecture label for the built ISO's filename — keeps
+  # x86_64/aarch64 unambiguous when both sit side by side in a downloads
+  # directory. A future dedicated Raspberry Pi image (sdImage, not isoImage —
+  # different boot mechanism) should follow the same "nixos-installer-<label>"
+  # convention, e.g. "nixos-installer-rpi.img".
+  archLabel =
+    { x86_64-linux = "x86_64"; aarch64-linux = "aarch64"; }
+    .${pkgs.stdenv.hostPlatform.system} or pkgs.stdenv.hostPlatform.system;
+
   # Cached here so it survives past the scrolling boot log — printed again
   # by environment.interactiveShellInit below every time a shell/terminal
   # starts, not just once during the systemd unit's boot-time output.
@@ -107,5 +116,5 @@ in
     };
   };
 
-  isoImage.isoName = lib.mkForce "nixos-installer-barebones.iso";
+  isoImage.isoName = lib.mkForce "nixos-installer-${archLabel}.iso";
 }

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -37,5 +37,14 @@ in
 
   nixpkgs.config.allowUnfree = true;
 
-  isoImage.isoName = lib.mkForce "nixos-installer-${archLabel}.iso";
+  # isoImage.isoName/image.fileName do NOT control the real output
+  # filename for this cd-dvd-based ISO builder in this nixpkgs snapshot —
+  # confirmed by testing: setting isoName has no effect on the actual file
+  # under system.build.isoImage's iso/ subdir, which is instead built from
+  # isoBaseName + system.nixos.label + the target platform. Override
+  # isoBaseName instead; the resulting filename is e.g.
+  # "nixos-installer-x86_64-26.05.20260710.8f0500b-x86_64-linux.iso" —
+  # verbose, but the actual, working way to get "installer" and the
+  # architecture into the real filename here.
+  isoImage.isoBaseName = lib.mkForce "nixos-installer-${archLabel}";
 }

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -37,14 +37,12 @@ in
 
   nixpkgs.config.allowUnfree = true;
 
-  # isoImage.isoName/image.fileName do NOT control the real output
-  # filename for this cd-dvd-based ISO builder in this nixpkgs snapshot —
-  # confirmed by testing: setting isoName has no effect on the actual file
-  # under system.build.isoImage's iso/ subdir, which is instead built from
-  # isoBaseName + system.nixos.label + the target platform. Override
-  # isoBaseName instead; the resulting filename is e.g.
-  # "nixos-installer-x86_64-26.05.20260710.8f0500b-x86_64-linux.iso" —
-  # verbose, but the actual, working way to get "installer" and the
-  # architecture into the real filename here.
+  # isoImage.isoName/image.fileName do NOT control the real output filename
+  # for this cd-dvd-based ISO builder in this nixpkgs snapshot — confirmed
+  # by building both ways: setting isoName had zero effect on the actual
+  # file under system.build.isoImage's iso/ subdir (stayed
+  # "nixos-minimal-<label>-<arch>.iso" regardless). isoBaseName is the
+  # option that's actually load-bearing here; overriding it produces the
+  # intended "nixos-installer-<arch>.iso" exactly.
   isoImage.isoBaseName = lib.mkForce "nixos-installer-${archLabel}";
 }

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -1,0 +1,96 @@
+# Barebones NixOS installer ISO — generic hardware, no host-specific drivers.
+#
+# Boots to a minimal shell, auto-joins the Tailscale (headscale) tailnet, and
+# enables key-only SSH. No authkey is embedded (this repo is public) — on
+# first boot `tailscale up` prints a login URL to the console (as text and
+# as a scannable QR code); open it on another device — e.g. scan the QR
+# with a phone — to authorize the node into the tailnet. Once it's joined,
+# SSH in over Tailscale using the key below and drive `nixos-install`
+# remotely (partition, format, nixos-generate-config, install) per the
+# remote-install workflow in the host-provisioner skill.
+#
+# Build (from a NixOS host, e.g. david):
+#   nix build .#nixosConfigurations.installer.config.system.build.isoImage --refresh
+#
+# Find the node once it joins the tailnet:
+#   ssh admin@ts.theyoder.family    # or check the headscale admin UI
+#   ssh root@<hostname>.<tailnet-domain>
+{ lib, pkgs, modulesPath, ... }:
+let
+  tailscaleUp = pkgs.writeShellScript "tailscale-autoconnect" ''
+    set -eu
+
+    urlFile=$(mktemp)
+    trap 'rm -f "$urlFile"' EXIT
+
+    # Run `tailscale up` in the background and tee its output so we can
+    # grab the headscale login URL as soon as it's printed, without
+    # blocking on the auth wait before we've shown the QR code.
+    ${lib.getExe' pkgs.tailscale "tailscale"} up \
+      --login-server=https://ts.theyoder.family \
+      --ssh \
+      --hostname=nixos-installer \
+      2>&1 | tee "$urlFile" &
+    tsPid=$!
+
+    url=""
+    for _ in $(seq 1 30); do
+      url=$(grep -oE 'https://[^ ]+' "$urlFile" | head -n1 || true)
+      [ -n "$url" ] && break
+      sleep 1
+    done
+
+    if [ -n "$url" ]; then
+      echo ""
+      echo "Scan to join the tailnet: $url"
+      echo ""
+      ${lib.getExe pkgs.qrencode} -t ANSIUTF8 "$url"
+    fi
+
+    wait "$tsPid"
+  '';
+in
+{
+  imports = [
+    # Minimal installer base: no GUI, gives a shell with nixos-install available
+    (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
+  ];
+
+  nixpkgs.config.allowUnfree = true;
+
+  networking.hostName = "nixos-installer";
+
+  # Key-only SSH — no passwords baked into a public ISO image.
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+    };
+  };
+
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK5JWm3A5tXTCPq8YTua30QH2+Pa/Mz96QC5KJZKdEsz"
+  ];
+
+  services.tailscale.enable = true;
+
+  # No authkey embedded (public repo). tailscale-autoconnect prints the
+  # headscale login URL (and a QR code) to the console on boot — open it,
+  # or scan it, on another device to authorize the node, then SSH to it
+  # over the tailnet.
+  systemd.services.tailscale-autoconnect = {
+    description = "Join the Tailscale (headscale) tailnet on boot";
+    after = [ "network-online.target" "tailscaled.service" ];
+    wants = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      StandardOutput = "journal+console";
+      StandardError = "journal+console";
+      ExecStart = "${tailscaleUp}";
+    };
+  };
+
+  isoImage.isoName = lib.mkForce "nixos-installer-barebones.iso";
+}

--- a/hosts/installer/configuration.nix
+++ b/hosts/installer/configuration.nix
@@ -1,4 +1,8 @@
 # Barebones NixOS installer ISO — generic hardware, no host-specific drivers.
+# Two architectures (x86_64-linux, aarch64-linux) share this file; see
+# rpi5.nix for the Raspberry Pi 5 sdImage variant, which needs Pi-specific
+# hardware modules this generic ISO doesn't. Both import common.nix for the
+# shared Tailscale/SSH/QR logic.
 #
 # Boots to a minimal shell, auto-joins the Tailscale (headscale) tailnet, and
 # enables key-only SSH. No authkey is embedded (this repo is public) — on
@@ -18,103 +22,20 @@
 { lib, pkgs, modulesPath, ... }:
 let
   # Clear per-architecture label for the built ISO's filename — keeps
-  # x86_64/aarch64 unambiguous when both sit side by side in a downloads
-  # directory. A future dedicated Raspberry Pi image (sdImage, not isoImage —
-  # different boot mechanism) should follow the same "nixos-installer-<label>"
-  # convention, e.g. "nixos-installer-rpi.img".
+  # x86_64/aarch64/rpi5 unambiguous when they sit side by side in a
+  # downloads directory.
   archLabel =
     { x86_64-linux = "x86_64"; aarch64-linux = "aarch64"; }
     .${pkgs.stdenv.hostPlatform.system} or pkgs.stdenv.hostPlatform.system;
-
-  # Cached here so it survives past the scrolling boot log — printed again
-  # by environment.interactiveShellInit below every time a shell/terminal
-  # starts, not just once during the systemd unit's boot-time output.
-  qrCacheFile = "/run/tailscale-qr.txt";
-
-  tailscaleUp = pkgs.writeShellScript "tailscale-autoconnect" ''
-    set -eu
-
-    urlFile=$(mktemp)
-    trap 'rm -f "$urlFile"' EXIT
-
-    # Run `tailscale up` in the background and tee its output so we can
-    # grab the headscale login URL as soon as it's printed, without
-    # blocking on the auth wait before we've shown the QR code.
-    ${lib.getExe' pkgs.tailscale "tailscale"} up \
-      --login-server=https://ts.theyoder.family \
-      --ssh \
-      --hostname=nixos-installer \
-      2>&1 | tee "$urlFile" &
-    tsPid=$!
-
-    url=""
-    for _ in $(seq 1 30); do
-      url=$(grep -oE 'https://[^ ]+' "$urlFile" | head -n1 || true)
-      [ -n "$url" ] && break
-      sleep 1
-    done
-
-    if [ -n "$url" ]; then
-      {
-        echo ""
-        echo "Scan to join the tailnet: $url"
-        echo ""
-        ${lib.getExe pkgs.qrencode} -t ANSIUTF8 "$url"
-      } | tee ${qrCacheFile}
-    fi
-
-    wait "$tsPid"
-  '';
 in
 {
   imports = [
     # Minimal installer base: no GUI, gives a shell with nixos-install available
     (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
+    ./common.nix
   ];
 
   nixpkgs.config.allowUnfree = true;
-
-  networking.hostName = "nixos-installer";
-
-  # Key-only SSH — no passwords baked into a public ISO image.
-  services.openssh = {
-    enable = true;
-    settings = {
-      PermitRootLogin = "prohibit-password";
-      PasswordAuthentication = false;
-    };
-  };
-
-  users.users.root.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK5JWm3A5tXTCPq8YTua30QH2+Pa/Mz96QC5KJZKdEsz"
-  ];
-
-  services.tailscale.enable = true;
-
-  # Re-print the cached QR code/URL (see qrCacheFile above) whenever a shell
-  # starts — the autologin console shell on boot, or reconnecting to tty1 —
-  # so it's still there once the terminal has settled, not just a one-shot
-  # flash buried in the scrolling boot log.
-  environment.interactiveShellInit = ''
-    cat ${qrCacheFile} 2>/dev/null || true
-  '';
-
-  # No authkey embedded (public repo). tailscale-autoconnect prints the
-  # headscale login URL (and a QR code) to the console on boot — open it,
-  # or scan it, on another device to authorize the node, then SSH to it
-  # over the tailnet.
-  systemd.services.tailscale-autoconnect = {
-    description = "Join the Tailscale (headscale) tailnet on boot";
-    after = [ "network-online.target" "tailscaled.service" ];
-    wants = [ "network-online.target" ];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      StandardOutput = "journal+console";
-      StandardError = "journal+console";
-      ExecStart = "${tailscaleUp}";
-    };
-  };
 
   isoImage.isoName = lib.mkForce "nixos-installer-${archLabel}.iso";
 }

--- a/hosts/installer/rpi5.nix
+++ b/hosts/installer/rpi5.nix
@@ -1,0 +1,23 @@
+# Raspberry Pi 5 (CM5/Pi 5) barebones installer sdImage. Boots directly from
+# an SD card/NVMe — no installation-cd-minimal.nix involved, and no
+# Pi-specific hardware handling of our own: raspberry-pi-5.base (imported at
+# the flake.nix level, from the nixos-raspberrypi flake — same one used by
+# the stage-plotiphar kiosk host on the host/plotiphar branch) covers the
+# Pi 5's firmware/bootloader/kernel needs.
+#
+# Build (from a NixOS host, e.g. david):
+#   nix build .#nixosConfigurations.installer-rpi5.config.system.build.sdImage --refresh
+{ lib, ... }:
+{
+  imports = [ ./common.nix ];
+
+  networking.hostName = lib.mkForce "nixos-installer-rpi5";
+
+  # Same "nixos-installer-<label>" naming convention as the x86_64/aarch64
+  # ISOs (hosts/installer/configuration.nix) — the actual output filename is
+  # this plus a nixos-raspberrypi-added compression suffix, e.g.
+  # nixos-installer-rpi5.img.zst. mkForce needed: nixos-raspberrypi's own
+  # flake.nix sets image.baseName (which sdImage.imageBaseName aliases to)
+  # at normal priority.
+  sdImage.imageBaseName = lib.mkForce "nixos-installer-rpi5";
+}

--- a/hosts/tyoder-mbp/configuration.nix
+++ b/hosts/tyoder-mbp/configuration.nix
@@ -25,5 +25,15 @@
 
   # Set primary user for system defaults
   system.primaryUser = "tyoder";
+
+  # =============================================================================
+  # LINUX BUILDER
+  # =============================================================================
+
+  # nix-darwin's built-in linux-builder VM. On Apple Silicon this builds
+  # aarch64-linux natively (no emulation) — needed to build the
+  # nixosConfigurations.installer-aarch64 ISO, which no other host in the
+  # fleet can currently build.
+  nix.linux-builder.enable = true;
 }
 


### PR DESCRIPTION
## Summary
- Adds `hosts/installer/configuration.nix`: a generic, hardware-agnostic NixOS installer ISO for remote `nixos-install` over Tailscale
- No authkey baked in (public repo) — `tailscale up` prints the headscale login URL and a scannable QR code to the console on boot, cached to `/run/tailscale-qr.txt` and re-printed on every shell start so it's still visible once the boot log settles
- Key-only SSH (root, `PasswordAuthentication = false`)
- Registered as `nixosConfigurations.installer` (x86_64) and `nixosConfigurations.installer-aarch64` (ARM) in flake.nix
- Enables nix-darwin's `linux-builder` on tyoder-mbp so the aarch64 ISO can be built natively on Apple Silicon (no emulation)
- Serves both pre-built ISOs from david at `nix-iso.theyoder.family` (internal-only) — new `data/nix-iso` ZFS dataset + Caddy static file server/directory listing
- Adds `hosts/installer/README.md` documenting how to build each variant, download the hosted copy, and use the ISO once booted

## Docs
See [hosts/installer/README.md](hosts/installer/README.md).

## Test plan
- [x] `nix eval` on both installer configs evaluates cleanly
- [x] x86_64 ISO built successfully on david
- [x] aarch64 ISO built successfully via tyoder-mbp's linux-builder VM
- [x] Boot an ISO, confirm QR code renders and node joins the tailnet
- [x] QR code/URL stays visible at the shell prompt after boot log scrolls past
- [x] `nix-iso.theyoder.family` serves both ISOs (200, directory listing verified)
- [x] SSH in over Tailscale, confirm `nixos-install` tooling is available