### PR TITLE
fix: register installer tailnet nodes as ephemeral

### DIFF
--- a/hosts/installer/common.nix
+++ b/hosts/installer/common.nix
@@ -19,9 +19,13 @@ let
     # Run `tailscale up` in the background and tee its output so we can
     # grab the headscale login URL as soon as it's printed, without
     # blocking on the auth wait before we've shown the QR code.
+    # --ephemeral: the installer environment itself is throwaway (RAM-only,
+    # gone on reboot) — the tailnet node should be too, so headscale doesn't
+    # accumulate a stale "nixos-installer" entry every time this boots.
     ${lib.getExe' pkgs.tailscale "tailscale"} up \
       --login-server=https://ts.theyoder.family \
       --ssh \
+      --ephemeral \
       --hostname=nixos-installer \
       2>&1 | tee "$urlFile" &
     tsPid=$!


### PR DESCRIPTION
## Summary
- The installer environment (all three variants: x86_64/aarch64 ISO, rpi5 sdImage) is RAM-only and gone on reboot — its tailnet registration should be too.
- Adds `--ephemeral` to the `tailscale up` call in `hosts/installer/common.nix`, so headscale automatically removes the node once it disconnects instead of accumulating a stale `nixos-installer` entry every boot.

## Test plan
- [x] `nix flake check` passes
- [x] `nix eval` on `installer` still produces `nixos-installer-x86_64.iso`