### PR TITLE
feat: add Hermes web dashboard as a service

### DIFF
--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -331,6 +331,7 @@ in
       remote = "git@github.com:TristonYoder/hermes-brain.git";
       deployKeyFile = config.age.secrets.hermes-brain-deploy-key.path;
     };
+    dashboard.enable = true;
   };
 
   modules.services.ai.open-webui = {

--- a/modules/services/ai/hermes-agent.nix
+++ b/modules/services/ai/hermes-agent.nix
@@ -3,6 +3,17 @@
 with lib;
 let
   cfg = config.modules.services.ai.hermes-agent;
+
+  # Mirrors the upstream module's own `effectivePackage` (nix/nixosModules.nix)
+  # so the dashboard's native-mode fallback runs the exact same build as the
+  # gateway (extraDependencyGroups = [ "matrix" ] pulls in mautrix etc.).
+  # Container mode doesn't need this — it execs into the already-resolved
+  # /data/current-package symlink inside the running container instead.
+  effectiveHermesPackage =
+    let hcfg = config.services.hermes-agent;
+    in if hcfg.extraPythonPackages == [ ] && hcfg.extraDependencyGroups == [ ]
+       then hcfg.package
+       else hcfg.package.override { inherit (hcfg) extraPythonPackages extraDependencyGroups; };
 in
 {
   options.modules.services.ai.hermes-agent = {
@@ -117,6 +128,34 @@ in
           safety net, not the primary sync path — Hermes is expected to commit
           its own deliberate changes; this timer only catches what it forgets,
           with a generic "auto-sync" commit message.
+        '';
+      };
+    };
+
+    dashboard = {
+      enable = mkEnableOption ''
+        Hermes's browser web dashboard (`hermes dashboard`) — config, API keys,
+        and session management UI — as a second service alongside the gateway
+      '';
+
+      port = mkOption {
+        type = types.port;
+        default = 9119;
+        description = ''
+          Port for the dashboard backend. Always bound to 127.0.0.1, never
+          publicly — reached only through the vHosts/Caddy reverse proxy (or
+          an SSH/Tailscale tunnel directly to the port).
+        '';
+      };
+
+      domain = mkOption {
+        type = types.str;
+        default = "hermes.${config.networking.domain}";
+        description = ''
+          vHosts domain the dashboard is registered under. Kept `public =
+          false` — the dashboard has no auth of its own when bound to
+          loopback (see module comment), so it's reachable over LAN/Tailscale
+          only, the same trust model as this repo's other internal admin UIs.
         '';
       };
     };
@@ -322,6 +361,66 @@ in
       timerConfig = {
         OnBootSec = "5min";
         OnUnitActiveSec = cfg.vaultGit.interval;
+      };
+    };
+
+    modules.services.vHosts.hosts = mkIf cfg.dashboard.enable {
+      ${cfg.dashboard.domain} = {
+        reverseProxyPort = cfg.dashboard.port;
+        displayName = "Hermes Dashboard";
+        category = "ai";
+        icon = "hermes";
+        public = false;
+      };
+    };
+
+    # `hermes dashboard` is a second, independent process from the gateway
+    # (`hermes gateway run`) — both read/write the same HERMES_HOME state, so
+    # it's safe to run side by side. `--no-open` skips the (headless-hostile)
+    # browser launch; `--skip-build` serves the SPA already built into the
+    # package (HERMES_WEB_DIST, set by the wrapper in nixosModules.nix)
+    # instead of shelling out to npm, which isn't available in this context.
+    #
+    # No dashboard-level auth is configured: it never binds beyond 127.0.0.1,
+    # so upstream's own auth gate (which only engages on non-loopback binds)
+    # stays off. Caddy is the sole ingress, same trust boundary as this
+    # repo's other internal-only admin UIs.
+    systemd.services.hermes-dashboard = mkIf cfg.dashboard.enable {
+      description = "Hermes Agent web dashboard";
+      after = [ "hermes-agent.service" ] ++ optional cfg.containerMode "docker.service";
+      requires = [ "hermes-agent.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.coreutils ] ++ optional cfg.containerMode pkgs.docker;
+
+      # Container mode: exec into the *running* gateway container rather than
+      # spinning up a second one — network=host means a loopback bind here is
+      # already the host's loopback, and /data/current-package is the same
+      # symlink the upstream module keeps pointed at effectivePackage, so this
+      # always runs the exact build the gateway is running. `docker exec`
+      # defaults to root, which would leave dashboard-written state
+      # root-owned inside a dir the gateway process (running as cfg.user)
+      # can't write back to — resolve the uid/gid at run time and match it,
+      # same as the upstream module's own preStart does for container create.
+      script =
+        if cfg.containerMode then ''
+          HERMES_UID=$(id -u ${config.services.hermes-agent.user})
+          HERMES_GID=$(id -g ${config.services.hermes-agent.group})
+          exec docker exec --user "$HERMES_UID:$HERMES_GID" hermes-agent \
+            /data/current-package/bin/hermes dashboard \
+            --no-open --skip-build \
+            --host 127.0.0.1 --port ${toString cfg.dashboard.port}
+        ''
+        else ''
+          exec ${effectiveHermesPackage}/bin/hermes dashboard \
+            --no-open --skip-build \
+            --host 127.0.0.1 --port ${toString cfg.dashboard.port}
+        '';
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = 5;
       };
     };
   };


### PR DESCRIPTION
## Summary
- hermes-agent only ran `hermes gateway run` (the Matrix bot loop) — the bundled browser dashboard (config/API keys/sessions, upstream port 9119) was never exposed.
- Adds `modules.services.ai.hermes-agent.dashboard.{enable,port,domain}` and a `hermes-dashboard` systemd service that runs `hermes dashboard` alongside the gateway, registered in the vHosts registry (Caddy/DNS/Gatus/Homepage pick it up automatically). `public = false` — no dashboard-level auth, so it stays LAN/Tailscale-only via Caddy.
- Container mode (used on david) execs into the already-running `hermes-agent` container instead of spinning up a second one, matching uid/gid so dashboard-written state isn't left root-owned.
- Enabled on david at `hermes.<domain>`.

Verified with `nixos-rebuild dry-run` against david on this branch — evaluates cleanly, correctly generates the new `hermes-dashboard.service` unit plus Caddyfile/gatus/DNS entries for the vHost.

## Test plan
- [x] `nixos-rebuild dry-run --flake github:TristonYoder/nix-config/feat/hermes-dashboard#david --refresh` succeeds
- [ ] CI test-configurations matrix passes
- [ ] After merge: `rebuild` on david, confirm `hermes-dashboard.service` is active and `hermes.<domain>` responds