### PR TITLE
Add Actual Budget MCP server, enable HTTP API on david

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -90,6 +90,13 @@ in
   # this host and already owns that port.
   modules.services.productivity.stirlingPdf.port = 7879;
 
+  # Actual Budget: plain REST wrapper (jhonderson/actual-http-api) and MCP
+  # server (agigante80/actual-mcp-server), both talking to the actual.nix
+  # service directly via @actual-app/api. Credentials in
+  # actual-http-api-secrets.age / actual-mcp-secrets.age (modules/secrets.nix).
+  modules.services.productivity.actualHttpApi.enable = true;
+  modules.services.productivity.actualMcp.enable = true;
+
   # Scrutiny and Pixelfed both default to port 8085. Pixelfed's port is
   # externally referenced (PITS reverse proxy, ActivityPub webfinger), so
   # move Scrutiny instead — it's Caddy-proxied and localhost-only.

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -71,6 +71,8 @@ with lib;
       # staying that way for now). Raw token value only, no KEY=VALUE wrapping.
       "ghcr-pull-token" = { file = ../secrets/ghcr-pull-token.age; owner = "root"; group = "root"; mode = "0400"; };
       "pocket-id-encryption-key" = { file = ../secrets/pocket-id-encryption-key.age; owner = "root"; group = "docker"; mode = "0440"; };
+      "actual-http-api-secrets" = { file = ../secrets/actual-http-api-secrets.age; owner = "root"; group = "docker"; mode = "0440"; };
+      "actual-mcp-secrets" = { file = ../secrets/actual-mcp-secrets.age; owner = "root"; group = "docker"; mode = "0440"; };
       # tidarr: docker-only service (docker/media/media-aq.nix), no NixOS module enable
       "tidarr-oidc-secret" = { file = ../secrets/tidarr-oidc-secret.age; mode = "0400"; };
       # stageplotifer: docker-only service (docker/productivity/stageplotifer.nix), no NixOS module enable.

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -35,8 +35,8 @@ in
 
     containerPort = mkOption {
       type = types.port;
-      default = 3000;
-      description = "Container port for the Actual HTTP API";
+      default = 5007;
+      description = "Container port for the Actual HTTP API (the app's own PORT default)";
     };
 
     image = mkOption {

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -41,7 +41,7 @@ in
 
     image = mkOption {
       type = types.str;
-      default = "ghcr.io/jhonderson/actual-http-api:latest";
+      default = "jhonderson/actual-http-api:latest";
       description = "OCI image for the Actual HTTP API";
     };
 

--- a/modules/services/productivity/actual-http-api.nix
+++ b/modules/services/productivity/actual-http-api.nix
@@ -8,7 +8,7 @@ let
     if cfg.actualServerUrl != "" then
       cfg.actualServerUrl
     else
-      "http://host.containers.internal:${toString actualModule.port}";
+      "http://host.docker.internal:${toString actualModule.port}";
   baseEnvironment = cfg.environment
     // optionalAttrs (resolvedActualServerUrl != "") {
       ACTUAL_SERVER_URL = resolvedActualServerUrl;
@@ -95,6 +95,7 @@ in
       volumes = [
         "${cfg.dataDir}:/data:rw"
       ];
+      extraOptions = [ "--add-host=host.docker.internal:host-gateway" ];
       log-driver = "journald";
     };
 

--- a/modules/services/productivity/actual-mcp.nix
+++ b/modules/services/productivity/actual-mcp.nix
@@ -8,7 +8,7 @@ let
     if cfg.actualServerUrl != "" then
       cfg.actualServerUrl
     else
-      "http://host.containers.internal:${toString actualModule.port}";
+      "http://host.docker.internal:${toString actualModule.port}";
   baseEnvironment = cfg.environment
     // optionalAttrs (resolvedActualServerUrl != "") {
       ACTUAL_SERVER_URL = resolvedActualServerUrl;
@@ -103,6 +103,7 @@ in
         "${cfg.dataDir}:/app/data:rw"
         "${cfg.logsDir}:/app/logs:rw"
       ];
+      extraOptions = [ "--add-host=host.docker.internal:host-gateway" ];
       log-driver = "journald";
     };
 

--- a/modules/services/productivity/actual-mcp.nix
+++ b/modules/services/productivity/actual-mcp.nix
@@ -2,7 +2,7 @@
 
 with lib;
 let
-  cfg = config.modules.services.productivity.actualHttpApi;
+  cfg = config.modules.services.productivity.actualMcp;
   actualModule = config.modules.services.productivity.actual;
   resolvedActualServerUrl =
     if cfg.actualServerUrl != "" then
@@ -18,37 +18,43 @@ let
     };
 in
 {
-  options.modules.services.productivity.actualHttpApi = {
-    enable = mkEnableOption "Actual Budget HTTP API";
+  options.modules.services.productivity.actualMcp = {
+    enable = mkEnableOption "Actual Budget MCP Server";
 
     domain = mkOption {
       type = types.str;
-      default = "api.budget.theyoder.family";
-      description = "Domain for the Actual HTTP API";
+      default = "mcp.budget.${config.networking.domain}";
+      description = "Domain for the Actual MCP Server";
     };
 
     port = mkOption {
       type = types.port;
-      default = 5007;
-      description = "Host port for the Actual HTTP API";
+      default = 3600;
+      description = "Host port for the Actual MCP Server";
     };
 
     containerPort = mkOption {
       type = types.port;
-      default = 3000;
-      description = "Container port for the Actual HTTP API";
+      default = 3600;
+      description = "Container port for the Actual MCP Server";
     };
 
     image = mkOption {
       type = types.str;
-      default = "ghcr.io/jhonderson/actual-http-api:latest";
-      description = "OCI image for the Actual HTTP API";
+      default = "ghcr.io/agigante80/actual-mcp-server:latest";
+      description = "OCI image for the Actual MCP Server";
     };
 
     dataDir = mkOption {
       type = types.str;
-      default = "/data/docker-appdata/actual-http-api";
-      description = "Data directory for the Actual HTTP API container";
+      default = "/data/docker-appdata/actual-mcp";
+      description = "Data directory for the Actual MCP Server container (local budget cache)";
+    };
+
+    logsDir = mkOption {
+      type = types.str;
+      default = "/data/docker-appdata/actual-mcp-logs";
+      description = "Logs directory for the Actual MCP Server container";
     };
 
     actualServerUrl = mkOption {
@@ -60,49 +66,53 @@ in
     environment = mkOption {
       type = types.attrsOf types.str;
       default = { };
-      description = "Additional environment variables for the Actual HTTP API container";
+      description = "Additional environment variables for the Actual MCP Server container";
     };
 
     environmentFiles = mkOption {
       type = types.listOf types.path;
-      default = optional (config.age.secrets ? actual-http-api-secrets) config.age.secrets.actual-http-api-secrets.path;
-      description = "Environment files passed to the Actual HTTP API container (must provide ACTUAL_SERVER_PASSWORD and API_KEY)";
+      default = optional (config.age.secrets ? actual-mcp-secrets) config.age.secrets.actual-mcp-secrets.path;
+      description = "Environment files passed to the Actual MCP Server container (must provide ACTUAL_PASSWORD, ACTUAL_BUDGET_SYNC_ID, MCP_SSE_AUTHORIZATION)";
     };
 
     openFirewall = mkOption {
       type = types.bool;
-      default = true;
-      description = "Open firewall port";
+      default = false;
+      description = "Open firewall port (leave closed; reach the server through the reverse proxy)";
     };
   };
 
   config = mkIf cfg.enable {
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0755 root root -"
+      "d ${cfg.logsDir} 0755 root root -"
     ];
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.port ];
     };
 
-    virtualisation.oci-containers.containers."actual-http-api" = {
+    virtualisation.oci-containers.containers."actual-mcp" = {
       image = cfg.image;
+      cmd = [ "--http" ];
       environment = baseEnvironment;
       environmentFiles = cfg.environmentFiles;
       ports = [
         "${toString cfg.port}:${toString cfg.containerPort}/tcp"
       ];
       volumes = [
-        "${cfg.dataDir}:/data:rw"
+        "${cfg.dataDir}:/app/data:rw"
+        "${cfg.logsDir}:/app/logs:rw"
       ];
       log-driver = "journald";
     };
 
     modules.services.vHosts.hosts.${cfg.domain} = {
       reverseProxyPort = cfg.port;
-      displayName = "Actual API";
+      displayName = "Actual MCP";
       category = "productivity";
       monitor = false;
+      public = false;
     };
   };
 }

--- a/modules/services/productivity/actual-mcp.nix
+++ b/modules/services/productivity/actual-mcp.nix
@@ -94,7 +94,6 @@ in
 
     virtualisation.oci-containers.containers."actual-mcp" = {
       image = cfg.image;
-      cmd = [ "--http" ];
       environment = baseEnvironment;
       environmentFiles = cfg.environmentFiles;
       ports = [

--- a/modules/services/productivity/default.nix
+++ b/modules/services/productivity/default.nix
@@ -7,6 +7,7 @@
     ./n8n.nix
     ./actual.nix
     ./actual-http-api.nix
+    ./actual-mcp.nix
     ./outline.nix
     ./tandoor.nix
     ./babybuddy.nix

--- a/secrets/actual-http-api-secrets.age
+++ b/secrets/actual-http-api-secrets.age
@@ -1,0 +1,10 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw YK1GQt8xzNevNKHhD5Np3TGyzAu9a12jwglUb/oP9X8
+Wv60FyO/tGkdqEmkiK9m9URkDvqj5jg+VWX9NMFT9mQ
+-> ssh-ed25519 G/hviA SJNpmiFiq/o73ARXGwBM7dT1xvHihgFo+MyRY+gNoA0
+ElQLXByHTH1CmwLhUHw44lPUzkX6WsaaJNtA7D1EOVk
+--- JaFzQxmABeJDpeKMHyetvSt8fd4oFWG6XLC+B0AiL/M
+Ú÷∞K’qÖ„«Ë„π
+'Â¨<;~^£It·†G{"·¶ÄO2œYRF√ï6:ƒa“‰˛˘•äDß?ÒÏ∏ˇNø“©ß™∫%»Œ,√Lﬁ$A‚0©
+/w,Ü
+ëÖ0÷uÆe¥ÉI∏®£˝ª;lˆQ˚8û˝Ëæ∑∞uèôˇ∆G‘qôa≈l≈À*ÚÖ

--- a/secrets/actual-mcp-secrets.age
+++ b/secrets/actual-mcp-secrets.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 QfFraw BSbgy/IPGqtmUpjoLx1PwAwJJ2IDj955D91iBEsiGwE
+WbSHcoyvSy52bKzF2XZ+rC3oVxixNZHcOJu1KapyrP0
+-> ssh-ed25519 G/hviA kC6cO+P7erSMWKNHki/+2nuC7dHkHob8Z9lShae/rwc
+8uNfApDZdsQmitUrCTGLLsQopZ44msw+s89Bf3PFKw8
+--- ucg1VkX+zz1tuEojJWySo32b97EWBmavVPEqf6IGkak
+¸º>Ò<,]Š>ëÖHöB9“%B“sµ&·9È)^F“=pÆ!w¸`m¡dHÆþÒ]ÄØtÌt2UÀf¬»3Ñ™]ºy½ÜÓÊ{­P1¬­,bªu%–«åpT¤ü¦;¢9œ¯æjIïòÈykŒ›×ÞIVÑ©Fì”À(@ls	9õ?v-qýTpü·«h]¯x=™€8g<·g]Ù*ØÛ‘ÅºlFPxIòëR]Ÿ^±ÛbgWˆb=Ê—ØPõb-ª)Ý>æÑtJV+Ýð;


### PR DESCRIPTION
## Summary
- New `actualMcp` module wrapping `agigante80/actual-mcp-server` (71 tools, HTTP transport) as an OCI container on david, registered privately in vHosts (not public).
- Enables the existing `actualHttpApi` module (jhonderson's REST wrapper), which was defined but never turned on.
- New agenix secrets for both services' credentials (`actual-http-api-secrets.age`, `actual-mcp-secrets.age`).

## Fixes found during activation
- `actual-http-api`'s image was pointed at a nonexistent `ghcr.io` path; the image is published to Docker Hub.
- `actualMcp`'s container `cmd` override broke the image's entrypoint (it already defaults to HTTP transport).
- `actual-http-api`'s `containerPort` didn't match the app's real internal `PORT` default (5007, not 3000).
- Both modules used `host.containers.internal` (a Podman-only DNS alias) to reach the host's `actual.nix` service; david runs plain Docker, which needs `host.docker.internal` + an explicit `--add-host` mapping.

## Test plan
- [x] `nixos-rebuild test` on david — both `docker-actual-http-api` and `docker-actual-mcp` come up clean, no other services regressed.
- [x] `actual-http-api` Swagger UI reachable on `:5007`.
- [x] `actual-mcp` reports `"initialized": true`, authenticates to Actual, served real account data through a live MCP session.
- [ ] Not yet persisted to boot — run `rebuild -b feat/actual-mcp boot` (or plain switch) on david before/after merge.