### PR TITLE
feat(plasma): declarative Plasma desktop across all Plasma hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,6 +547,13 @@ build has. The desktop theme, Aurorae theme and the look-and-feel's defaults/pre
 byte-identical to the KDE Store's Plasma 6 package, so nothing else needs reshaping. Note also
 that nixpkgs' `ant-theme` is the **GTK** theme only — none of the Plasma pieces.
 
+**david and tristons-workstation share `~/.config`.** Both set `useDataDrive`, so both symlink
+`/home/tristonyoder` to `/data/tristonyoder/home` on david's NFS export. plasma-manager rebuilds
+`plasma-org.kde.plasma.desktop-appletsrc` at every login, so the host you logged into last owns
+that file. Their `modules.plasma` options must stay identical — `externalMonitor` especially —
+or the two will fight over the panel layout. On the workstation `~/.local` is a host-local btrfs
+subvolume, so each host does keep its own plasma-manager last-run markers.
+
 **Known gaps:** per-tray-applet config (e.g. battery `showPercentage`) is accepted by
 plasma-manager's `items.configs` but silently dropped upstream — the Plasma scripting API has no
 support for nested containments. KWin custom tiling layouts are keyed by per-machine virtual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,41 @@ Docker services are organized in `docker/` by category. Changes to Docker servic
 - User configs in `home/` are imported via `flake.nix`
 - Changes to Home Manager configs require full system rebuild
 
+### Plasma Desktop Config (plasma-manager)
+
+The shared KDE Plasma look and panel layout lives in `home/modules/plasma/`, built on
+[plasma-manager](https://github.com/nix-community/plasma-manager). It originated on
+tristons-nixbook-pro — a macOS-shaped desktop: global menu top-left, tray/clock top-right,
+floating centered dock, window buttons on the left.
+
+Wiring per host: add both modules to `home-manager.sharedModules` in that host's `flake.nix`
+block, then set `home-manager.users.<user>.modules.plasma.enable = true` in the host config.
+Set `externalMonitor = true` on hosts that regularly drive a second display.
+
+**Panels are rebuilt from scratch at every login.** plasma-manager's startup script deletes
+`plasma-org.kde.plasma.desktop-appletsrc` and replays a generated `layout.js`. Editing panels
+through the GUI works until the next login, then reverts — change `home/modules/plasma/` instead.
+Everything else (themes, kwin, screen locker) is written additively, so unlisted settings keep
+whatever the machine had. `programs.plasma.overrideConfig = true` makes that strict, at the cost
+of deleting the KDE config files on activation.
+
+**Capturing GUI changes:** `nix run github:nix-community/plasma-manager` (rc2nix) dumps the live
+config as Nix. It does not emit panels, and its output carries a lot of noise — activity and
+screen UUIDs, kwallet/baloo state, host-specific values like `kwinrc.Xwayland.Scale`. Treat it as
+a diffing tool, not a drop-in.
+
+**Ant-Dark upstream is still Plasma 5.** `EliverLara/Ant` master ships `metadata.desktop`, which
+KF6's KPackage cannot read at all, plus KF5-era `contents/{components,lockscreen,logout,osd}`.
+`home/modules/plasma/themes.nix` writes a `metadata.json` and ships only the parts the Plasma 6
+build has. The desktop theme, Aurorae theme and the look-and-feel's defaults/previews/splash are
+byte-identical to the KDE Store's Plasma 6 package, so nothing else needs reshaping. Note also
+that nixpkgs' `ant-theme` is the **GTK** theme only — none of the Plasma pieces.
+
+**Known gaps:** per-tray-applet config (e.g. battery `showPercentage`) is accepted by
+plasma-manager's `items.configs` but silently dropped upstream — the Plasma scripting API has no
+support for nested containments. KWin custom tiling layouts are keyed by per-machine virtual
+desktop and screen UUIDs, so only `tiling.padding` is portable.
+
 ### macOS Homebrew/MAS Performance
 
 The Homebrew and Mac App Store (mas) modules use batch-checking for optimal rebuild performance:

--- a/flake.lock
+++ b/flake.lock
@@ -741,6 +741,29 @@
         "type": "github"
       }
     },
+    "plasma-manager": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785762349,
+        "narHash": "sha256-jZhZkzAwc7f3exzcTDJWP2WCAchCv0iNC3UF/QsahdQ=",
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "rev": "a19a2a029fa180911bd89c554dca1616e10f4c1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -808,7 +831,8 @@
         "nixos-raspberrypi": "nixos-raspberrypi",
         "nixos-vscode-server": "nixos-vscode-server",
         "nixpkgs": "nixpkgs_10",
-        "nixpkgs-unstable": "nixpkgs-unstable_2"
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "plasma-manager": "plasma-manager"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -246,6 +246,12 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
+              # Declarative Plasma. Loaded for every user on this host but inert
+              # until modules.plasma.enable is set in the host config.
+              home-manager.sharedModules = [
+                plasma-manager.homeModules.plasma-manager
+                ./home/modules/plasma
+              ];
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
               home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     
+    # Declarative KDE Plasma 6 config, as a Home Manager module.
+    # Upstream tracks home-manager master; we point it at our pinned
+    # release-26.05 instead. Bump this input deliberately rather than letting
+    # `nix flake update` drag it, since it can drift ahead of stable HM.
+    plasma-manager = {
+      url = "github:nix-community/plasma-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
+
     # Home Manager for Darwin (matches unstable)
     home-manager-unstable = {
       url = "github:nix-community/home-manager";
@@ -54,7 +64,7 @@
     hermes-agent.url = "github:NousResearch/hermes-agent";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, nixos-raspberrypi, flake-utils, iopenpod-flake, iopodcli, blueprint, hermes-agent, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, plasma-manager, nix-darwin, nix-homebrew, nix-bitcoin, nixos-vscode-server, agenix, nixos-hardware, nixos-raspberrypi, flake-utils, iopenpod-flake, iopodcli, blueprint, hermes-agent, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -267,6 +277,12 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
+              # Declarative Plasma. Loaded for every user on this host but inert
+              # until modules.plasma.enable is set in the host config.
+              home-manager.sharedModules = [
+                plasma-manager.homeModules.plasma-manager
+                ./home/modules/plasma
+              ];
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
               home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }

--- a/flake.nix
+++ b/flake.nix
@@ -165,10 +165,16 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
+              # Declarative Plasma. Loaded for every user on this host but inert
+              # until modules.plasma.enable is set in the host config.
+              home-manager.sharedModules = [
+                plasma-manager.homeModules.plasma-manager
+                ./home/modules/plasma
+              ];
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
             }
           ];
-          
+
           specialArgs = {
             inherit self nixpkgs nixpkgs-unstable nix-bitcoin iopenpod-flake iopodcli blueprint;
           };
@@ -205,6 +211,12 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
+              # Declarative Plasma. Loaded for every user on this host but inert
+              # until modules.plasma.enable is set in the host config.
+              home-manager.sharedModules = [
+                plasma-manager.homeModules.plasma-manager
+                ./home/modules/plasma
+              ];
               home-manager.users.tristonyoder = import ./home/tristonyoder.nix;
               home-manager.users.carolineyoder = import ./home/carolineyoder.nix;
             }

--- a/home/modules/plasma/default.nix
+++ b/home/modules/plasma/default.nix
@@ -1,0 +1,209 @@
+# Shared KDE Plasma 6 look and layout, via plasma-manager.
+#
+# This is the desktop that grew up by hand on tristons-nixbook-pro. It is a
+# macOS-shaped Plasma: global menu bar top-left, tray and clock top-right,
+# floating centered dock at the bottom, and window buttons on the left. On the
+# MacBooks the keyd Command<->Control swap (set per-host) puts every stock
+# `Meta+` shortcut under the physical Command key, which is the other half of
+# why it feels the way it does.
+#
+# plasma-manager rebuilds the panels from this file at every login: its startup
+# script deletes plasma-org.kde.plasma.desktop-appletsrc and replays a
+# generated layout.js. Panels are therefore fully declarative. Everything else
+# (themes, kwin, screen locker) is written additively, so settings not named
+# here keep whatever the machine already had. Set `programs.plasma.overrideConfig`
+# to make that strict — but note it deletes the KDE config files on activation.
+#
+# The theme assets themselves are packaged in ./themes.nix.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.plasma;
+
+  themes = import ./themes.nix { inherit pkgs; };
+
+  # Tray contents, in the order Plasma lists them. `extra` is the set of
+  # applets explicitly enabled beyond the built-in defaults.
+  trayItems = [
+    "org.kde.plasma.cameraindicator"
+    "org.kde.plasma.clipboard"
+    "org.kde.plasma.devicenotifier"
+    "org.kde.plasma.manage-inputmethod"
+    "org.kde.plasma.mediacontroller"
+    "org.kde.plasma.notifications"
+    "org.kde.kscreen"
+    "org.kde.plasma.battery"
+    "org.kde.plasma.bluetooth"
+    "org.kde.plasma.brightness"
+    "org.kde.plasma.keyboardindicator"
+    "org.kde.plasma.keyboardlayout"
+    "org.kde.plasma.networkmanagement"
+    "org.kde.plasma.volume"
+    "org.kde.plasma.weather"
+  ];
+
+  systemTray = {
+    name = "org.kde.plasma.systemtray";
+    systemTray.items.extra = trayItems;
+    # Note: per-tray-applet config (e.g. battery showPercentage) is accepted by
+    # plasma-manager's `items.configs` but silently dropped — the Plasma
+    # scripting API has no support for nested containments, so its emitter is
+    # commented out upstream. Set those few by hand in System Settings.
+  };
+
+  # Global menu bar. Left-aligned, sits opposite the tray.
+  menuBarPanel = screen: {
+    inherit screen;
+    location = "top";
+    alignment = "left";
+    height = 40;
+    hiding = "dodgewindows";
+    opacity = "adaptive";
+    widgets = [ "org.kde.plasma.appmenu" ];
+  };
+
+  # Tray + clock, right-aligned on the same top edge as the menu bar.
+  statusPanel = screen: {
+    inherit screen;
+    location = "top";
+    alignment = "right";
+    height = 40;
+    hiding = "dodgewindows";
+    opacity = "adaptive";
+    widgets = [
+      systemTray
+      "org.kde.plasma.digitalclock"
+    ];
+  };
+
+  # The dock: floating, centered, sized to its contents.
+  dockPanel = screen: {
+    inherit screen;
+    location = "bottom";
+    alignment = "center";
+    height = 50;
+    floating = true;
+    lengthMode = "fit";
+    hiding = "windowsgobelow";
+    opacity = "adaptive";
+    widgets = [
+      "org.kde.plasma.kickoff"
+      "org.kde.plasma.showdesktop"
+      "org.kde.plasma.icontasks"
+    ];
+  };
+in
+{
+  options.modules.plasma = {
+    enable = mkEnableOption "Shared KDE Plasma 6 look and layout";
+
+    externalMonitor = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Also lay out panels on screen 1. Hosts that regularly drive a second
+        display want this; leave it off on single-screen hosts so Plasma
+        doesn't create panels for a screen that never appears.
+
+        The second screen gets a pager and the global menu on its top-left
+        panel, matching how it is used in practice.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Theme assets land on XDG_DATA_DIRS via the Home Manager profile, which is
+    # where Plasma looks for global themes, decorations and plasmoids.
+    home.packages = [
+      themes.ant-dark
+      themes.andromeda-launcher
+      themes.kde-control-station
+    ];
+
+    programs.plasma = {
+      enable = true;
+
+      workspace = {
+        lookAndFeel = "Ant-Dark";
+        theme = "Ant-Dark";
+        iconTheme = "Ant-Dark";
+        # Ant-Dark ships its own .colors scheme, but the desktop actually runs
+        # on BreezeDark with Breeze widgets — only the shell, decoration and
+        # icons are Ant. Changing either of these visibly changes application
+        # chrome, so they are pinned deliberately.
+        colorScheme = "BreezeDark";
+        widgetStyle = "Breeze";
+
+        cursor.theme = "breeze_cursors";
+
+        splashScreen = {
+          engine = "KSplashQML";
+          theme = "Ant-Dark";
+        };
+
+        windowDecorations = {
+          library = "org.kde.kwin.aurorae";
+          theme = "__aurorae__svg__Ant-Dark";
+        };
+      };
+
+      kwin = {
+        # macOS traffic-light arrangement: everything on the left, nothing on
+        # the right. Mirrors ButtonsOnLeft=XAI_M_SEH.
+        titlebarButtons = {
+          left = [
+            "close"
+            "maximize"
+            "minimize"
+            "spacer"
+            "more-window-actions"
+            "spacer"
+            "on-all-desktops"
+            "hide-from-screencast"
+            "help"
+          ];
+          right = [ ];
+        };
+
+        virtualDesktops = {
+          number = 1;
+          rows = 1;
+        };
+
+        # The 25/50/25 custom tiling preset can't be shared: Plasma keys tile
+        # layouts by virtual-desktop and screen UUID, both of which are
+        # generated per machine. Only the padding is portable.
+        tiling.padding = 4;
+      };
+
+      kscreenlocker.passwordRequiredDelay = 30;
+
+      panels =
+        [
+          (menuBarPanel 0)
+          (statusPanel 0)
+          (dockPanel 0)
+        ]
+        ++ optionals cfg.externalMonitor [
+          ((menuBarPanel 1) // {
+            widgets = [
+              "org.kde.plasma.pager"
+              "org.kde.plasma.showdesktop"
+              "org.kde.plasma.appmenu"
+            ];
+          })
+          (statusPanel 1)
+          (dockPanel 1)
+        ];
+
+      # Global shortcuts are deliberately left unmanaged. Every binding on
+      # nixbook-pro is a Plasma default — the Mac-like feel comes from the keyd
+      # Command<->Control swap in the host config, not from rebound keys.
+      # Managing them here would only add noise that drifts from upstream
+      # defaults on each Plasma release.
+    };
+  };
+}

--- a/home/modules/plasma/default.nix
+++ b/home/modules/plasma/default.nix
@@ -46,7 +46,6 @@ let
   ];
 
   systemTray = {
-    name = "org.kde.plasma.systemtray";
     systemTray.items.extra = trayItems;
     # Note: per-tray-applet config (e.g. battery showPercentage) is accepted by
     # plasma-manager's `items.configs` but silently dropped — the Plasma

--- a/home/modules/plasma/default.nix
+++ b/home/modules/plasma/default.nix
@@ -120,6 +120,17 @@ in
       themes.ant-dark
       themes.andromeda-launcher
       themes.kde-control-station
+
+      # Ant-Dark is a folder-icon theme: its index.theme inherits
+      # Reversal-dark, then Papirus-Dark, for everything else. Upstream ships
+      # only the folder icons, whereas the KDE Store build that was installed
+      # by hand on nixbook-pro also bundled ~2800 app icons of its own with no
+      # git source to package. Providing the inherited themes covers the same
+      # ground reproducibly — app icons will resolve to Reversal/Papirus rather
+      # than that bundle, so a handful will look different from the machine
+      # this was captured on.
+      pkgs.reversal-icon-theme
+      pkgs.papirus-icon-theme
     ];
 
     programs.plasma = {

--- a/home/modules/plasma/themes.nix
+++ b/home/modules/plasma/themes.nix
@@ -1,0 +1,136 @@
+# Third-party Plasma theme assets, packaged from upstream git.
+#
+# None of these are in nixpkgs. nixpkgs' `ant-theme` ships only the GTK theme
+# (share/themes/Ant) — not the Plasma look-and-feel, desktop theme, Aurorae
+# window decoration, color scheme, or icons. All of this was originally
+# installed by hand through the KDE Store ("Get New Global Themes..."), which
+# is exactly what made the look unreproducible.
+#
+# Everything installs under $out/share, so the Home Manager profile puts it on
+# XDG_DATA_DIRS and Plasma discovers it the same way it discovered
+# ~/.local/share.
+#
+# To update: bump `rev`, then get the new hash with
+#   nix flake prefetch --json github:<owner>/<repo>/<rev> | grep hash
+
+{ pkgs }:
+
+let
+  inherit (pkgs) fetchFromGitHub stdenvNoCC lib;
+in
+{
+  # Ant-Dark by EliverLara — look-and-feel, desktop theme, Aurorae decoration,
+  # color scheme, icon theme, SDDM theme and wallpapers, all from one repo.
+  ant-dark = stdenvNoCC.mkDerivation {
+    pname = "ant-dark-plasma";
+    version = "0-unstable-2026-03-24";
+
+    src = fetchFromGitHub {
+      owner = "EliverLara";
+      repo = "Ant";
+      rev = "79ddc06b40ad1e96c87d9270c71d7db3bfa0c3cd";
+      hash = "sha256-dAx05R9QWkDcuzJF/GUhK2R7hGjY7JvtTyXEDpE+p5E=";
+    };
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      kde=kde/Dark
+
+      mkdir -p \
+        $out/share/plasma/look-and-feel \
+        $out/share/plasma/desktoptheme \
+        $out/share/aurorae/themes \
+        $out/share/icons \
+        $out/share/sddm/themes \
+        $out/share/color-schemes \
+        $out/share/wallpapers
+
+      cp -r $kde/plasma/look-and-feel/Ant-Dark $out/share/plasma/look-and-feel/
+      cp -r $kde/plasma/desktoptheme/Ant-Dark  $out/share/plasma/desktoptheme/
+      cp -r $kde/aurorae/Ant-Dark              $out/share/aurorae/themes/
+      cp -r $kde/icons/Ant-Dark                $out/share/icons/
+      cp -r $kde/sddm/Ant-Dark                 $out/share/sddm/themes/
+
+      install -m444 $kde/color-schemes/Ant-Dark.colors $out/share/color-schemes/
+      install -m444 $kde/wallpaper/Ant-Dark.jpg    $out/share/wallpapers/
+      install -m444 $kde/wallpaper/Ant-Dark-s2.jpg $out/share/wallpapers/
+      install -m444 $kde/wallpaper/Ant-Dark.svg    $out/share/wallpapers/
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Ant-Dark theme for KDE Plasma 6";
+      homepage = "https://github.com/EliverLara/Ant";
+      license = lib.licenses.gpl3Plus;
+      platforms = lib.platforms.linux;
+    };
+  };
+
+  # Application launcher used in the dock.
+  andromeda-launcher = stdenvNoCC.mkDerivation {
+    pname = "andromeda-launcher";
+    version = "0.6";
+
+    src = fetchFromGitHub {
+      owner = "EliverLara";
+      repo = "AndromedaLauncher";
+      rev = "6bd0ac49b60888dd502169b0eacf5ca5146b1ec1";
+      hash = "sha256-MSYD8eH6m4vWfvoAfHkqMed+ZGjFE0Ln75cqIZYq9Eg=";
+    };
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/plasma/plasmoids/AndromedaLauncher
+      cp -r metadata.json contents $out/share/plasma/plasmoids/AndromedaLauncher/
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Modern application launcher plasmoid for Plasma 6";
+      homepage = "https://github.com/EliverLara/AndromedaLauncher";
+      license = lib.licenses.gpl3Plus;
+      platforms = lib.platforms.linux;
+    };
+  };
+
+  # Quick-settings panel plasmoid. Upstream is a CMake project, but
+  # plasma_install_package(package) just copies package/ verbatim — there is
+  # nothing compiled, so we skip cmake entirely.
+  kde-control-station = stdenvNoCC.mkDerivation {
+    pname = "kde-control-station";
+    version = "2.8.0";
+
+    src = fetchFromGitHub {
+      owner = "EliverLara";
+      repo = "kde-control-station";
+      rev = "bb473188a19d6cbe89a9c1bb5b08c7ddc609375d";
+      hash = "sha256-Hjjz3RefycImPgAuTUchr8Jikh4HlLf+fOPuh0aMP2M=";
+    };
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/plasma/plasmoids/KdeControlStation
+      cp -r package/metadata.json package/contents \
+        $out/share/plasma/plasmoids/KdeControlStation/
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Modern control center plasmoid for Plasma 6";
+      homepage = "https://github.com/EliverLara/kde-control-station";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.linux;
+    };
+  };
+}

--- a/home/modules/plasma/themes.nix
+++ b/home/modules/plasma/themes.nix
@@ -21,6 +21,12 @@ in
 {
   # Ant-Dark by EliverLara — look-and-feel, desktop theme, Aurorae decoration,
   # color scheme, icon theme, SDDM theme and wallpapers, all from one repo.
+  #
+  # Upstream master is still the Plasma 5 release. Verified against the KDE
+  # Store's Plasma 6 build (what was installed by hand on tristons-nixbook-pro):
+  # the desktop theme, Aurorae theme and the look-and-feel's defaults/previews/
+  # splash are byte-identical, and only the look-and-feel wrapper differs. So we
+  # reshape just that wrapper below rather than hunting for another source.
   ant-dark = stdenvNoCC.mkDerivation {
     pname = "ant-dark-plasma";
     version = "0-unstable-2026-03-24";
@@ -49,11 +55,42 @@ in
         $out/share/color-schemes \
         $out/share/wallpapers
 
-      cp -r $kde/plasma/look-and-feel/Ant-Dark $out/share/plasma/look-and-feel/
-      cp -r $kde/plasma/desktoptheme/Ant-Dark  $out/share/plasma/desktoptheme/
-      cp -r $kde/aurorae/Ant-Dark              $out/share/aurorae/themes/
-      cp -r $kde/icons/Ant-Dark                $out/share/icons/
-      cp -r $kde/sddm/Ant-Dark                 $out/share/sddm/themes/
+      cp -r $kde/plasma/desktoptheme/Ant-Dark $out/share/plasma/desktoptheme/
+      cp -r $kde/aurorae/Ant-Dark             $out/share/aurorae/themes/
+      cp -r $kde/icons/Ant-Dark               $out/share/icons/
+      cp -r $kde/sddm/Ant-Dark                $out/share/sddm/themes/
+
+      # The look-and-feel package needs two fixups for Plasma 6:
+      #
+      # 1. KF6's KPackage no longer reads metadata.desktop, so an upstream
+      #    checkout is simply invisible to Plasma 6. Write the JSON form
+      #    instead. (kns:// dependency hints are dropped — they only tell the
+      #    KDE Store what else to download, which is our job now.)
+      # 2. contents/{components,lockscreen,logout,osd} are KF5-era QML that the
+      #    Plasma 6 package dropped. Shipping them risks a broken lock screen
+      #    and logout dialog, so keep only what the Plasma 6 build ships.
+      lnf=$out/share/plasma/look-and-feel/Ant-Dark
+      mkdir -p $lnf/contents
+      for c in defaults previews splash; do
+        cp -r $kde/plasma/look-and-feel/Ant-Dark/contents/$c $lnf/contents/
+      done
+
+      cat > $lnf/metadata.json <<'EOF'
+      {
+          "KPackageStructure": "Plasma/LookAndFeel",
+          "KPlugin": {
+              "Authors": [ { "Email": "eliverlara@gmail.com", "Name": "EliverLara" } ],
+              "Category": "Plasma Look And Feel",
+              "EnabledByDefault": true,
+              "Id": "Ant-Dark",
+              "License": "GPL 3+",
+              "Name": "Ant-Dark",
+              "ServiceTypes": [ "Plasma/LookAndFeel" ],
+              "Version": "0.1",
+              "Website": "https://github.com/EliverLara/Ant/tree/master/kde/Dark"
+          }
+      }
+      EOF
 
       install -m444 $kde/color-schemes/Ant-Dark.colors $out/share/color-schemes/
       install -m444 $kde/wallpaper/Ant-Dark.jpg    $out/share/wallpapers/

--- a/hosts/david/configuration.nix
+++ b/hosts/david/configuration.nix
@@ -456,4 +456,20 @@ in
     };
   };
 
+  # ===========================================================================
+  # DESKTOP
+  # ===========================================================================
+
+  # Shared Plasma look and panel layout. david is a server that gets used as a
+  # workstation, so it gets the same desktop as everything else.
+  #
+  # NOTE: this host and tristons-workstation share /home/tristonyoder — the
+  # workstation NFS-mounts this host's /data and both symlink the home to
+  # /data/tristonyoder/home, so ~/.config is one directory. plasma-manager
+  # rebuilds plasma-org.kde.plasma.desktop-appletsrc at every login, so
+  # whichever host you log into last wins that file. Keep the plasma options
+  # here identical to the workstation's — including externalMonitor — or the
+  # two will fight over the panel layout.
+  home-manager.users.tristonyoder.modules.plasma.enable = true;
+
 }

--- a/hosts/tristons-nixbook-pro/configuration.nix
+++ b/hosts/tristons-nixbook-pro/configuration.nix
@@ -128,6 +128,21 @@
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 
+  # ===========================================================================
+  # DESKTOP
+  # ===========================================================================
+
+  # Declarative Plasma look and panel layout. This host is where the layout
+  # originated, so it is the reference implementation — see home/modules/plasma.
+  home-manager.users.tristonyoder.modules.plasma = {
+    enable = true;
+    externalMonitor = true;
+  };
+
+  # HiDPI on the built-in Retina panel. Host-specific: this would be wrong on
+  # any of the other Plasma hosts, so it stays out of the shared module.
+  home-manager.users.tristonyoder.programs.plasma.configFile.kwinrc.Xwayland.Scale = 1.5;
+
   # Passwordless guest account -> locked-down kiosk browser at apps.theyoder.family
   modules.system.guestKiosk.enable = true;
 }

--- a/hosts/tristons-nixbook/configuration.nix
+++ b/hosts/tristons-nixbook/configuration.nix
@@ -89,6 +89,14 @@
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 
+  # =============================================================================
+  # DESKTOP
+  # =============================================================================
+
+  # Shared Plasma look and panel layout. Single built-in display, so no
+  # second-screen panel set.
+  home-manager.users.tristonyoder.modules.plasma.enable = true;
+
   # Passwordless guest account -> locked-down kiosk browser at apps.theyoder.family
   modules.system.guestKiosk.enable = true;
 }

--- a/hosts/tristons-workstation/configuration.nix
+++ b/hosts/tristons-workstation/configuration.nix
@@ -338,6 +338,22 @@
 
   home-manager.users.tristonyoder.modules.appShortcuts.enable = true;
 
+  # =============================================================================
+  # DESKTOP
+  # =============================================================================
+
+  # Shared Plasma look and panel layout.
+  #
+  # NOTE: this host and david share /home/tristonyoder — both set
+  # useDataDrive, so both symlink it to /data/tristonyoder/home on david's NFS
+  # export, and ~/.config with it. plasma-manager rebuilds
+  # plasma-org.kde.plasma.desktop-appletsrc at every login, so whichever host
+  # you log into last wins that file. Keep the plasma options here identical to
+  # david's — including externalMonitor — or the two will fight over the panel
+  # layout. (~/.local is a host-local btrfs subvolume here, so each host does
+  # keep its own plasma-manager last-run markers.)
+  home-manager.users.tristonyoder.modules.plasma.enable = true;
+
   modules.services.storage.ipodSync = {
     enable = true;
     user = "tristonyoder";


### PR DESCRIPTION
Ports the hand-built Plasma desktop from tristons-nixbook-pro into the repo, so all
four Plasma hosts share one declarative look and panel layout.

## What's here

- `home/modules/plasma/` — the shared config, as a `modules.plasma.enable` home module
  following the existing `app-shortcuts` pattern. Panels, Ant-Dark theming, left-side
  titlebar buttons, single virtual desktop, screen-locker grace.
- `home/modules/plasma/themes.nix` — Ant-Dark and the two plasmoids packaged from
  upstream git at pinned revs. None are in nixpkgs; nixpkgs' `ant-theme` is the GTK
  theme only.
- `plasma-manager` flake input, wired into the four Plasma hosts via
  `home-manager.sharedModules`.

The layout is macOS-shaped: global menu top-left, tray/clock top-right, floating
centered dock, window buttons on the left. On the MacBooks the existing keyd
Command↔Control swap puts stock `Meta+` shortcuts under the physical Command key.

## Hosts

| Host | Enabled | externalMonitor |
|---|---|---|
| david | yes | no |
| tristons-workstation | yes | no |
| tristons-nixbook | yes | no |
| tristons-nixbook-pro | yes | yes |

All four build. david, tristons-workstation and tristons-nixbook are already switched
and running with zero failed units; nixbook-pro is built but not yet activated.

## Shared home caveat

david and tristons-workstation both set `useDataDrive`, so they share
`/home/tristonyoder` — and `~/.config` with it — over NFS. plasma-manager rebuilds
`plasma-org.kde.plasma.desktop-appletsrc` at every login, so the host logged into last
owns that file. Their generated panel script and plasma configFile are byte-identical,
so there's nothing to thrash, but **`externalMonitor` must be changed on both together**.
Documented in both host configs and CLAUDE.md.

## Known deltas from the source machine

- **Icon theme.** The installed Ant-Dark icons (36 MB, 7090 entries) are not what's in
  the Ant repo (584) — the KDE Store build bundled ~2800 app icons with no git source.
  This ships upstream's folder icons (byte-identical) plus `reversal-icon-theme` and
  `papirus-icon-theme`, which Ant-Dark's `index.theme` already inherits from. Folder
  icons match; some app icons will differ.
- **Battery `showPercentage`** doesn't carry over — plasma-manager accepts
  `items.configs` but drops it, since the Plasma scripting API has no support for
  nested containments.
- **KWin custom tiling layout** can't port; Plasma keys tile layouts by per-machine
  virtual desktop and screen UUIDs. Only `tiling.padding` survives.

## Notes

Upstream Ant-Dark master is still the Plasma 5 release — KF6's KPackage can't read its
`metadata.desktop`, and `contents/{components,lockscreen,logout,osd}` are KF5 QML the
Plasma 6 build dropped. The derivation writes `metadata.json` and ships only the Plasma 6
parts. Everything else in the package was verified byte-identical to the KDE Store build.

Panels are rebuilt from scratch at each login, so GUI panel edits revert — change the
module instead. Everything else is written additively; `programs.plasma.overrideConfig`
would make it strict.
