### PR TITLE
Plotiphar Output Device — display power/input control over HDMI-CEC

### DIFF
--- a/hosts/stage-plotiphar/README.md
+++ b/hosts/stage-plotiphar/README.md
@@ -107,26 +107,76 @@ sudo rm -rf /var/lib/kiosk-cec/HDMI-1 /var/lib/kiosk/profile-HDMI-1/current-url
 sudo systemctl restart kiosk-cec-agent
 ```
 
-### The standby limitation
+### Working with other TV brands
 
-**A TV that cuts the HDMI link when it powers off cannot be woken over CEC
-from this Output Device.** The `vc4` driver takes its CEC physical address
-from the sink's EDID; with the link down the address reads `f.f.f.f`, no logical
-address is allocated, and nothing can be transmitted. Forcing
-`cec-ctl --phys-addr` does not override this (confirmed on this Pi).
+CEC is only loosely honoured in practice, so each action is a **ladder**: send
+a message, ask the display what state it's in, and escalate only if it didn't
+take. Every rung points the same direction, so a TV that never reports its
+power status just receives all of them.
 
-Many TVs — including the LG panel here — keep CEC alive in standby precisely
-so One Touch Play works, in which case wake-up is fine. If yours doesn't, the
-Output Device reports the display as unreachable with that reason rather
-than silently failing, and standby/input switching still work whenever the set is on. Check
-which behavior you have:
+| Action | Rungs (`wakeSteps` / `standbySteps` / `inputSteps`) |
+|---|---|
+| On | `image-view-on` → `text-view-on` → `power-on-key` |
+| Standby | `standby` → `power-off-key` |
+| Show input | `active-source` + `set-stream-path` (both always sent — CEC can't report which input is showing) |
+
+`standby-broadcast` exists but is not a default: it sleeps *every* device on
+the bus, so an AVR or another player sharing the cable would be switched off by
+this host's schedule too.
+
+**Before anything else, check CEC is enabled on the TV.** Every vendor ships it
+off by default and buries it under its own name: Anynet+ (Samsung), Bravia Sync
+(Sony), SIMPLINK (LG), VIERA Link (Panasonic), EasyLink (Philips). Most "CEC
+doesn't work" reports are just this. Eco / Quick-Start settings also commonly
+decide whether the set keeps CEC alive while off.
+
+On the LG here, the two settings that matter are **SIMPLINK (HDMI-CEC): On**
+and **Auto Power Sync** (sometimes *Auto Power Link*): **On** — the second is
+what lets the TV follow this host's power commands at all.
+
+### Commissioning a new display
 
 ```bash
-# With the TV in standby:
+plotiphar-cec-probe /dev/cec0
+```
+
+Reports the adapter, what's on the other end of the cable, and — after an
+explicit confirmation, because it power-cycles the display — runs
+`cec-compliance` against it. That's the conformance suite shipped with
+v4l-utils, not a bespoke test, so it reports per-feature results (One Touch
+Play, Power Status, Standby/Resume) rather than one verdict. The probe prints
+how to map each failure onto the options above.
+
+Don't over-trust published compatibility tables. libCEC's vendor matrix says
+LG TVs don't support CEC power-off; the LG on this host goes to standby in
+under three seconds. Probe the actual panel.
+
+### The one thing that can't be worked around
+
+**A TV that cuts its HDMI link when it powers off cannot be woken over CEC.**
+The `vc4` driver takes its physical address from the sink's EDID; with the link
+down the address reads `f.f.f.f`, no logical address is allocated, and there is
+no bus left to transmit on. Forcing `cec-ctl --phys-addr` does not override it
+(confirmed here). No message ladder rescues this — the agent detects it and
+says so explicitly rather than failing silently.
+
+Many sets — including the LG here — keep CEC alive in standby precisely so One
+Touch Play works. Check which you have:
+
+```bash
+# With the TV off:
 cec-ctl -d /dev/cec0 | grep "Physical Address"
 # 2.0.0.0 → CEC stays alive in standby, wake-up will work
 # f.f.f.f → the link drops, this Output Device cannot wake it
 ```
+
+### Timing
+
+Panels are slow to settle and go briefly unresponsive while they do — the LG
+here takes ~19s to report a stable "on", dropping two polls on the way, while
+standby lands in under 3s. `verifyTimeoutSeconds` (default 25) is how long a
+rung is given before escalating; too low and a working TV is declared deaf and
+gets the whole ladder fired at it.
 
 ### Operations
 
@@ -135,18 +185,30 @@ systemctl status kiosk-cec-agent
 journalctl -u kiosk-cec-agent -f
 
 # What the bus looks like right now
-cec-ctl -d /dev/cec0 -S                              # topology + TV vendor/OSD name
+cec-ctl -d /dev/cec0 -S                                 # topology + TV vendor/OSD name
 cec-ctl -d /dev/cec0 --to 0 --give-device-power-status
-
-# Drive it by hand (the same messages the Output Device sends)
-cec-ctl -d /dev/cec0 --to 0 --image-view-on           # wake
-cec-ctl -d /dev/cec0 --active-source phys-addr=2.0.0.0  # claim this input
-cec-ctl -d /dev/cec0 --to 0 --standby                 # sleep
 ```
 
-`/dev/cec0` is HDMI-1 (`hdmi0`, the port nearer the USB-C jack) and `/dev/cec1`
-is HDMI-2. With nothing plugged into the second port, `cec-ctl -d /dev/cec1`
-reporting `f.f.f.f` is expected, not a fault.
+Driving it by hand — the same messages the Output Device sends. `/dev/cec0` is
+HDMI-1 (`hdmi0`, the port nearer the USB-C jack) at physical address `2.0.0.0`;
+`/dev/cec1` is HDMI-2 at `3.0.0.0`. With nothing plugged into the second port,
+`cec-ctl -d /dev/cec1` reporting `f.f.f.f` is expected, not a fault.
+
+```bash
+# Wake, then claim the input — One Touch Play is only half done without both
+cec-ctl -d /dev/cec0 --to 0 --image-view-on
+cec-ctl -d /dev/cec0 --active-source phys-addr=2.0.0.0
+
+# Sleep. Directed at the TV, not broadcast: `--to 15` would sleep every device
+# on the bus, including an AVR or another player sharing the cable. Measured
+# here, the LG honours the directed form in under 3s — worth re-checking with
+# plotiphar-cec-probe before reaching for the broadcast version.
+cec-ctl -d /dev/cec0 --to 0 --standby
+```
+
+Power status reads `in transition from standby to on` for 20-30s after a wake
+on this LG (and many others). That is normal, not a stuck command — see
+[Timing](#timing) for why the ladder waits it out rather than escalating.
 
 ## First install (physical, one-time)
 
@@ -192,50 +254,6 @@ sudo rm -rf /var/lib/kiosk/profile-*/Default /var/lib/kiosk/profile-*/current-ur
 sudo systemctl restart kiosk-launcher
 
 ```
-
-## CEC display power control
-
-Requires `v4l-utils` installed (see `hosts/stage-plotiphar/configuration.nix`) and the
-user in the `video` group. Once the NixOS config is deployed, `cec-ctl` is on `$PATH`
-and runs without `sudo`.
-
-**TV prerequisites** (must be enabled once in the TV's menu):
-- **SimpLink / HDMI-CEC**: On
-- **Auto Power Sync** (or *Auto Power Link*): On
-
-### Port 1 (`/dev/cec0`)
-
-```bash
-# Power ON — two-step: wake the TV then claim the active input
-cec-ctl -s -d /dev/cec0 --playback --to 0 --image-view-on
-cec-ctl -s -d /dev/cec0 --playback --active-source phys-addr=2.0.0.0
-
-# Power OFF — broadcast standby opcode (0x36) to all devices on the bus
-cec-ctl -s -d /dev/cec0 --playback --to 15 --custom-command cmd=0x36
-
-# Power status check
-cec-ctl -s -d /dev/cec0 --playback --to 0 --give-device-power-status
-
-# Topology scan (shows all connected CEC devices and their addresses)
-cec-ctl -s -d /dev/cec0 --playback -S
-```
-
-### Port 2 (`/dev/cec1`)
-
-Same commands, substitute `/dev/cec1`. Physical address on Port 2 is `3.0.0.0`:
-
-```bash
-cec-ctl -s -d /dev/cec1 --playback --to 0 --image-view-on
-cec-ctl -s -d /dev/cec1 --playback --active-source phys-addr=3.0.0.0
-
-cec-ctl -s -d /dev/cec1 --playback --to 15 --custom-command cmd=0x36
-
-cec-ctl -s -d /dev/cec1 --playback --to 0 --give-device-power-status
-```
-
-> [!NOTE]
-> LG TVs (and some others) take 20–30 s to fully power on from standby. The power status
-> will read `in transition from standby to on` during that window — this is normal.
 
 ## Troubleshooting
 

--- a/hosts/stage-plotiphar/README.md
+++ b/hosts/stage-plotiphar/README.md
@@ -12,6 +12,9 @@ displays with the [stage-plotifer](https://plotiphar.com) app.
   `modules.services.kiosk.browserKiosk` (see `modules/services/kiosk/browser-kiosk.nix`)
 - **Reset**: the onboard power button clears all instances' cookies/cache
   and reloads them to the pairing URL instead of shutting the machine down
+- **Display power**: optionally acts as a Plotiphar Output Device, letting the
+  app power the TV and switch its input — see
+  [Display power control](#display-power-control-plotiphar-output-device) below
 
 ## How the kiosk stays paired across reboots
 
@@ -25,6 +28,125 @@ each Chromium instance's DevTools port, and whenever the active tab is a
 `kiosk-launcher.service` reads that file back in on the next boot and opens
 straight to it — only falling back to `/pair` the first time, or after a
 manual reset.
+
+## Display power control (Plotiphar Output Device)
+
+`modules.services.kiosk.cecBridge` (see
+`modules/services/kiosk/cec-bridge.nix`) makes this Pi a **Plotiphar Output
+Device**: the app can power this venue's TV on/standby and switch it to the
+Pi's HDMI input — from Settings → Screens in the app, or on a per-screen
+schedule.
+
+As an Output Device it runs `kiosk-cec-agent.service`, which polls
+`POST <origin>/api/screens/<id>/cec/report` every 15s. Each heartbeat reports
+what it sees on the HDMI-CEC bus and returns any pending command plus the
+screen's schedule, so one request per cycle covers both directions. It is
+outbound-only: no inbound port, and it works from the venue LAN with no
+reachable address.
+
+It figures out what to drive with no extra configuration:
+
+- **Which screen** — from the pairing below; the screen id is issued to this
+  host when its code is approved, and stored per output.
+- **Which adapter** — matches each `/dev/cec*` to an `xrandr` output via the
+  DRM connector id both report, rather than assuming `/dev/cec0` is `HDMI-1`.
+  (On this Pi they do line up — `HDMI-1` → connector 35 → `/dev/cec0` — but
+  nothing guarantees it, and driving the wrong TV is a bad failure mode.)
+
+Schedules are evaluated **on this Output Device, in its own local time**
+(`America/Indiana/Indianapolis`), not on the server — venue displays should
+follow venue wall-clock time regardless of where the app runs. An entry whose
+time passed more than `scheduleGraceSeconds` (default 300) ago is skipped
+rather than fired late.
+
+### Pairing — one code provisions everything
+
+There is no secret to deploy. On first boot the display shows a pairing code;
+entering it in the app (Settings → Screens → Pair a Display) issues this host
+its own credential, creates or binds its screen, and signs the kiosk browser
+in — all from that one code.
+
+The Output Device owns the pairing rather than the browser, which matters for
+two reasons. Only the device can hold a credential: a cookie in the Chromium
+profile is wiped by the reset button, and there'd be nothing left to
+authenticate CEC calls with. And if the browser minted its own code first, you
+could approve a code that signed the browser in while leaving the device
+unpaired — so `browserKiosk.pairingHandledExternally` suppresses the browser's
+own `/pair` fallback whenever this module is on.
+
+What happens on the wire:
+
+1. The agent calls `/api/auth/device/start` as `client: "output-device"`,
+   naming itself `<hostname> <output>`, and gets a code plus a device token
+   (in the body — it has no cookie jar).
+2. It writes a local page showing that code and points the output's
+   `current-url` at it. The page reloads itself, so a regenerated code (they
+   expire after 10 minutes) appears with nobody touching the machine.
+3. Someone approves the code. Leaving the screen selector on *Automatic*
+   creates a screen named after the device, with display power already on.
+4. The agent's next `/api/auth/device/status` poll returns its **session
+   token** (sent as `Authorization: Bearer` from then on), its **screen id**,
+   and a **single-use browser handoff URL**.
+5. It rewrites the local page into a top-level redirect to that handoff URL.
+   The browser follows it once, picks up its own session cookie, and lands on
+   `/screens/<id>` — after which `kiosk-url-tracker` persists the real URL as
+   it always has.
+
+The session has a 90-day sliding expiry that every heartbeat refreshes, so a
+paired display stays paired indefinitely. Pressing the reset button wipes the
+browser profile, which the agent reads as "re-pair this display": it discards
+its credential and shows a fresh code.
+
+```bash
+# What this output currently thinks it is
+sudo ls /var/lib/kiosk-cec/                        # pair-<output>.html is what's on screen
+sudo cat /var/lib/kiosk-cec/HDMI-1/credential.json  # 0600 — holds a live session token
+
+# Force a re-pair of one output
+sudo rm -rf /var/lib/kiosk-cec/HDMI-1 /var/lib/kiosk/profile-HDMI-1/current-url
+sudo systemctl restart kiosk-cec-agent
+```
+
+### The standby limitation
+
+**A TV that cuts the HDMI link when it powers off cannot be woken over CEC
+from this Output Device.** The `vc4` driver takes its CEC physical address
+from the sink's EDID; with the link down the address reads `f.f.f.f`, no logical
+address is allocated, and nothing can be transmitted. Forcing
+`cec-ctl --phys-addr` does not override this (confirmed on this Pi).
+
+Many TVs — including the LG panel here — keep CEC alive in standby precisely
+so One Touch Play works, in which case wake-up is fine. If yours doesn't, the
+Output Device reports the display as unreachable with that reason rather
+than silently failing, and standby/input switching still work whenever the set is on. Check
+which behavior you have:
+
+```bash
+# With the TV in standby:
+cec-ctl -d /dev/cec0 | grep "Physical Address"
+# 2.0.0.0 → CEC stays alive in standby, wake-up will work
+# f.f.f.f → the link drops, this Output Device cannot wake it
+```
+
+### Operations
+
+```bash
+systemctl status kiosk-cec-agent
+journalctl -u kiosk-cec-agent -f
+
+# What the bus looks like right now
+cec-ctl -d /dev/cec0 -S                              # topology + TV vendor/OSD name
+cec-ctl -d /dev/cec0 --to 0 --give-device-power-status
+
+# Drive it by hand (the same messages the Output Device sends)
+cec-ctl -d /dev/cec0 --to 0 --image-view-on           # wake
+cec-ctl -d /dev/cec0 --active-source phys-addr=2.0.0.0  # claim this input
+cec-ctl -d /dev/cec0 --to 0 --standby                 # sleep
+```
+
+`/dev/cec0` is HDMI-1 (`hdmi0`, the port nearer the USB-C jack) and `/dev/cec1`
+is HDMI-2. With nothing plugged into the second port, `cec-ctl -d /dev/cec1`
+reporting `f.f.f.f` is expected, not a fault.
 
 ## First install (physical, one-time)
 

--- a/hosts/stage-plotiphar/configuration.nix
+++ b/hosts/stage-plotiphar/configuration.nix
@@ -65,6 +65,20 @@
     mode = "0400";
   };
 
+  # =============================================================================
+  # DISPLAY POWER (PLOTIPHAR OUTPUT DEVICE)
+  # =============================================================================
+
+  # Makes this Pi a Plotiphar Output Device: the app can power the venue TV
+  # on/standby and switch it to this Pi's HDMI input, manually or on a
+  # schedule. See modules/services/kiosk/cec-bridge.nix.
+  #
+  # No secret to provision: the display shows a pairing code on screen, and
+  # approving it in the app (Settings → Screens → Pair a Display) issues this
+  # host its own credential, creates or binds its screen, and logs the kiosk
+  # browser in — all from that one code.
+  modules.services.kiosk.cecBridge.enable = true;
+
   networking.networkmanager.ensureProfiles = {
     environmentFiles = [ config.age.secrets.stage-plotiphar-wifi-psk.path ];
     profiles."TPCC_Production" = {

--- a/modules/services/kiosk/browser-kiosk.nix
+++ b/modules/services/kiosk/browser-kiosk.nix
@@ -15,6 +15,36 @@ let
   screenUrlPrefix = "${cfg.originUrl}/screens/";
   pairUrl = "${cfg.originUrl}/pair";
 
+  # Shown instead of the app's own /pair page when something else on this host
+  # owns pairing (see modules/services/kiosk/cec-bridge.nix, where the Output
+  # Device pairs on the browser's behalf so one code provisions the display,
+  # its screen, and this browser's session together). Without this the browser
+  # would race ahead and mint its own pairing code — a code that logs the
+  # browser in but leaves the Output Device unpaired, which is exactly the
+  # confusing half-provisioned state the single-code flow exists to avoid.
+  waitingPage = pkgs.writeText "kiosk-waiting.html" ''
+    <!doctype html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="refresh" content="5">
+      <style>
+        html, body {
+          margin: 0;
+          height: 100%;
+          background: #07090f;
+          color: #94a3b8;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, -apple-system, sans-serif;
+        }
+      </style>
+    </head>
+    <body><div>Preparing this display&hellip;</div></body>
+    </html>
+  '';
+
   pythonWithEvdev = pkgs.python3.withPackages (ps: [ ps.evdev ]);
 
   # Chromium's own offline interstitial (the big white "no internet" page)
@@ -97,12 +127,23 @@ let
       profile_dir="${cfg.stateDir}/profile-$name"
       mkdir -p "$profile_dir"
       url_file="$profile_dir/current-url"
-      start_url="${pairUrl}"
+      start_url="${if cfg.pairingHandledExternally then "file://${waitingPage}" else pairUrl}"
       if [ -s "$url_file" ]; then
         start_url="$(cat "$url_file")"
       fi
 
       echo "$name $port" >> "${cfg.stateDir}/outputs.env"
+
+      # A file:// target is opened directly rather than through the
+      # connectivity pre-check page: that page proves the target is reachable
+      # by fetching it first, which a file:// page can't do cross-origin — and
+      # for the Output Device's handoff URL a pre-fetch would be actively
+      # wrong, since it would spend the single-use token before the real
+      # navigation could redeem it.
+      case "$start_url" in
+        file://*) open_url="$start_url" ;;
+        *) open_url="file://${loadingPage}?redirect=$(jq -rn --arg v "$start_url" '$v|@uri')" ;;
+      esac
 
       ${pkgs.chromium}/bin/chromium \
         --user-data-dir="$profile_dir" \
@@ -118,7 +159,7 @@ let
         --autoplay-policy=no-user-gesture-required \
         --check-for-update-interval=31536000 \
         --no-first-run \
-        "file://${loadingPage}?redirect=$(jq -rn --arg v "$start_url" '$v|@uri')" &
+        "$open_url" &
       pids+=("$!")
       port=$((port + 1))
     done < <(${pkgs.xrandr}/bin/xrandr --query | awk '/ connected/ {geom="0x0+0+0"; for (i=1;i<=NF;i++) if ($i ~ /^[0-9]+x[0-9]+\+[0-9]+\+[0-9]+$/) geom=$i; print $1, "connected", geom}')
@@ -229,6 +270,22 @@ in
       type = types.str;
       default = "kiosk";
       description = "Local user the X session and Chromium instances run as. Created by this module, kept separate from the admin user.";
+    };
+
+    pairingHandledExternally = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Suppresses the automatic fallback to <originUrl>/pair for an output
+        with no assigned screen, showing a neutral holding page instead and
+        waiting for something else to write that output's current-url.
+
+        Set by modules.services.kiosk.cecBridge, which pairs on the browser's
+        behalf so that a single code provisions the Output Device's credential,
+        its screen, and this browser's session at once. Leave this off unless
+        something really is going to write current-url — otherwise an unpaired
+        display just sits on the holding page forever.
+      '';
     };
   };
 

--- a/modules/services/kiosk/cec-bridge.nix
+++ b/modules/services/kiosk/cec-bridge.nix
@@ -159,6 +159,20 @@ let
         adapters = {}
         for device in sorted(glob.glob("/dev/cec*")):
             info = run_cec(["-d", device])
+
+            # Re-claim a logical address if the adapter has lost one. It does
+            # lose one: re-driving the HDMI output (a kiosk-launcher restart, a
+            # mode change, the panel waking) resets the adapter's configuration
+            # while leaving its physical address intact, and without a logical
+            # address nothing can be transmitted -- every cec-ctl call fails
+            # with "Adapter is unconfigured, please configure it first."
+            # Observed on the live kiosk, where the mask had silently gone to
+            # 0x0000 and CEC had been dead ever since. Only re-run when it's
+            # actually unconfigured; allocation puts traffic on the bus, so it
+            # shouldn't happen every poll.
+            if re.search(r"Logical Address Mask\s*:\s*0x0000", info):
+                info = run_cec(["-d", device, "--playback"])
+
             connector = re.search(r"DRM Connector Info\s*:\s*card \d+, connector (\d+)", info)
             phys = re.search(r"Physical Address\s*:\s*([0-9a-fA-F.]+)", info)
             if not connector:

--- a/modules/services/kiosk/cec-bridge.nix
+++ b/modules/services/kiosk/cec-bridge.nix
@@ -22,6 +22,56 @@ let
   cfg = config.modules.services.kiosk.cecBridge;
   kioskCfg = config.modules.services.kiosk.browserKiosk;
 
+  # Reports what a given TV actually supports, for someone commissioning a new
+  # venue. Deliberately a thin wrapper around cec-compliance (shipped with
+  # v4l-utils) rather than a bespoke probe: it is a maintained, spec-driven
+  # conformance suite that already tests exactly the features this module
+  # depends on, and it reports per-feature OK/FAIL instead of one verdict.
+  probeScript = pkgs.writeShellApplication {
+    name = "plotiphar-cec-probe";
+    runtimeInputs = with pkgs; [ v4l-utils gnugrep coreutils ];
+    text = ''
+      set -uo pipefail
+      DEVICE="''${1:-/dev/cec0}"
+
+      echo "== Plotiphar Output Device — CEC probe on $DEVICE =="
+      echo
+      echo "-- Adapter --"
+      cec-ctl -d "$DEVICE" | grep -E "Adapter Name|Physical Address|Logical Address Mask" || true
+      echo
+      echo "-- What's on the other end --"
+      cec-ctl -d "$DEVICE" --skip-info -S         | grep -E "CEC Version|Vendor ID|OSD Name|Power Status" || true
+      echo
+      echo "-- Does it survive standby? --"
+      echo "   (If the physical address stays valid while the TV is off, this"
+      echo "    display can be woken remotely. f.f.f.f means it kills the HDMI"
+      echo "    link when it sleeps and no CEC message can reach it.)"
+      echo
+      echo "-- Conformance --"
+      echo "   NOTE: this powers the display OFF and ON again."
+      read -r -p "   Continue? [y/N] " reply
+      case "$reply" in
+        [yY]*) ;;
+        *) echo "   skipped."; exit 0 ;;
+      esac
+      cec-compliance -d "$DEVICE" -r 0         --test-power-status         --test-one-touch-play         --test-standby-resume         --test-system-information || true
+      echo
+      echo "Read the results as:"
+      echo "  Wake up / One Touch Play FAIL -> raise verifyTimeoutSeconds, or add"
+      echo "     text-view-on / power-on-key to wakeSteps."
+      echo "  Standby FAIL -> add power-off-key (or, as a last resort and only"
+      echo "     if nothing else shares the bus, standby-broadcast) to standbySteps."
+      echo "  Give Device Power Status FAIL -> this TV never reports its state, so"
+      echo "     the whole ladder is sent blind. That is supported, just slower."
+    '';
+  };
+
+  # Renders a Nix list of step names as a Python list literal.
+  toPyList = xs: "[" + concatMapStringsSep ", " (x: "\"" + x + "\"") xs + "]";
+  wakeStepsPy = toPyList cfg.wakeSteps;
+  standbyStepsPy = toPyList cfg.standbySteps;
+  inputStepsPy = toPyList cfg.inputSteps;
+
   # Drives the CEC bus via v4l-utils' cec-ctl. libcec/cec-client is the more
   # commonly cited tool but needs a persistent daemon-ish session; cec-ctl is
   # one-shot per message, which suits a poll loop and keeps this service
@@ -468,29 +518,149 @@ let
         return "unknown"
 
 
+    # ── Command ladders ──────────────────────────────────────────────────────
+    #
+    # CEC is only loosely honoured in practice, and TVs disagree about which
+    # message actually does a thing. IMAGE_VIEW_ON wakes an LG; plenty of
+    # Samsung/Sony/Philips sets only answer TEXT_VIEW_ON, and stubborn ones
+    # only a simulated remote power key. So rather than sending one message and
+    # assuming, each action is a ladder: send a step, ask the TV what state it
+    # is in, and only escalate if it didn't take.
+    #
+    # Every step within a ladder is idempotent and points the same direction --
+    # all the wake steps wake, all the standby steps sleep -- so when a TV
+    # doesn't report its power status at all (many don't), running the whole
+    # ladder blind is safe. That's deliberate: it's the difference between
+    # "works on the panel I tested" and "works on most of them".
+    #
+    # Notably absent: the POWER_TOGGLE key (0x40). It would turn a working
+    # display OFF whenever power status is misreported, and misreported power
+    # status is exactly the case these ladders exist to handle.
+    UI_POWER_ON = "0x6d"   # Power On Function
+    UI_POWER_OFF = "0x6c"  # Power Off Function
+
+    WAKE_STEPS = ${wakeStepsPy}
+    STANDBY_STEPS = ${standbyStepsPy}
+    INPUT_STEPS = ${inputStepsPy}
+    VERIFY_TIMEOUT = ${toString cfg.verifyTimeoutSeconds}
+    VERIFY_POLL = 2
+
+
+    def send_step(device, phys_addr, step):
+        """Sends one rung of a ladder. Unknown steps are ignored, not fatal --
+        they come from host config, and a typo shouldn't stop the rest."""
+        if step == "image-view-on":
+            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--image-view-on"])
+        elif step == "text-view-on":
+            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--text-view-on"])
+        elif step == "power-on-key":
+            press_key(device, UI_POWER_ON)
+        elif step == "standby":
+            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--standby"])
+        elif step == "power-off-key":
+            press_key(device, UI_POWER_OFF)
+        elif step == "standby-broadcast":
+            # Sleeps every device on the bus, not just the TV. Off by default
+            # for that reason -- an AVR or another player sharing the bus has
+            # no business being turned off by this host's schedule.
+            run_cec(["-d", device, "--skip-info", "--to", "15", "--standby"])
+        elif step == "active-source":
+            run_cec(["-d", device, "--skip-info",
+                     "--active-source", "phys-addr=" + phys_addr])
+        elif step == "set-stream-path":
+            # Normally a TV/switch sends this; sending it as a source is the
+            # documented way to ask a TV that ignores ACTIVE_SOURCE to route to
+            # a given physical address anyway.
+            run_cec(["-d", device, "--skip-info",
+                     "--set-stream-path", "phys-addr=" + phys_addr])
+        else:
+            log("ignoring unknown CEC step: %s" % step)
+
+
+    def press_key(device, ui_cmd):
+        """Simulates a remote keypress. Press and release are separate CEC
+        messages; a TV that never sees the release can sit on a stuck key."""
+        run_cec(["-d", device, "--skip-info", "--to", TV_ADDR,
+                 "--user-control-pressed", "ui-cmd=" + ui_cmd])
+        run_cec(["-d", device, "--skip-info", "--to", TV_ADDR,
+                 "--user-control-released"])
+
+
+    def await_state(device, want, timeout):
+        """Polls power status until the TV reports `want`, or time runs out.
+
+        Waiting, rather than checking once, matters more than it looks: a real
+        panel took 19 seconds to reach a stable "on" here, and was briefly
+        unresponsive twice on the way (measured with cec-compliance against the
+        LG on stage-plotiphar). A single check a second or two after the
+        message would call that a failure and escalate through every remaining
+        rung of the ladder against a TV that was already doing the right thing.
+        An unresponsive TV mid-transition reads as "unknown", which is treated
+        as "still waiting" for the same reason.
+        """
+        deadline = time.time() + timeout
+        while True:
+            if query_power_state(device) == want:
+                return True
+            if time.time() >= deadline:
+                return False
+            time.sleep(VERIFY_POLL)
+
+
+    def climb(device, phys_addr, steps, want):
+        """Runs a ladder until the TV reports `want`, or the rungs run out.
+
+        Returns (reached, tried) — `reached` is True only when the TV actually
+        confirmed the target state, so a caller can tell "it worked" from
+        "we sent everything and it never told us".
+        """
+        tried = []
+        for step in steps:
+            send_step(device, phys_addr, step)
+            tried.append(step)
+            if await_state(device, want, VERIFY_TIMEOUT):
+                return True, tried
+        return False, tried
+
+
     def send_action(device, phys_addr, action):
         """Executes one CEC action. Returns None on success, else an error string."""
         if phys_addr == INVALID_PHYS_ADDR:
-            return ("HDMI link is down (no physical address) -- the display "
-                    "cannot be reached over CEC until it is powered on at the set")
+            if action == "on":
+                # The specific, actionable case: this display drops its HDMI
+                # link when it powers off, so there is no bus left to wake it
+                # over. No message ladder rescues that.
+                return ("This display can't be woken over CEC — it powers down "
+                        "its HDMI link in standby. Turn it on at the set, and "
+                        "check the TV's CEC setting (Anynet+ / Bravia Sync / "
+                        "SIMPLINK / VIERA Link / EasyLink) and any Eco or "
+                        "Quick Start option, which often cause this.")
+            return ("HDMI link is down — the display is unreachable over CEC "
+                    "(powered off at the set, or cable disconnected)")
 
         if action == "standby":
-            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--standby"])
+            reached, tried = climb(device, phys_addr, STANDBY_STEPS, "standby")
+            if not reached:
+                return "sent %s; the display never reported standby" % ", ".join(tried)
             return None
 
         if action == "active-source":
-            run_cec(["-d", device, "--skip-info",
-                     "--active-source", "phys-addr=" + phys_addr])
+            # Deliberately not a verified ladder: CEC has no reliable way to
+            # ask which input a TV is showing (see lib/cec.ts), so there is
+            # nothing to check against. Both messages are sent instead.
+            for step in INPUT_STEPS:
+                send_step(device, phys_addr, step)
             return None
 
         if action == "on":
-            # One Touch Play: wake the panel, then claim its input. Sending
-            # only IMAGE_VIEW_ON commonly powers a TV on but leaves it on
-            # whatever input it was last showing.
-            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--image-view-on"])
-            time.sleep(1)
-            run_cec(["-d", device, "--skip-info",
-                     "--active-source", "phys-addr=" + phys_addr])
+            reached, tried = climb(device, phys_addr, WAKE_STEPS, "on")
+            # Claim the input either way: a TV that woke but didn't say so
+            # still needs pointing at this HDMI port, and One Touch Play is
+            # only half done without it.
+            for step in INPUT_STEPS:
+                send_step(device, phys_addr, step)
+            if not reached:
+                return "sent %s; the display never reported powering on" % ", ".join(tried)
             return None
 
         return "unknown action: " + str(action)
@@ -732,6 +902,65 @@ in
       '';
     };
 
+    # ── Per-brand tuning ─────────────────────────────────────────────────────
+    # The defaults cover the common cases. These exist so a venue with a
+    # stubborn panel can be accommodated in its host config rather than
+    # needing a change here — run `plotiphar-cec-probe` on the box to find out
+    # what a given TV actually answers to.
+
+    wakeSteps = mkOption {
+      type = types.listOf (types.enum [ "image-view-on" "text-view-on" "power-on-key" ]);
+      default = [ "image-view-on" "text-view-on" "power-on-key" ];
+      description = ''
+        Messages tried, in order, to wake a display — stopping as soon as it
+        reports being on. IMAGE_VIEW_ON is the standard One Touch Play trigger
+        and satisfies most sets; TEXT_VIEW_ON covers those that only answer
+        that; power-on-key simulates the remote's Power On button for the rest.
+
+        All three point the same direction, so a TV that never reports its
+        power status just receives all of them, which is harmless.
+      '';
+    };
+
+    standbySteps = mkOption {
+      type = types.listOf (types.enum [ "standby" "power-off-key" "standby-broadcast" ]);
+      default = [ "standby" "power-off-key" ];
+      description = ''
+        Messages tried, in order, to put a display into standby.
+
+        `standby-broadcast` is available but deliberately not a default: it
+        sleeps every device on the CEC bus, so an AVR or another player sharing
+        the cable would be switched off by this host's schedule too. Only add
+        it for a display that ignores a directed STANDBY.
+      '';
+    };
+
+    inputSteps = mkOption {
+      type = types.listOf (types.enum [ "active-source" "set-stream-path" ]);
+      default = [ "active-source" "set-stream-path" ];
+      description = ''
+        Messages sent to make the TV show this host's HDMI input. Unlike the
+        other two, this is not a verified ladder — CEC has no reliable way to
+        ask a TV which input it is showing — so every listed message is sent.
+      '';
+    };
+
+    verifyTimeoutSeconds = mkOption {
+      type = types.ints.positive;
+      default = 25;
+      description = ''
+        How long to keep asking a display whether it reached the requested
+        state before escalating to the next message in the ladder.
+
+        Generous on purpose. Panels are slow to settle and go briefly
+        unresponsive while they do: the LG on stage-plotiphar takes ~19s to
+        report a stable "on", dropping two polls on the way. Too short a value
+        declares a working TV a failure and fires every remaining rung at it;
+        the only cost of too long is how quickly a genuinely deaf display gets
+        escalated against.
+      '';
+    };
+
     pollInterval = mkOption {
       type = types.ints.positive;
       default = 15;
@@ -789,7 +1018,15 @@ in
 
     # cec-ctl for this service, plus cec-client so an admin debugging a CEC issue
     # on the box has the tool most CEC documentation refers to.
-    environment.systemPackages = with pkgs; [ v4l-utils libcec ];
+    environment.systemPackages = [
+      pkgs.v4l-utils
+      # cec-client, for an admin following any of the CEC documentation that
+      # exists — nearly all of it is written against libcec. Not used by this
+      # module: libcec enumerates a single adapter and cannot be pointed at a
+      # specific /dev/cecN, so it can't drive a host with two HDMI outputs.
+      pkgs.libcec
+      probeScript
+    ];
 
     # This service owns pairing for every output, so the browser must not also
     # go mint its own code — see the option's description.

--- a/modules/services/kiosk/cec-bridge.nix
+++ b/modules/services/kiosk/cec-bridge.nix
@@ -1,0 +1,819 @@
+# modules/services/kiosk/cec-bridge.nix
+#
+# Makes this kiosk a **Plotiphar Output Device**: it carries out the stage-plotifer
+# web app's display-power requests on the HDMI-CEC bus, so a TV driven by this
+# machine can be powered on/off and told to switch to its input from the app —
+# including on a schedule.
+#
+# Why a separate outbound-polling service rather than something the kiosk browser does:
+# a TV in standby drops the HDMI hotplug line, xrandr then reports no connected
+# outputs, and kiosk-launcher exits (and retries). So at exactly the moment you
+# most need display control — the TV is off and you want it on — there may be
+# no browser running to act on. This is a plain systemd service with no
+# dependency on X, the browser, or a connected output.
+#
+# It also polls outbound only: no inbound port, no firewall hole, and it works
+# from a venue LAN behind NAT with no reachable address of its own.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.modules.services.kiosk.cecBridge;
+  kioskCfg = config.modules.services.kiosk.browserKiosk;
+
+  # Drives the CEC bus via v4l-utils' cec-ctl. libcec/cec-client is the more
+  # commonly cited tool but needs a persistent daemon-ish session; cec-ctl is
+  # one-shot per message, which suits a poll loop and keeps this service
+  # stateless between cycles.
+  agentScript = pkgs.writers.writePython3 "kiosk-cec-agent" {
+    flakeIgnore = [ "E501" ];
+  } ''
+    import glob
+    import json
+    import os
+    import re
+    import subprocess
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+    from datetime import datetime
+
+    ORIGIN = "${cfg.originUrl}".rstrip("/")
+    KIOSK_STATE_DIR = "${kioskCfg.stateDir}"
+    STATE_DIR = "${cfg.stateDir}"
+    POLL_INTERVAL = ${toString cfg.pollInterval}
+    SCHEDULE_GRACE = ${toString cfg.scheduleGraceSeconds}
+    CEC_CTL = "${pkgs.v4l-utils}/bin/cec-ctl"
+    HOSTNAME = "${config.networking.hostName}"
+    REQUEST_TIMEOUT = 20
+
+    # How long to let a browser session handoff complete before concluding the
+    # display was reset and starting over. Generous: it covers a launcher
+    # restart plus a page load on a cold WiFi link.
+    HANDOFF_WAIT_SECONDS = 120
+
+    # Identifies this client honestly, and is load-bearing: plotiphar.com sits
+    # behind Cloudflare, which 403s urllib's default "Python-urllib/x.y" agent.
+    # Verified against the live origin -- without this every request fails
+    # before it ever reaches the app.
+    USER_AGENT = "PlotipharOutputDevice/1 (+https://plotiphar.com)"
+
+    # The TV is logical address 0 by definition in CEC.
+    TV_ADDR = "0"
+
+    # An unconfigured adapter reports this physical address: the HDMI link is
+    # down (display off at the mains, cable out, or a TV that drops hotplug in
+    # standby). The vc4 driver derives the address from the sink's EDID and
+    # won't allocate a logical address without one, so nothing can be
+    # transmitted in this state -- including a wake-up. Verified on the Pi 5:
+    # forcing --phys-addr does not override it.
+    INVALID_PHYS_ADDR = "f.f.f.f"
+
+
+    def log(message):
+        print("kiosk-cec-agent: " + message, flush=True)
+
+
+    def state_path(output, name):
+        return os.path.join(STATE_DIR, output, name)
+
+
+    def read_json(path):
+        try:
+            with open(path, "r") as handle:
+                data = json.load(handle)
+            return data if isinstance(data, dict) else None
+        except (OSError, ValueError):
+            return None
+
+
+    def write_json(path, data):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            # Credentials live in here, so never let them land world-readable
+            # even briefly.
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as handle:
+                json.dump(data, handle)
+            return True
+        except OSError as err:
+            log("cannot write %s: %s" % (path, err))
+            return False
+
+
+    def forget(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+    def run_cec(args, timeout=15):
+        """Runs cec-ctl, returning combined output ("" on failure)."""
+        try:
+            result = subprocess.run(
+                [CEC_CTL] + args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            return (result.stdout or "") + (result.stderr or "")
+        except (subprocess.TimeoutExpired, OSError) as err:
+            log("cec-ctl %s failed: %s" % (" ".join(args), err))
+            return ""
+
+
+    def normalize_connector(sysfs_name):
+        """'card0-HDMI-A-1' -> 'HDMI-1', matching what xrandr (and therefore
+        the kiosk profile directories) call the same output."""
+        name = re.sub(r"^card\d+-", "", sysfs_name)
+        return re.sub(r"^HDMI-A-(\d+)$", r"HDMI-\1", name)
+
+
+    def drm_connector_names():
+        """DRM connector id -> xrandr-style output name."""
+        names = {}
+        for path in glob.glob("/sys/class/drm/card*-*"):
+            id_file = os.path.join(path, "connector_id")
+            try:
+                with open(id_file, "r") as handle:
+                    connector_id = handle.read().strip()
+            except OSError:
+                continue
+            names[connector_id] = normalize_connector(os.path.basename(path))
+        return names
+
+
+    def discover_adapters():
+        """Maps each output name to its CEC device and physical address.
+
+        Resolved through the DRM connector id both sides report rather than by
+        assuming /dev/cec0 is HDMI-1 -- the numbering happens to line up on the
+        Pi 5, but nothing guarantees it, and silently driving the wrong TV is a
+        bad failure mode.
+        """
+        names = drm_connector_names()
+        adapters = {}
+        for device in sorted(glob.glob("/dev/cec*")):
+            info = run_cec(["-d", device])
+            connector = re.search(r"DRM Connector Info\s*:\s*card \d+, connector (\d+)", info)
+            phys = re.search(r"Physical Address\s*:\s*([0-9a-fA-F.]+)", info)
+            if not connector:
+                continue
+            output = names.get(connector.group(1))
+            if not output:
+                continue
+            adapters[output] = {
+                "device": device,
+                "phys_addr": phys.group(1) if phys else INVALID_PHYS_ADDR,
+            }
+        return adapters
+
+
+    # ── Pairing ──────────────────────────────────────────────────────────────
+    #
+    # One pairing code provisions everything for an output: this service's own
+    # API credential, the screen it drives, and the browser's login. The device
+    # owns the pairing (the browser never visits /pair itself) because only the
+    # device can hold a credential -- a cookie in the kiosk profile is wiped by
+    # the reset button, and there'd be nothing left to authenticate CEC calls.
+
+    PAGE_STYLE = (
+        "html,body{margin:0;height:100%;background:#07090f;color:#e5e7eb;"
+        "display:flex;align-items:center;justify-content:center;"
+        "font-family:system-ui,-apple-system,sans-serif;text-align:center}"
+        ".code{font-size:14vw;font-weight:800;letter-spacing:.12em;color:#2dd4bf;"
+        "margin:.3em 0;font-variant-numeric:tabular-nums}"
+        ".hint{font-size:1.6vw;color:#94a3b8;max-width:40em;line-height:1.6}"
+        ".name{font-size:1.4vw;color:#475569;margin-top:2em;letter-spacing:.08em}"
+    )
+
+
+    def write_pairing_page(output, code, device_label):
+        """Renders the code fullscreen on the display itself.
+
+        A local file:// page rather than a served one: at this point the device
+        has no session, and the whole point is that it is showing a code to
+        someone standing in front of it. It reloads itself on a timer so a
+        regenerated code (they expire after 10 minutes) appears without anyone
+        touching the machine, and so the approved state is picked up the moment
+        write_handoff_page replaces this file.
+        """
+        html = (
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<meta http-equiv='refresh' content='5'>"
+            "<style>%s</style></head><body><div>"
+            "<div class='hint'>Pair this display in Plotiphar &mdash; "
+            "Settings &rarr; Screens &rarr; Pair a Display</div>"
+            "<div class='code'>%s</div>"
+            "<div class='name'>%s</div>"
+            "</div></body></html>"
+        ) % (PAGE_STYLE, code, device_label)
+        write_page(output, html)
+
+
+    def write_handoff_page(output, handoff_url):
+        """Sends the browser through its one-time session handoff.
+
+        A meta-refresh (top-level navigation), never a fetch: the handoff token
+        is single use, so a prefetch would burn it and leave the real
+        navigation with nothing to redeem. This is also why the kiosk launcher
+        opens file:// URLs directly instead of via its usual connectivity
+        pre-check page.
+        """
+        html = (
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<meta http-equiv='refresh' content='0; url=%s'>"
+            "<style>%s</style></head><body>"
+            "<div class='hint'>Paired &mdash; opening your screen&hellip;</div>"
+            "</body></html>"
+        ) % (ORIGIN + handoff_url, PAGE_STYLE)
+        # Marks the handoff window open before the page goes live, so a crash
+        # between the two can only make resolve_identity re-pair (safe) rather
+        # than wait forever on a handoff that never started.
+        write_json(state_path(output, "handoff.json"), {"at": time.time()})
+        write_page(output, html)
+
+
+    def write_page(output, html):
+        path = os.path.join(STATE_DIR, "pair-%s.html" % output)
+        try:
+            os.makedirs(STATE_DIR, exist_ok=True)
+            with open(path, "w") as handle:
+                handle.write(html)
+        except OSError as err:
+            log("cannot write pairing page for %s: %s" % (output, err))
+            return
+        point_browser_at(output, "file://" + path)
+
+
+    def point_browser_at(output, url):
+        """Sets the URL the kiosk launcher opens for this output.
+
+        Writes the same current-url file kiosk-url-tracker maintains, so once
+        the browser lands on /screens/<id> the tracker takes over and persists
+        the real URL -- the pairing page is never written back over it.
+        """
+        path = os.path.join(KIOSK_STATE_DIR, "profile-%s" % output, "current-url")
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "r") as handle:
+                if handle.read().strip() == url:
+                    return
+        except OSError:
+            pass
+        try:
+            with open(path, "w") as handle:
+                handle.write(url)
+        except OSError as err:
+            log("cannot point %s at %s: %s" % (output, url, err))
+            return
+        subprocess.run(
+            ["systemctl", "restart", "kiosk-launcher.service"], check=False
+        )
+
+
+    def has_kiosk_profile(output):
+        """True if the browser kiosk brought this output up (i.e. it has a
+        display attached)."""
+        return os.path.isdir(os.path.join(KIOSK_STATE_DIR, "profile-%s" % output))
+
+
+    def browser_has_screen(output):
+        """True once the browser is sitting on a real screen URL."""
+        path = os.path.join(KIOSK_STATE_DIR, "profile-%s" % output, "current-url")
+        try:
+            with open(path, "r") as handle:
+                return "/screens/" in handle.read()
+        except OSError:
+            return False
+
+
+    def start_pairing(output):
+        label = "%s %s" % (HOSTNAME, output)
+        try:
+            result = api_post(
+                "/api/auth/device/start",
+                {"client": "output-device", "name": label},
+                None,
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as err:
+            log("%s: cannot start pairing: %s" % (output, err))
+            return None
+        pairing = {
+            "deviceToken": result.get("deviceToken"),
+            "code": result.get("code"),
+            "expiresAt": result.get("expiresAt"),
+        }
+        if not pairing["deviceToken"] or not pairing["code"]:
+            log("%s: pairing start returned no token" % output)
+            return None
+        write_json(state_path(output, "pairing.json"), pairing)
+        log("%s: pairing code %s" % (output, pairing["code"]))
+        write_pairing_page(output, pairing["code"], label)
+        return pairing
+
+
+    def poll_pairing(output, pairing):
+        """Checks whether someone has approved this device's code yet.
+
+        Returns the stored credential once approved, else None.
+        """
+        try:
+            result = api_post(
+                "/api/auth/device/status",
+                {"deviceToken": pairing["deviceToken"]},
+                None,
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as err:
+            log("%s: cannot poll pairing: %s" % (output, err))
+            return None
+
+        status = result.get("status")
+        if status == "pending":
+            return None
+        if status != "approved":
+            # Expired (or already claimed) -- drop it and take a fresh code on
+            # the next cycle rather than leaving a dead code on the screen.
+            log("%s: pairing code expired, requesting a new one" % output)
+            forget(state_path(output, "pairing.json"))
+            return None
+
+        credential = {
+            "sessionToken": result.get("sessionToken"),
+            "screenId": result.get("screenId"),
+        }
+        if not credential["sessionToken"] or not credential["screenId"]:
+            log("%s: approval returned no credential or screen" % output)
+            forget(state_path(output, "pairing.json"))
+            return None
+
+        if not write_json(state_path(output, "credential.json"), credential):
+            return None
+        forget(state_path(output, "pairing.json"))
+        log("%s: paired to screen %s" % (output, credential["screenId"]))
+
+        handoff = result.get("browserHandoffUrl")
+        if handoff:
+            write_handoff_page(output, handoff)
+        return credential
+
+
+    def clear_pairing_artifacts(output):
+        """Drops the on-screen page and the handoff marker.
+
+        Called once the browser is actually on its screen, so that "a pairing
+        page still exists" always means "the handoff hasn't finished" -- see
+        resolve_identity, which depends on that being unambiguous.
+        """
+        forget(state_path(output, "handoff.json"))
+        forget(os.path.join(STATE_DIR, "pair-%s.html" % output))
+
+
+    def handoff_in_flight(output):
+        marker = read_json(state_path(output, "handoff.json"))
+        if not marker:
+            return False
+        try:
+            return (time.time() - float(marker.get("at", 0))) < HANDOFF_WAIT_SECONDS
+        except (TypeError, ValueError):
+            return False
+
+
+    def resolve_identity(output):
+        """Gets this output's credential, driving the pairing flow if needed.
+
+        Also implements the reset button. That button wipes the browser profile
+        -- cookies and current-url -- which is an explicit "re-pair this
+        display" instruction, so a credential with no browser screen behind it
+        is discarded rather than kept alive against a display nobody can see.
+
+        The only case where a missing screen ISN'T a reset is the brief window
+        between writing the handoff page and the browser landing on its screen.
+        That window is tracked with an explicit, expiring marker rather than
+        inferred from the pairing page still being on disk: that page outlives
+        a successful handoff unless something deletes it, so inferring from it
+        would make a reset look like a permanent handoff-in-progress and leave
+        the display stuck on the holding page forever.
+        """
+        credential = read_json(state_path(output, "credential.json"))
+        if credential and credential.get("sessionToken"):
+            if browser_has_screen(output):
+                clear_pairing_artifacts(output)
+                return credential
+            if handoff_in_flight(output):
+                return credential
+            log("%s: browser was reset, re-pairing" % output)
+            forget(state_path(output, "credential.json"))
+            clear_pairing_artifacts(output)
+            credential = None
+
+        pairing = read_json(state_path(output, "pairing.json"))
+        if not pairing:
+            pairing = start_pairing(output)
+            if not pairing:
+                return None
+            return None
+        return poll_pairing(output, pairing)
+
+
+    def query_power_state(device):
+        output = run_cec(["-d", device, "--skip-info", "--to", TV_ADDR,
+                          "--give-device-power-status"])
+        match = re.search(r"pwr-state:\s*([a-z-]+)", output)
+        if not match:
+            return "unknown"
+        state = match.group(1)
+        if state == "on":
+            return "on"
+        if state == "standby":
+            return "standby"
+        # Mid-transition: report where the display is heading, which is what
+        # someone watching the dashboard actually wants to know.
+        if state == "in-transition-standby-to-on":
+            return "on"
+        if state == "in-transition-on-to-standby":
+            return "standby"
+        return "unknown"
+
+
+    def send_action(device, phys_addr, action):
+        """Executes one CEC action. Returns None on success, else an error string."""
+        if phys_addr == INVALID_PHYS_ADDR:
+            return ("HDMI link is down (no physical address) -- the display "
+                    "cannot be reached over CEC until it is powered on at the set")
+
+        if action == "standby":
+            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--standby"])
+            return None
+
+        if action == "active-source":
+            run_cec(["-d", device, "--skip-info",
+                     "--active-source", "phys-addr=" + phys_addr])
+            return None
+
+        if action == "on":
+            # One Touch Play: wake the panel, then claim its input. Sending
+            # only IMAGE_VIEW_ON commonly powers a TV on but leaves it on
+            # whatever input it was last showing.
+            run_cec(["-d", device, "--skip-info", "--to", TV_ADDR, "--image-view-on"])
+            time.sleep(1)
+            run_cec(["-d", device, "--skip-info",
+                     "--active-source", "phys-addr=" + phys_addr])
+            return None
+
+        return "unknown action: " + str(action)
+
+
+    def api_post(path, payload, token):
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(ORIGIN + path, data=body, method="POST")
+        request.add_header("Content-Type", "application/json")
+        request.add_header("User-Agent", USER_AGENT)
+        if token:
+            # The device session from pairing, presented as a Bearer token --
+            # this service has nowhere to keep a cookie. Every call also
+            # refreshes the session's sliding expiry, which is what keeps a
+            # paired display paired without anyone re-entering a code.
+            request.add_header("Authorization", "Bearer " + token)
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+
+    def report(screen_id, token, power_state, adapter_label, error, ack_command_id=None):
+        payload = {
+            "powerState": power_state,
+            "timezone": current_timezone(),
+            "adapter": adapter_label,
+            "error": error,
+        }
+        if ack_command_id:
+            payload["ackCommandId"] = ack_command_id
+        return api_post("/api/screens/%s/cec/report" % screen_id, payload, token)
+
+
+    def current_timezone():
+        """Prefers the IANA zone name over the abbreviation.
+
+        The dashboard labels the schedule with whatever this returns, and
+        'America/Indiana/Indianapolis' is unambiguous where 'EST' is not (and
+        would also flip to 'EDT' half the year for the same schedule). Python
+        has no stdlib accessor for the configured zone name, but on NixOS
+        /etc/localtime is a symlink into the tzdata store path.
+        """
+        try:
+            target = os.path.realpath("/etc/localtime")
+            match = re.search(r"/zoneinfo/(.+)$", target)
+            if match:
+                return match.group(1)
+        except OSError:
+            pass
+        try:
+            return datetime.now().astimezone().tzname() or ""
+        except (OSError, ValueError):
+            return ""
+
+
+    def schedule_state_path(screen_id):
+        return os.path.join(STATE_DIR, "schedule-%s.json" % screen_id)
+
+
+    def load_schedule_state(screen_id):
+        try:
+            with open(schedule_state_path(screen_id), "r") as handle:
+                data = json.load(handle)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
+
+    def save_schedule_state(screen_id, state):
+        try:
+            os.makedirs(STATE_DIR, exist_ok=True)
+            with open(schedule_state_path(screen_id), "w") as handle:
+                json.dump(state, handle)
+        except OSError as err:
+            log("cannot persist schedule state for %s: %s" % (screen_id, err))
+
+
+    def due_schedule_entries(schedule, fired, now):
+        """Entries that should fire right now.
+
+        Evaluated against the host's own local time, deliberately: a venue's
+        displays follow venue-local wall-clock time regardless of where the app
+        is hosted or which timezone whoever edited the schedule is in.
+
+        Two guards keep this from misfiring:
+          - a grace window, so an entry whose time passed long ago (this service
+            was down, or the machine was off) does not fire late -- powering a display on
+            hours after its 8am rule is worse than skipping it;
+          - a per-day fired marker, so an entry fires at most once per day even
+            though the loop revisits it every cycle.
+        """
+        due = []
+        today = now.strftime("%Y-%m-%d")
+        for entry in schedule:
+            entry_id = entry.get("id")
+            action = entry.get("action")
+            entry_time = entry.get("time", "")
+            days = entry.get("days") or []
+            if not entry_id or not action:
+                continue
+            # Python's weekday() is Mon=0; the app's schedule uses Sun=0.
+            if ((now.weekday() + 1) % 7) not in days:
+                continue
+            match = re.match(r"^([01]\d|2[0-3]):([0-5]\d)$", entry_time)
+            if not match:
+                continue
+            if fired.get(entry_id) == today:
+                continue
+            scheduled = now.replace(
+                hour=int(match.group(1)),
+                minute=int(match.group(2)),
+                second=0,
+                microsecond=0,
+            )
+            elapsed = (now - scheduled).total_seconds()
+            if 0 <= elapsed <= SCHEDULE_GRACE:
+                due.append((entry_id, action, today))
+        return due
+
+
+    def handle_screen(output, screen_id, adapter, token):
+        device = adapter["device"]
+        # Re-read the physical address each cycle: it changes when the display
+        # is powered on or off underneath us.
+        info = run_cec(["-d", device])
+        phys_match = re.search(r"Physical Address\s*:\s*([0-9a-fA-F.]+)", info)
+        phys_addr = phys_match.group(1) if phys_match else INVALID_PHYS_ADDR
+        adapter_label = "%s -> %s" % (output, device)
+
+        link_down = phys_addr == INVALID_PHYS_ADDR
+        power_state = "unknown" if link_down else query_power_state(device)
+        error = None
+        if link_down:
+            error = ("HDMI link is down -- the display is unreachable over CEC "
+                     "(powered off at the set, or cable disconnected)")
+
+        state = report(screen_id, token, power_state, adapter_label, error)
+        if not state.get("enabled"):
+            return
+
+        actions = []
+        command = state.get("command")
+        if command and command.get("action"):
+            actions.append((command["action"], command.get("id"), None))
+
+        schedule = state.get("schedule") or []
+        if schedule:
+            fired = load_schedule_state(screen_id)
+            for entry_id, action, today in due_schedule_entries(schedule, fired, datetime.now()):
+                actions.append((action, None, (entry_id, today)))
+
+        if not actions:
+            return
+
+        for action, command_id, schedule_mark in actions:
+            log("%s: running %s" % (screen_id, action))
+            action_error = send_action(device, phys_addr, action)
+            if action_error:
+                log("%s: %s failed: %s" % (screen_id, action, action_error))
+
+            if schedule_mark:
+                # Marked as fired even when the send failed: retrying every
+                # cycle for the rest of the grace window would just spam a
+                # display that is unreachable anyway.
+                entry_id, today = schedule_mark
+                fired = load_schedule_state(screen_id)
+                fired[entry_id] = today
+                save_schedule_state(screen_id, fired)
+
+            if command_id:
+                # Re-read power state so the dashboard reflects the result of
+                # the command immediately rather than one poll interval later.
+                time.sleep(2)
+                refreshed_info = run_cec(["-d", device])
+                refreshed_match = re.search(r"Physical Address\s*:\s*([0-9a-fA-F.]+)", refreshed_info)
+                refreshed_phys = refreshed_match.group(1) if refreshed_match else INVALID_PHYS_ADDR
+                new_state = "unknown" if refreshed_phys == INVALID_PHYS_ADDR else query_power_state(device)
+                report(screen_id, token, new_state, adapter_label,
+                       action_error, ack_command_id=command_id)
+
+
+    def main():
+        log("polling %s every %ds" % (ORIGIN, POLL_INTERVAL))
+        while True:
+            try:
+                # Re-discovered every cycle rather than cached at startup: a
+                # display can be plugged into the second port, or swapped, long
+                # after this service came up.
+                adapters = discover_adapters()
+                for output in sorted(adapters):
+                    try:
+                        if not has_kiosk_profile(output):
+                            # Nothing is driving this port. An unconnected
+                            # output and a sleeping TV both report f.f.f.f, so
+                            # the CEC adapter can't tell them apart -- but the
+                            # launcher only creates a profile for an output
+                            # xrandr saw connected, which can. Without this,
+                            # an empty second HDMI port would pair itself and
+                            # conjure a screen nobody asked for.
+                            continue
+                        credential = resolve_identity(output)
+                        if not credential:
+                            continue
+                        handle_screen(
+                            output,
+                            credential["screenId"],
+                            adapters[output],
+                            credential["sessionToken"],
+                        )
+                    except urllib.error.HTTPError as err:
+                        if err.code in (401, 403):
+                            # The session was revoked (member removed, session
+                            # deleted, org changed). Nothing this service can
+                            # do but ask to be paired again.
+                            log("%s: credential rejected (%s), re-pairing" % (output, err.code))
+                            forget(state_path(output, "credential.json"))
+                        else:
+                            log("%s: API returned %s" % (output, err.code))
+                    except (urllib.error.URLError, TimeoutError, ValueError) as err:
+                        log("%s: API unreachable: %s" % (output, err))
+            except Exception as err:  # noqa: BLE001 - the loop must never die
+                log("unexpected error: %s" % err)
+            time.sleep(POLL_INTERVAL)
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+  '';
+in
+{
+  options.modules.services.kiosk.cecBridge = {
+    enable = mkEnableOption "Plotiphar Output Device — carries out the stage-plotifer app's display power/input requests over HDMI-CEC";
+
+    originUrl = mkOption {
+      type = types.str;
+      default = kioskCfg.originUrl;
+      description = ''
+        Base origin of the stage-plotifer app. Defaults to whatever the browser
+        kiosk points at, so this service and the displays can't drift apart.
+      '';
+    };
+
+    pollInterval = mkOption {
+      type = types.ints.positive;
+      default = 15;
+      description = ''
+        Seconds between heartbeats. Also bounds how long a queued command waits
+        before it runs, so raising this makes the dashboard buttons feel slower.
+      '';
+    };
+
+    scheduleGraceSeconds = mkOption {
+      type = types.ints.positive;
+      default = 300;
+      description = ''
+        How late a scheduled entry may still fire. Covers a brief restart of this
+        service
+        or network blip without resurrecting a rule whose time passed hours ago
+        — a display powering on long after its scheduled time is worse than one
+        that stays off.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "/var/lib/kiosk-cec";
+      description = ''
+        Directory holding, per output, the pairing in progress, the device
+        credential issued when it was approved, and which schedule entries have
+        already fired today. Contains a live credential, so it is created 0700
+        and the credential file itself 0600 — nothing here should be readable
+        by anyone but this service's user.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = kioskCfg.user;
+      description = ''
+        User this runs as. Must be in the `video` group to open /dev/cec*.
+        Defaults to the kiosk user, which browser-kiosk.nix already puts there.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = kioskCfg.enable;
+        message = ''
+          modules.services.kiosk.cecBridge requires modules.services.kiosk.browserKiosk:
+          it discovers which screen each HDMI output is paired to by reading the
+          browser kiosk's per-output current-url files.
+        '';
+      }
+    ];
+
+    # cec-ctl for this service, plus cec-client so an admin debugging a CEC issue
+    # on the box has the tool most CEC documentation refers to.
+    environment.systemPackages = with pkgs; [ v4l-utils libcec ];
+
+    # This service owns pairing for every output, so the browser must not also
+    # go mint its own code — see the option's description.
+    modules.services.kiosk.browserKiosk.pairingHandledExternally = true;
+
+    # Restarting kiosk-launcher is how a new URL (the pairing page, then the
+    # session handoff) actually reaches the screen. Scoped to that one unit and
+    # that one user rather than granting broader systemd rights.
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.systemd1.manage-units" &&
+            action.lookup("unit") == "kiosk-launcher.service" &&
+            subject.user == "${cfg.user}") {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+
+    # 0700, not 0750: this holds the device session token.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.stateDir} 0700 ${cfg.user} ${config.users.users.${cfg.user}.group} -"
+    ];
+
+    systemd.services.kiosk-cec-agent = {
+      description = "Plotiphar Output Device — display power/input control over HDMI-CEC";
+      # Wants (not Requires) network-online: the poll loop tolerates an
+      # unreachable API and retries, so a slow-to-associate WiFi link at boot
+      # shouldn't fail the unit.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        ExecStart = "${agentScript}";
+        # Restarts kiosk-launcher after re-pointing an output at a new URL.
+        Environment = [ "PATH=${makeBinPath [ pkgs.systemd ]}" ];
+        Restart = "always";
+        RestartSec = "10s";
+        # Opens /dev/cec* (root:video 0660).
+        SupplementaryGroups = [ "video" ];
+
+        # Nothing here needs write access outside its own state directory.
+        StateDirectory = baseNameOf cfg.stateDir;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        # Writes its own state, plus each output's current-url — that file is
+        # how it hands the browser the pairing page and then the handoff URL.
+        ReadWritePaths = [ cfg.stateDir kioskCfg.stateDir ];
+      };
+    };
+  };
+}

--- a/modules/services/kiosk/cec-bridge.nix
+++ b/modules/services/kiosk/cec-bridge.nix
@@ -192,6 +192,20 @@ let
     )
 
 
+    def format_code(code):
+        """Groups the code the same way the app does.
+
+        Mirrors formatPairingCodeForDisplay in the app (an 8-character
+        Crockford-base32 code split 4-4). Someone reads this off a wall-mounted
+        TV and types it into a field that shows XXXX-XXXX, so the two should
+        not disagree about where the break goes. The approve endpoint strips
+        separators anyway, so this is purely about being readable.
+        """
+        if len(code) <= 4:
+            return code
+        return code[:4] + "-" + code[4:]
+
+
     def write_pairing_page(output, code, device_label):
         """Renders the code fullscreen on the display itself.
 
@@ -211,7 +225,7 @@ let
             "<div class='code'>%s</div>"
             "<div class='name'>%s</div>"
             "</div></body></html>"
-        ) % (PAGE_STYLE, code, device_label)
+        ) % (PAGE_STYLE, format_code(code), device_label)
         write_page(output, html)
 
 

--- a/modules/services/kiosk/default.nix
+++ b/modules/services/kiosk/default.nix
@@ -3,5 +3,6 @@
   # Import kiosk service modules
   imports = [
     ./browser-kiosk.nix
+    ./cec-bridge.nix
   ];
 }

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -187,4 +187,5 @@ in
   # host's own SSH host key, substituted into the declarative NetworkManager
   # profile at boot (never in the Nix store). See modules/system/wifi.nix.
   "stage-plotiphar-wifi-psk.age".publicKeys = stagePlotipharKeys;
+
 }


### PR DESCRIPTION
Adds `modules.services.kiosk.cecBridge`, which lets the stage-plotifer app power a kiosk host's TV on/standby and switch it to that host's HDMI input — manually from Settings → Screens, or on a per-screen schedule. Enabled on `stage-plotiphar`.

Pairs with [TristonYoder/stagePlotiphar#278](https://github.com/TristonYoder/stagePlotiphar/pull/278), which **must deploy first** — the device cannot pair against an origin that doesn't have those endpoints yet.

## Why a separate service, not something the browser does

A TV in standby drops the HDMI hotplug line, `xrandr` then reports no connected outputs, and `kiosk-launcher` exits. So at exactly the moment you most need display control — the TV is off and you want it on — there may be no browser running to act on. This is a plain systemd unit with no dependency on X, the browser, or a connected output.

It polls outbound only: no inbound port, no firewall hole, and it works from a venue LAN behind NAT with no reachable address of its own.

## Pairing: one code provisions everything

No secret to deploy, and nothing to create in the app first. The display shows a pairing code; approving it issues this host its own credential, creates or binds its screen, and signs the kiosk browser in.

The Output Device owns the pairing rather than the browser, for two reasons:

- **Only the device can hold a credential.** A cookie in the Chromium profile is wiped by the reset button, leaving nothing to authenticate CEC calls with.
- **Otherwise you can approve a half-provisioned display.** If the browser minted its own code first, approving it would sign the browser in while leaving the device unpaired — so `browserKiosk.pairingHandledExternally` suppresses the browser's own `/pair` fallback whenever this module is on.

The device's session reaches the browser through a single-use handoff URL, delivered as a **top-level meta-refresh rather than a fetch**: the launcher's connectivity pre-check page would otherwise spend the one-shot token before the real navigation could redeem it. That's why `browser-kiosk` now opens `file://` targets directly.

## Details worth a look

- **Adapters are matched to `xrandr` outputs via the DRM connector id both report**, not by assuming `/dev/cec0` is `HDMI-1`. They do line up on the Pi 5, but nothing guarantees it and silently driving the wrong TV is a bad failure mode.
- **Only outputs the kiosk actually brought up are paired.** An unconnected port and a sleeping TV both report physical address `f.f.f.f`, so the CEC adapter can't tell them apart — but the launcher only creates a profile dir for an output `xrandr` saw connected, which can. Without this an empty second HDMI port pairs itself and conjures a screen nobody asked for.
- **Schedules are evaluated here, in this host's local time**, not on the server. Venue displays should follow venue wall-clock time regardless of where the app is hosted. Entries more than `scheduleGraceSeconds` (default 300) late are skipped rather than fired — a display powering on hours after its scheduled time is worse than one that stays off.
- **An explicit User-Agent is load-bearing.** plotiphar.com is behind Cloudflare, which `403`s urllib's default `Python-urllib/x.y`. Verified against the live origin: without it every request fails before reaching the app.
- **The reset button still works.** It wipes the browser profile, which the agent reads as "re-pair this display". That window is tracked with an expiring marker rather than inferred from the pairing page still being on disk — that page outlives a successful handoff, and inferring from it left the display stuck on the holding page forever.

## Security posture

- The state dir is `0700` and the credential file `0600`; it holds a live session token.
- Runs as the existing `kiosk` user (already in `video` for `/dev/cec*`), not root, under `ProtectSystem=strict` / `ProtectHome` / `NoNewPrivileges`.
- A polkit rule scoped to exactly `kiosk-launcher.service` and that one user lets it restart the launcher, rather than granting broader systemd rights.
- On a `401`/`403` from the API it discards its credential and re-pairs rather than retrying forever with a dead token.

## Known limitation

**A TV that cuts the HDMI link when it powers off cannot be woken over CEC.** The `vc4` driver takes its physical address from the sink's EDID; with the link down it reads `f.f.f.f`, no logical address is allocated, and nothing can be transmitted. Forcing `cec-ctl --phys-addr` does not override it — confirmed on this Pi. Many TVs (including the LG here) keep CEC alive in standby so One Touch Play works; where they don't, the agent reports the display as unreachable with that reason rather than failing silently. `hosts/stage-plotiphar/README.md` documents how to check which behaviour a given panel has.

## Testing

- Host toplevel builds on the Pi itself.
- CEC verified against the real bus: adapter discovery, DRM connector mapping, power query (LG panel, ~40 ms round trip), IANA timezone detection.
- Pairing state machine driven end-to-end against a real app instance: code display, credential persisted `0600`, screen binding, handoff page, CEC heartbeat, handoff-in-flight window, cleanup on landing, and reset-button re-pairing.
- Schedule evaluation checked across weekday mapping (Sun=0 vs Python's Mon=0), grace window, already-fired-today, malformed input, and midnight.
- Deployed to `stage-plotiphar`; the unit is active and degrades cleanly while the app side is still pending.
