### PR TITLE
fix: stop apps-manifest ACME retry loop

### DIFF
--- a/modules/services/providers/app-manifest.nix
+++ b/modules/services/providers/app-manifest.nix
@@ -8,10 +8,20 @@ let
   shortcutHosts = filter (h: h.enable && h.shortcut)
     (attrValues config.modules.services.vHosts.hosts);
 
+  # A virtualHost may carry an explicit scheme — Caddy treats a leading
+  # "http://" as a site address that disables automatic HTTPS (the well-known
+  # endpoint does this on the host server). Strip any scheme before rebuilding
+  # the URL, otherwise the manifest emits "https://http://domain". Mirrors the
+  # normalisation in providers/dns-technitium.nix.
+  urlOf = vhost:
+    if hasPrefix "http://" vhost
+    then vhost
+    else "https://${removePrefix "https://" vhost}";
+
   appsJson = builtins.toJSON {
     apps = map (h: {
       name     = h.displayName;
-      url      = "https://${h.virtualHost}";
+      url      = urlOf h.virtualHost;
       category = if h.category != "" then h.category else "services";
       icon     = h.icon;
     }) shortcutHosts;
@@ -32,7 +42,10 @@ in
     modules.services.vHosts.hosts.${cfg.domain} = {
       shortcut    = false;
       monitor     = false;
-      dnsChallenge = false;
+      # dnsChallenge must stay true (the default). This domain is internal-only
+      # — it is NXDOMAIN on public resolvers — so HTTP-01 and TLS-ALPN-01 can
+      # never validate, and Caddy retries forever. DNS-01 only needs a TXT
+      # record in the Cloudflare zone, which works without any public A record.
       rawConfig   = true;
       extraConfig = ''
         header Access-Control-Allow-Origin "*"


### PR DESCRIPTION
Applied and verified on david from this branch.

## The loop

`app-manifest.nix` set `dnsChallenge = false` on its vHost, so Caddy skipped the `cloudflare_tls` import and fell back to HTTP-01 / TLS-ALPN-01. Those challenges require Let's Encrypt to resolve the name publicly, but `apps-manifest.theyoder.family` is internal-only:

```
dig @1.1.1.1 apps-manifest.theyoder.family  ->  NXDOMAIN
```

So every attempt failed with `urn:ietf:params:acme:error:dns` and Caddy retried forever — 25 log entries in 24h, no cert ever obtained.

DNS-01 needs only a TXT record in the Cloudflare zone, not a public A record. Removing the override restores the default (`true`), matching every other internal-only vHost — `dns01.theyoder.family` and `status.theyoder.family` already hold valid certs this way.

## Also fixed

The manifest generator prefixed `https://` unconditionally. A `virtualHost` may carry an explicit scheme — Caddy treats a leading `http://` as a site address that disables automatic HTTPS, which the well-known endpoint uses on the host server. That produced:

```
{"name":"Well-Known","url":"https://http://theyoder.family"}
```

and a broken desktop shortcut. Now scheme-aware, mirroring the normalisation already in `providers/dns-technitium.nix`.

## Verified on david

- Cert obtained ~10s after reload (Let's Encrypt, via DNS-01)
- `https://apps-manifest.theyoder.family/apps.json` -> HTTP 200, `ssl_verify_result=0`
- Zero `apps-manifest` log lines after issuance — loop stopped
- Manifest now emits `"url":"http://theyoder.family"` for Well-Known