### PR TITLE
fix: stop tailscale login QR from stealing tty1 from the display manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,6 +592,25 @@ The live installer environment runs entirely in RAM with **no swap by default**.
 
 **Diagnostics:** `free -h` on the installer (check `Swap: 0B` to confirm no cushion exists) before starting a heavy install.
 
+### Never Give a Boot-Time Service `TTYPath=/dev/tty1`
+**Hosts:** any host with a display manager (server, desktop, kiosk profiles)
+
+A systemd service with `StandardInput=tty` and `TTYPath=/dev/tty1` makes systemd acquire tty1 as that service's *controlling terminal*. sddm-helper's `ioctl(STDIN_FILENO, TIOCSCTTY)` on tty1 then returns EPERM, the greeter exits with `SDDM::Auth::HELPER_TTY_ERROR`, and `display-manager.service` burns its 3 restarts within 30s and gives up with `start-limit-hit` — permanently, even after the offending service releases tty1.
+
+This bit `tailscale-login-qr` (fixed in PR #322): it was `wantedBy = multi-user.target` and slept 10s before its first check, holding tty1 straight through the display-manager start window. The symptom looks like a boot failure — the machine comes up, SSH works, but there's never a login screen.
+
+**Rule:** any unit that writes to the console must be started *on demand*, never placed in the boot transaction, on hosts that run a display manager. Split "decide whether the console output is needed" (no TTY) from "show it" (TTY, started via `systemctl start --wait`).
+
+**Diagnostics:**
+```bash
+journalctl -b -u display-manager | grep -c HELPER_TTY_ERROR   # >0 = tty1 contention
+journalctl -b | grep -iE 'take control of'                    # names the tty and its owner
+# find who claimed it -- compare unit start times against the display-manager window
+systemctl show -p TTYPath -p StandardInput '*.service' 2>/dev/null | grep -B1 tty1
+```
+
+Note the failure survives a rollback of the *running* system only if you also boot an older generation — the profile symlink still points at the broken one.
+
 ### SDDM Blinking Cursor (No Login Screen)
 **Host:** david — Plasma 6 + NVIDIA
 

--- a/modules/services/infrastructure/tailscale.nix
+++ b/modules/services/infrastructure/tailscale.nix
@@ -47,7 +47,10 @@ in
         interactive authentication — e.g. it has no preauth key yet, or
         an existing one expired. Lets you complete login from a phone
         with console-only access (no SSH, no Tailscale yet). A no-op
-        once the node is already logged in — the service just exits.
+        once the node is already logged in — nothing touches tty1.
+
+        Note: while the QR is up it owns /dev/tty1, so a display manager
+        on the same host cannot start until login completes.
       '';
     };
   };
@@ -67,20 +70,22 @@ in
       ];
     };
 
-    systemd.services.tailscale-login-qr = mkIf cfg.showLoginQr {
-      description = "Show a QR code on the console for interactive tailscale login, if needed";
+    # Split in two on purpose. systemd opens TTYPath when the unit starts,
+    # regardless of what the script does, and StandardInput=tty makes that
+    # TTY the service's controlling terminal. A single always-started unit
+    # therefore owned /dev/tty1 for as long as it polled, which made
+    # sddm-helper's ioctl(TIOCSCTTY) on tty1 fail with EPERM and took
+    # display-manager.service down with a start-limit-hit on every host with
+    # a graphical greeter. So the polling half runs with no TTY at all, and
+    # only starts the TTY-owning half when login is actually needed.
+    systemd.services.tailscale-login-qr-watch = mkIf cfg.showLoginQr {
+      description = "Watch for tailscale needing interactive login";
       after = [ "tailscaled.service" "tailscaled-autoconnect.service" ];
       wants = [ "tailscaled.service" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ config.services.tailscale.package pkgs.qrencode pkgs.jq ];
+      path = [ config.services.tailscale.package pkgs.jq ];
       serviceConfig = {
         Type = "simple";
-        StandardInput = "tty";
-        StandardOutput = "tty";
-        StandardError = "tty";
-        TTYPath = "/dev/tty1";
-        TTYReset = true;
-        TTYVHangup = true;
         Restart = "on-failure";
         RestartSec = "5s";
       };
@@ -97,16 +102,36 @@ in
               exit 0
               ;;
             NeedsLogin|NeedsMachineAuth|Stopped)
-              echo "=== Tailscale needs authentication — scan this QR code or visit the URL below ==="
-              tailscale up ${optionalString (cfg.loginServer != "") "--login-server=${cfg.loginServer}"} 2>&1 | while IFS= read -r line; do
-                echo "$line"
-                case "$line" in
-                  https://*) echo "$line" | qrencode -t ANSIUTF8 ;;
-                esac
-              done
+              systemctl start --wait tailscale-login-qr.service || true
               ;;
           esac
           sleep 5
+        done
+      '';
+    };
+
+    systemd.services.tailscale-login-qr = mkIf cfg.showLoginQr {
+      description = "Show a QR code on the console for interactive tailscale login";
+      # Deliberately not wantedBy any target -- tailscale-login-qr-watch
+      # starts it on demand. Anything that puts this in the boot transaction
+      # takes /dev/tty1 away from the display manager.
+      path = [ config.services.tailscale.package pkgs.qrencode ];
+      serviceConfig = {
+        Type = "simple";
+        StandardInput = "tty";
+        StandardOutput = "tty";
+        StandardError = "tty";
+        TTYPath = "/dev/tty1";
+        TTYReset = true;
+        TTYVHangup = true;
+      };
+      script = ''
+        echo "=== Tailscale needs authentication — scan this QR code or visit the URL below ==="
+        tailscale up ${optionalString (cfg.loginServer != "") "--login-server=${cfg.loginServer}"} 2>&1 | while IFS= read -r line; do
+          echo "$line"
+          case "$line" in
+            https://*) echo "$line" | qrencode -t ANSIUTF8 ;;
+          esac
         done
       '';
     };


### PR DESCRIPTION
`tailscale-login-qr` (added in b4cbd03) started on every boot with `StandardInput=tty` + `TTYPath=/dev/tty1`, which makes systemd acquire tty1 as the service's controlling terminal. sddm-helper's `ioctl(TIOCSCTTY)` on tty1 then returns EPERM, the greeter exits with `HELPER_TTY_ERROR`, and display-manager burns its 3 restarts inside 30s and gives up.

The script slept 10s before its first state check, so tty1 stayed held right through the display-manager start window.

Confirmed on two hosts:
- **tristons-nixbook** — first affected generation is 44 (built Jul 29, first build containing b4cbd03). Gens 42/43 boot fine; 44 and 45 both fail with 18 TTY errors each.
- **david** — display-manager has been failed since the 15:05 rebuild today, same 18 TTY errors, QR unit held tty1 from 15:05:45 to 15:05:55 and the DM hit its start limit at 15:05:50.

Affects every host with a display manager (server, desktop, kiosk profiles). Edge hosts are unaffected and are where the QR is actually useful.

Fix: split the polling loop (no TTY) from the QR display (TTY, started on demand by the watcher). tty1 is only claimed when login is genuinely needed.

Verified `nixos-rebuild build` for tristons-nixbook: `tailscale-login-qr.service` now has no `[Install]` section and is absent from `multi-user.target.wants`.