### PR TITLE
feat: console QR code fallback for tailscale login

### DIFF
--- a/modules/services/infrastructure/tailscale.nix
+++ b/modules/services/infrastructure/tailscale.nix
@@ -37,6 +37,19 @@ in
       default = "https://ts.theyoder.family";
       description = "Headscale login server URL (empty uses default Tailscale coordination)";
     };
+
+    showLoginQr = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Render a scannable QR code of the tailscale login URL on the
+        physical/virtual console (tty1) whenever the node needs
+        interactive authentication — e.g. it has no preauth key yet, or
+        an existing one expired. Lets you complete login from a phone
+        with console-only access (no SSH, no Tailscale yet). A no-op
+        once the node is already logged in — the service just exits.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -52,6 +65,50 @@ in
         "--snat-subnet-routes=false"
         "--accept-routes=false"
       ];
+    };
+
+    systemd.services.tailscale-login-qr = mkIf cfg.showLoginQr {
+      description = "Show a QR code on the console for interactive tailscale login, if needed";
+      after = [ "tailscaled.service" "tailscaled-autoconnect.service" ];
+      wants = [ "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ config.services.tailscale.package pkgs.qrencode pkgs.jq ];
+      serviceConfig = {
+        Type = "simple";
+        StandardInput = "tty";
+        StandardOutput = "tty";
+        StandardError = "tty";
+        TTYPath = "/dev/tty1";
+        TTYReset = true;
+        TTYVHangup = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      script = ''
+        # Give tailscaled-autoconnect (if configured) a head start to log
+        # in via authKeyFile before falling back to interactive/QR login.
+        sleep 10
+
+        getState() { tailscale status --json --peers=false | jq -r '.BackendState'; }
+
+        while true; do
+          case "$(getState)" in
+            Running)
+              exit 0
+              ;;
+            NeedsLogin|NeedsMachineAuth|Stopped)
+              echo "=== Tailscale needs authentication — scan this QR code or visit the URL below ==="
+              tailscale up ${optionalString (cfg.loginServer != "") "--login-server=${cfg.loginServer}"} 2>&1 | while IFS= read -r line; do
+                echo "$line"
+                case "$line" in
+                  https://*) echo "$line" | qrencode -t ANSIUTF8 ;;
+                esac
+              done
+              ;;
+          esac
+          sleep 5
+        done
+      '';
     };
 
     # Workaround for Tailscale Wireguard Bug


### PR DESCRIPTION
## Summary
- Adds a `showLoginQr` option (default true) to the shared `modules/services/infrastructure/tailscale.nix` module
- When a node needs interactive tailscale auth (no preauth key, expired/consumed key, etc.), renders the login URL as a scannable QR code on the physical/virtual console (tty1)
- No-op once already logged in — the watcher service exits immediately

## Motivation
Came up while bringing up a new edge host (hermes-agent) with no console credentials — if Tailscale ever fails to auto-join, there was no way back in without SSH, which itself depends on Tailscale. This gives any host a phone-scannable fallback straight from the console.

## Test plan
- [x] `nixos-rebuild dry-run` succeeds for pits with this change
- [x] Verify QR renders correctly on a real console when a node needs auth