### PR TITLE
feat: PXE netboot for the barebones installer

### DIFF
--- a/.github/workflows/build-installer-iso.yml
+++ b/.github/workflows/build-installer-iso.yml
@@ -1,6 +1,6 @@
-name: Build Installer ISOs
+name: Build Installer Images
 
-# Only runs when something that actually changes the installer ISO's
+# Only runs when something that actually changes the installer images'
 # contents changes — the installer config itself, the SSH key baked into
 # it (modules/system/users.nix), or the flake outputs that define it.
 # Everything else on main is a no-op for this workflow.
@@ -37,7 +37,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          🔵 Building installer images (x86_64 + aarch64 + rpi5) on david
+          🔵 Building installer images (ISO x86_64/aarch64/rpi5 + netboot x86_64/aarch64) on david
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -99,6 +99,35 @@ jobs:
           build_and_publish installer isoImage
           build_and_publish installer-aarch64 isoImage
           build_and_publish installer-rpi5 sdImage
+
+          # Netboot bundles (kernel/initrd/netboot.ipxe) for
+          # modules/services/infrastructure/pxe-boot.nix — published one
+          # subdirectory per architecture under /data/nix-pxe, since
+          # nixpkgs' generated netboot.ipxe references its kernel/initrd by
+          # relative filename within the same directory.
+          build_and_publish_netboot() {
+            local attr="$1"
+            local archdir="$2"
+            echo "--- Building nixosConfigurations.$attr.config.system.build.netbootBundle ---"
+            local out_link="/tmp/installer-netboot-$attr"
+            sudo nix build \
+              "github:TristonYoder/nix-config#nixosConfigurations.$attr.config.system.build.netbootBundle" \
+              --refresh --out-link "$out_link"
+
+            local dest="/data/nix-pxe/$archdir"
+            local tmp_dest="/data/nix-pxe/.${archdir}.new"
+            sudo rm -rf "$tmp_dest"
+            sudo mkdir -p "$tmp_dest"
+            sudo cp -L "$out_link"/* "$tmp_dest/"
+            sudo chown -R caddy:caddy "$tmp_dest"
+            sudo rm -rf "$dest"
+            sudo mv "$tmp_dest" "$dest"
+            sudo rm -f "$out_link"
+            echo "✅ Published netboot bundle to $dest"
+          }
+
+          build_and_publish_netboot installer-netboot x86_64
+          build_and_publish_netboot installer-netboot-aarch64 aarch64
         EOF
 
     - name: Notify success
@@ -107,7 +136,7 @@ jobs:
       uses: ./.github/actions/matrix-notification
       with:
         message: |
-          ✅ Installer images published to https://nix-iso.theyoder.family/
+          ✅ Installer images published (ISOs to https://nix-iso.theyoder.family/, netboot to /data/nix-pxe)
         room_id: ${{ secrets.MATRIX_ROOM_ID }}
         homeserver_url: ${{ secrets.MATRIX_HOMESERVER_URL }}
         access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -358,6 +358,37 @@
           ];
         };
 
+        # PXE/iPXE netboot variant of the barebones installer — kernel +
+        # initrd pair instead of an ISO, for modules/services/infrastructure/pxe-boot.nix
+        # to serve. Pi 5 is intentionally not covered here — it network-boots
+        # via its own EEPROM/TFTP mechanism, not iPXE chainloading, and needs
+        # a materially different implementation.
+        installer-netboot = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+
+          modules = [
+            ./hosts/installer/netboot.nix
+          ];
+
+          specialArgs = {
+            inherit nixpkgs;
+          };
+        };
+
+        # Same netboot config, built for aarch64. See installer-aarch64 above
+        # for the emulated-builder caveat — same applies here.
+        installer-netboot-aarch64 = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+
+          modules = [
+            ./hosts/installer/netboot.nix
+          ];
+
+          specialArgs = {
+            inherit nixpkgs;
+          };
+        };
+
         # -----------------------------------------------------------------------------
         # pits - Pi in the Sky - Edge Server (Cloud VPS)
         # -----------------------------------------------------------------------------

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -22,6 +22,25 @@ in
   networking.useDHCP = lib.mkForce false;
   networking.interfaces.enp4s0f1.useDHCP = false;
 
+  # enp4s0f1 is a live 802.1Q trunk to the UniFi switch. VLAN 10 (User
+  # Devices, 10.150.10.0/24) is tagged on it — used by
+  # modules/services/infrastructure/pxe-boot.nix, which needs L2 adjacency
+  # to that subnet to see client PXE broadcasts (proxyDHCP requires being on
+  # the same segment as the booting client). No default gateway here — this
+  # interface only needs local-subnet reachability, not a route out.
+  networking.vlans.vlan10 = {
+    id = 10;
+    interface = "enp4s0f1";
+  };
+
+  networking.interfaces.vlan10 = {
+    useDHCP = false;
+    ipv4.addresses = [{
+      address = "10.150.10.30";
+      prefixLength = 24;
+    }];
+  };
+
   # =============================================================================
   # SYSTEM IDENTIFICATION
   # =============================================================================
@@ -216,6 +235,17 @@ in
     category = "ai";
     icon = "invoke-ai";
     monitor = false; # runs on workstation, not always reachable
+  };
+
+  # PXE/iPXE netboot for the barebones installer — see
+  # modules/services/infrastructure/pxe-boot.nix. Bound to vlan10 only
+  # (never Core Services). /data/nix-pxe is a ZFS dataset, created the same
+  # manual way as /data/nix-iso below (`zfs create data/nix-pxe`) — not
+  # declared here, since this repo doesn't manage ZFS dataset creation
+  # itself for these one-off, no-secrets install-media stores.
+  modules.services.infrastructure.pxeBoot = {
+    enable = true;
+    bootFilesDir = "/data/nix-pxe";
   };
 
   # Nix installer ISOs - static file server over /data/nix-iso (ZFS dataset).

--- a/hosts/installer/README.md
+++ b/hosts/installer/README.md
@@ -22,13 +22,21 @@ a key-only SSH shell to drive `nixos-install` from anywhere.
 
 ## Flake outputs
 
-Three flake outputs today, each producing a clearly-labeled image:
+Five flake outputs today — three ISO/sdImage builds, plus two netboot
+builds for PXE (see "PXE netboot" below):
 
-| Output | Architecture | Filename | Base |
+| Output | Architecture | Output | Base |
 |---|---|---|---|
 | `nixosConfigurations.installer` | x86_64-linux | `nixos-installer-x86_64.iso` | `installation-cd-minimal.nix` |
 | `nixosConfigurations.installer-aarch64` | aarch64-linux | `nixos-installer-aarch64.iso` | `installation-cd-minimal.nix` |
 | `nixosConfigurations.installer-rpi5` | aarch64-linux (Raspberry Pi 5 / CM5) | `nixos-installer-rpi5.img.zst` | `nixos-raspberrypi` flake (`raspberry-pi-5.base`) |
+| `nixosConfigurations.installer-netboot` | x86_64-linux | `netbootBundle` (kernel + initrd + iPXE script) | `netboot-minimal.nix` |
+| `nixosConfigurations.installer-netboot-aarch64` | aarch64-linux | `netbootBundle` | `netboot-minimal.nix` |
+
+The netboot outputs share [common.nix](common.nix) with the ISO builds — see
+[netboot.nix](netboot.nix). Pi 5 has no netboot output: it network-boots via
+its own EEPROM/TFTP mechanism (no iPXE chainload involved), which is a
+materially different implementation not covered here.
 
 `installer-rpi5` needs its own base — generic aarch64 UEFI ISOs don't boot on
 the Pi 5, it needs Pi-specific firmware/bootloader/kernel handling. See
@@ -47,7 +55,8 @@ option that's actually load-bearing is `isoImage.isoBaseName` (used in
 ## CI: automatic rebuilds
 
 [`.github/workflows/build-installer-iso.yml`](../../.github/workflows/build-installer-iso.yml)
-builds and publishes all three images to `/data/nix-iso` on david whenever
+builds and publishes all five images (ISO x86_64/aarch64/rpi5 to
+`/data/nix-iso`, netboot x86_64/aarch64 to `/data/nix-pxe`) on david whenever
 something that actually changes their contents lands on `main`:
 `hosts/installer/**`, `modules/system/users.nix` (the baked-in SSH key), or
 `flake.nix`. Every other push is a no-op for this workflow — it doesn't run
@@ -67,7 +76,7 @@ written under a `.new` suffix and `mv`'d into place, so Caddy never serves a
 half-written file mid-build.
 
 Trigger a manual rebuild any time from the Actions tab ("Build Installer
-ISOs" → Run workflow), or:
+Images" → Run workflow), or:
 
 ```bash
 gh workflow run build-installer-iso.yml
@@ -130,6 +139,18 @@ the kernel — see CI section above) or from `tyoder-mbp`'s native
 pre-built). The result is a directory; the actual `.img.zst` file is under
 `<out-link>/sd-image/`.
 
+### Netboot (PXE) bundle
+
+```bash
+nix build '.#nixosConfigurations.installer-netboot.config.system.build.netbootBundle' --refresh
+# or installer-netboot-aarch64 — same emulation/linux-builder options as aarch64 above
+```
+
+The result is a directory containing `bzImage`, `initrd`, and `netboot.ipxe`
+— publish all three together into `/data/nix-pxe/x86_64/` (or `aarch64/`) on
+david. `netboot.ipxe` references the other two by relative filename, so they
+must stay siblings.
+
 ## Downloading a pre-built image
 
 All three variants are hosted on david at **https://nix-iso.theyoder.family/**
@@ -153,3 +174,48 @@ rebuild/upload needed unless you're testing an unmerged change.
    `nixos-generate-config`, `nixos-install --flake
    github:TristonYoder/nix-config#<hostname>` — per the remote-install
    workflow in the `host-provisioner` skill.
+
+## PXE netboot — no USB stick required
+
+Any PXE-capable x86_64 or aarch64 client on **VLAN 10 (User Devices,
+`10.150.10.0/24`)** can netboot straight into the installer, served by
+`modules.services.infrastructure.pxeBoot` on david (`enp4s0f1`, tagged VLAN
+10, `10.150.10.30`). See
+[`modules/services/infrastructure/pxe-boot.nix`](../../modules/services/infrastructure/pxe-boot.nix)
+for the dnsmasq proxyDHCP/TFTP config. Pi 5 is **not** covered — it needs its
+own EEPROM/TFTP boot flow, unrelated to iPXE chainloading.
+
+**david only answers proxyDHCP/TFTP requests on VLAN 10.** UniFi still owns
+real DHCP for that network — david never hands out IP leases, it only
+answers the PXE-specific boot-file questions a client asks in parallel with
+its normal DHCP request. This is a one-time UniFi change, done manually
+(not scripted — infrequent, low value to automate, real risk of a
+self-inflicted DHCP outage on the wrong network if scripted against the
+wrong target):
+
+1. **UniFi Network app → Settings → Networks → (the VLAN 10 / User Devices
+   network) → DHCP.**
+2. Set these two options under "DHCP Option 66/67" (or the equivalent
+   advanced DHCP fields, depending on controller version):
+   - **Option 66 (TFTP server name):** `10.150.10.30` — david's `vlan10` IP.
+   - **Option 67 (bootfile name):** `undionly.kpxe` — the BIOS chainload
+     binary. **Leave this as the single BIOS filename, even though UEFI and
+     aarch64 clients exist.** UniFi's DHCP option 67 is a single static
+     value with no per-client-architecture logic. Getting UEFI/aarch64
+     clients the *correct* loader (`ipxe-x86_64.efi` / `ipxe-aarch64.efi`)
+     is exactly why dnsmasq runs in **proxyDHCP** mode alongside UniFi's
+     real DHCP: proxyDHCP answers the PXE-specific option-93
+     (client-architecture) query itself and overrides the bootfile per
+     client, so UniFi's single static value only actually matters as a
+     fallback for clients that don't get a proxyDHCP answer in time. Legacy
+     BIOS is the safest fallback value.
+   - If your controller only exposes one plain "TFTP Server" / "Boot
+     Filename" field pair rather than named "Option 66/67", these are the
+     same setting under a different label.
+3. Save and apply. No reboot of UniFi devices needed — new DHCP option
+   values take effect on the next client DHCP transaction.
+4. **Verify:** boot a spare PXE-capable machine on VLAN 10 and watch it
+   reach the iPXE boot menu / installer. If it hangs at "PXE-E51: No DHCP or
+   proxyDHCP offers were received," double check david's `vlan10` interface
+   is up (`ip a show vlan10` on david) and that the UniFi switch port
+   `enp4s0f1` is plugged into is still trunking VLAN 10.

--- a/hosts/installer/netboot.nix
+++ b/hosts/installer/netboot.nix
@@ -1,0 +1,38 @@
+# PXE/iPXE netboot variant of the barebones installer — same Tailscale/SSH
+# logic as configuration.nix (the ISO variant), but built as a kernel +
+# initrd pair instead of an ISO9660 filesystem, since that's what PXE needs.
+#
+# nixpkgs' netbootIpxeScript (system.build.netbootRamdisk) bundles the
+# *entire* squashed Nix store into the initrd itself — there's no separate
+# squashfs fetch at boot, so only two files need to be served: the kernel
+# and that initrd. netbootBundle below packages both plus the generated
+# netboot.ipxe script (which references them by the relative names "bzImage"
+# and "initrd") into one directory, ready to publish alongside the ISOs.
+#
+# Build (from a NixOS host, e.g. david):
+#   nix build .#nixosConfigurations.installer-netboot.config.system.build.netbootBundle --refresh
+{ pkgs, modulesPath, config, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/netboot/netboot-minimal.nix")
+    ./common.nix
+  ];
+
+  nixpkgs.config.allowUnfree = true;
+
+  system.build.netbootBundle = pkgs.linkFarm "nixos-installer-netboot" [
+    {
+      name = "bzImage";
+      path = "${config.system.build.kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
+    }
+    {
+      name = "initrd";
+      path = "${config.system.build.netbootRamdisk}/initrd";
+    }
+    {
+      name = "netboot.ipxe";
+      path = "${config.system.build.netbootIpxeScript}/netboot.ipxe";
+    }
+  ];
+}

--- a/modules/services/infrastructure/default.nix
+++ b/modules/services/infrastructure/default.nix
@@ -7,6 +7,7 @@
     ./headscale.nix
     ./nix-cache-server.nix
     ./postgresql.nix
+    ./pxe-boot.nix
     ./scrutiny.nix
     ./tailscale.nix
     ./technitium.nix

--- a/modules/services/infrastructure/pxe-boot.nix
+++ b/modules/services/infrastructure/pxe-boot.nix
@@ -1,0 +1,145 @@
+# PXE/iPXE netboot for the barebones NixOS installer (see hosts/installer/).
+# Boots any PXE-capable client on `interface`'s VLAN straight into the
+# installer, no USB stick required.
+#
+# Deliberately scoped: proxyDHCP + TFTP are bound to a single interface
+# (`cfg.interface`, expected to be a VLAN-tagged link to the client subnet —
+# see hosts/david/configuration.nix's vlan10). dnsmasq's own DNS resolver is
+# disabled (`port = 0`) so this never competes with the real DHCP server
+# (UniFi) or DNS (Technitium) already serving that network — it only
+# answers PXE-specific queries, and only on that one interface.
+#
+# Boot files live in one shared directory (`cfg.bootFilesDir`), served two
+# ways: TFTP (for the small iPXE chainload binaries every PXE ROM can fetch)
+# and HTTP via the vHosts registry (for the installer kernel/initrd, which
+# are too large to serve efficiently over TFTP). The iPXE binaries
+# themselves come straight from nixpkgs and are symlinked in at activation.
+#
+# The kernel/initrd/netboot.ipxe come from this repo's
+# nixosConfigurations.installer-netboot(-aarch64) flake outputs and are
+# published into cfg.bootFilesDir/<x86_64|aarch64>/ separately (CI, same
+# pattern as the nix-iso vHost for the ISO images) — one subdirectory per
+# architecture, since x86_64 and aarch64 clients need different
+# kernel/initrd pairs. nixpkgs' generated netboot.ipxe references its kernel
+# and initrd by relative filename ("bzImage"/"initrd"), which iPXE resolves
+# against the script's own URL — so dnsmasq just needs to send each client
+# to the right architecture's netboot.ipxe and the relative fetches follow
+# automatically.
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.infrastructure.pxeBoot;
+
+  ipxeX86_64 = pkgs.ipxe;
+  ipxeAarch64 = pkgs.pkgsCross.aarch64-multiplatform.ipxe;
+in
+{
+  options.modules.services.infrastructure.pxeBoot = {
+    enable = mkEnableOption "PXE/iPXE netboot for the barebones NixOS installer";
+
+    interface = mkOption {
+      type = types.str;
+      default = "vlan10";
+      description = ''
+        Interface to bind proxyDHCP and TFTP to. Must have L2 adjacency to
+        the client subnet — proxyDHCP only sees broadcast traffic on its
+        own segment. Never set this to a Core Services interface.
+      '';
+    };
+
+    subnet = mkOption {
+      type = types.str;
+      default = "10.150.10.0";
+      description = "Network address of the client subnet reachable via `interface`.";
+    };
+
+    netmask = mkOption {
+      type = types.str;
+      default = "255.255.255.0";
+      description = "Netmask of the client subnet reachable via `interface`.";
+    };
+
+    domain = mkOption {
+      type = types.str;
+      default = "pxe.${config.networking.domain}";
+      description = "Domain the boot files (kernel/initrd/iPXE script) are served over HTTP from.";
+    };
+
+    bootFilesDir = mkOption {
+      type = types.path;
+      default = "/var/lib/tftpboot";
+      description = ''
+        Directory serving both TFTP and HTTP boot files. iPXE chainload
+        binaries are symlinked directly under here automatically. The
+        installer kernel/initrd/netboot.ipxe must be published separately
+        (e.g. by CI) into <bootFilesDir>/x86_64/ and <bootFilesDir>/aarch64/
+        as nixosConfigurations.installer-netboot(-aarch64)'s netbootBundle
+        output — one subdirectory per architecture.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.dnsmasq = {
+      enable = true;
+      settings = {
+        port = 0; # DNS off — Technitium already owns DNS on this network
+        interface = [ cfg.interface ];
+        bind-interfaces = true;
+        except-interface = [ "lo" ];
+
+        dhcp-range = [ "${cfg.subnet},proxy,${cfg.netmask}" ];
+
+        enable-tftp = true;
+        tftp-root = cfg.bootFilesDir;
+
+        # RFC4578 client-architecture option (93) — pick the right
+        # first-stage loader per PXE ROM without guessing.
+        dhcp-match = [
+          "set:bios,option:client-arch,0"
+          "set:efi-x86_64,option:client-arch,7"
+          "set:efi-x86_64,option:client-arch,9"
+          "set:efi-arm64,option:client-arch,11"
+        ];
+
+        # iPXE identifies itself via a DHCP user-class on its second
+        # request — once we see that, hand it the real boot script over
+        # HTTP instead of re-serving the TFTP chainload binary. Split by
+        # client-arch too (not just tag:ipxe) so x86_64 and aarch64 clients
+        # land on their own netboot.ipxe with the matching kernel/initrd.
+        dhcp-userclass = [ "set:ipxe,iPXE" ];
+
+        dhcp-boot = [
+          "tag:ipxe,tag:bios,http://${cfg.domain}/x86_64/netboot.ipxe"
+          "tag:ipxe,tag:efi-x86_64,http://${cfg.domain}/x86_64/netboot.ipxe"
+          "tag:ipxe,tag:efi-arm64,http://${cfg.domain}/aarch64/netboot.ipxe"
+          "tag:!ipxe,tag:bios,undionly.kpxe"
+          "tag:!ipxe,tag:efi-x86_64,ipxe-x86_64.efi"
+          "tag:!ipxe,tag:efi-arm64,ipxe-aarch64.efi"
+        ];
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.bootFilesDir} 0755 dnsmasq dnsmasq -"
+      "L+ ${cfg.bootFilesDir}/undionly.kpxe - - - - ${ipxeX86_64}/undionly.kpxe"
+      "L+ ${cfg.bootFilesDir}/ipxe-x86_64.efi - - - - ${ipxeX86_64}/ipxe.efi"
+      "L+ ${cfg.bootFilesDir}/ipxe-aarch64.efi - - - - ${ipxeAarch64}/ipxe.efi"
+    ];
+
+    # HTTP side of cfg.bootFilesDir — kernel/initrd/netboot.ipxe. Internal
+    # only (not `public`), same as the nix-iso vHost these installer
+    # artifacts sit alongside.
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      rawConfig = true;
+      displayName = "PXE Boot";
+      category = "infrastructure";
+      monitor = false; # directory listing, not a service with a stable 200
+      extraConfig = ''
+        root * ${cfg.bootFilesDir}
+        file_server browse
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds netboot flake outputs (`installer-netboot`, `installer-netboot-aarch64`) producing a kernel+initrd+iPXE script for the existing barebones installer.
- New `modules/services/infrastructure/pxe-boot.nix`: dnsmasq proxyDHCP + TFTP bound to a single VLAN 10 interface (never Core Services), per-client-architecture iPXE chainloading, boot files served over HTTP via the vHosts registry.
- Tags VLAN 10 (User Devices, `10.150.10.0/24`) on david's `enp4s0f1` (a previously-unused live trunk port) with a static `10.150.10.30` — needed for L2 adjacency to PXE clients.
- CI (`build-installer-iso.yml`) extended to build and publish netboot bundles to `/data/nix-pxe/{x86_64,aarch64}`.
- Manual UniFi DHCP option 66/67 runbook in `hosts/installer/README.md` (not scripted — one-time, infrequent, real risk if automated against the wrong network).
- Pi 5 is explicitly out of scope: it netboots via its own EEPROM/TFTP mechanism, not iPXE chainloading.

Nothing has been switched on david yet — this only stages the config. Before merging + switching:
1. `zfs create data/nix-pxe` on david.
2. Apply the UniFi DHCP option 66/67 change per the runbook.

## Test plan
- [x] `nix flake check` passes fleet-wide
- [x] `nixos-rebuild dry-run --flake github:TristonYoder/nix-config/feat/pxe-boot-installer#david` — plans cleanly, new units (dnsmasq, vlan10 interface, PXE vHost) appear as expected
- [x] `nixos-rebuild build --flake github:TristonYoder/nix-config/feat/pxe-boot-installer#david` — full closure builds with no errors, not activated
- [ ] `zfs create data/nix-pxe` on david, then `switch`, then boot a real PXE client on VLAN 10 and confirm it reaches the iPXE menu