### PR TITLE
Add Blueprint as a native service on david

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,12 +48,13 @@
     # External app flakes
     iopenpod-flake.url = "github:TristonYoder/iopenpod-flake";
     iopodcli.url = "github:TristonYoder/iOpenPodCLI";
+    blueprint.url = "github:TristonYoder/blueprint";
 
     # Hermes Agent (NousResearch) — official NixOS module
     hermes-agent.url = "github:NousResearch/hermes-agent";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, nixos-raspberrypi, flake-utils, iopenpod-flake, iopodcli, hermes-agent, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, nixos-raspberrypi, flake-utils, iopenpod-flake, iopodcli, blueprint, hermes-agent, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -159,7 +160,7 @@
           ];
           
           specialArgs = {
-            inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake iopodcli;
+            inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake iopodcli blueprint;
           };
         };
 

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -107,6 +107,12 @@ in
   # AzuraCast - Internet radio station management (azuracast.* admin, radio.* public player)
   modules.services.media.azuracast.enable = true;
 
+  # Blueprint - personal dashboard (native, non-Docker, from TristonYoder/blueprint's own flake)
+  modules.services.productivity.blueprint = {
+    enable = true;
+    domain = "blueprint.tristonyoder.com";
+  };
+
   # Auto-create an AzuraCast station for each m3u file (Plexamp/Jellyfin mixes)
   # dropped into the shared m3u/playlist folder, and mirror every station into
   # Navidrome as an Internet Radio Station

--- a/modules/services/productivity/blueprint.nix
+++ b/modules/services/productivity/blueprint.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, blueprint, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.productivity.blueprint;
+
+  # blueprint's own flake.nix owns the buildNpmPackage derivation (source,
+  # npmDepsHash, standalone installPhase) — this module just consumes the
+  # package output and wires it into systemd/postgres/vHosts, same pattern
+  # as iopodcli's overlay in modules/services/storage/ipod-sync.nix.
+  blueprintPkg = blueprint.packages.${pkgs.system}.default;
+in
+{
+  options.modules.services.productivity.blueprint = {
+    enable = mkEnableOption "Blueprint personal dashboard";
+
+    domain = mkOption {
+      type = types.str;
+      default = "blueprint.${config.networking.domain}";
+      description = "Domain for Blueprint";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 3212;
+      description = "Port Blueprint's Next.js server listens on";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "blueprint";
+      description = "System user Blueprint runs as, and its Postgres role/database name";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.user;
+      description = "Blueprint service user";
+    };
+    users.groups.${cfg.user} = { };
+
+    # Peer-auth over the Unix socket against the shared instance, matching
+    # this repo's only other example (matrix-synapse) — no password/secret
+    # needed since the systemd service runs as this same-named role.
+    services.postgresql = {
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+      ensureDatabases = [ cfg.user ];
+    };
+
+    systemd.services.blueprint = {
+      description = "Blueprint personal dashboard";
+      after = [ "network.target" "postgresql.service" ];
+      requires = [ "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        NODE_ENV = "production";
+        PORT = toString cfg.port;
+        HOSTNAME = "127.0.0.1";
+        DATABASE_URL = "postgresql:///${cfg.user}?host=/run/postgresql";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.user;
+        ExecStart = "${pkgs.nodejs_22}/bin/node ${blueprintPkg}/server.js";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+
+    # Not automated yet: `drizzle-kit migrate` is a build-time devDependency,
+    # not part of the standalone runtime output, so there's no migration
+    # runner wired into the service start. Run it manually after first
+    # deploy and after any future schema change, from a checkout with
+    # node_modules (the systemd unit's own build output doesn't carry
+    # drizzle-kit itself):
+    #   DATABASE_URL="postgresql:///blueprint?host=/run/postgresql" \
+    #     sudo -u blueprint npx drizzle-kit migrate
+
+    modules.services.vHosts.hosts.${cfg.domain} = {
+      reverseProxyPort = cfg.port;
+      displayName = "Blueprint";
+      category = "productivity";
+    };
+  };
+}

--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -2,6 +2,7 @@
 {
   # Import productivity service modules
   imports = [
+    ./blueprint.nix
     ./vaultwarden.nix
     ./n8n.nix
     ./actual.nix


### PR DESCRIPTION
## Summary
- Blueprint now owns its own `buildNpmPackage` flake (TristonYoder/blueprint), with CI there keeping `npmDepsHash`/`flake.lock` current
- Imports that flake as an input here and adds `modules/services/productivity/blueprint.nix`, which wires the package into systemd/postgres/vHosts instead of duplicating the build recipe (replaces the reverted attempt in 738a18e)
- Enabled on david at `blueprint.tristonyoder.com`, internal-only

## Test plan
- [ ] CI (`test-nixos-config.yml`) passes for all hosts, including david's `dry-run`