### PR TITLE
fix(stageplotiphar): grant the docker group NOPASSWD sudo to restart the app service

### DIFF
--- a/docker/productivity/stageplotiphar.nix
+++ b/docker/productivity/stageplotiphar.nix
@@ -155,6 +155,36 @@
     ];
   };
 
+  # Lets the app repo's own CI deploy job (TristonYoder/stagePlotiphar,
+  # .github/workflows/build-container.yml `deploy` job, running on the
+  # "stageplotiphar-david" self-hosted runner) restart this one unit after
+  # `docker pull`ing a new `:latest` image, without granting it broader sudo.
+  # Mirrors the manual `sudo docker pull ...; sudo systemctl restart
+  # docker-stageplotiphar.service` the site owner ran by hand before that
+  # deploy job existed.
+  #
+  # `docker pull`/`docker tag` themselves need no sudo — dockerAccess in
+  # modules/services/development/github-runner.nix already puts the runner
+  # in the "docker" group, and that alone is already root-equivalent host
+  # access via the docker socket (see that module's comment on
+  # `dockerAccess`). Scoping this rule to the "docker" group rather than to
+  # the runner's actual (DynamicUser-assigned, unpredictable) username is
+  # what makes it robust to that: anyone able to reach root via the socket
+  # gains nothing new from also being able to restart this one systemd
+  # unit, so matching on group membership costs no real security margin
+  # while sidestepping DynamicUser's generated-username fragility.
+  security.sudo.extraRules = [
+    {
+      groups = [ "docker" ];
+      commands = [
+        {
+          command = "${pkgs.systemd}/bin/systemctl restart docker-stageplotiphar.service";
+          options = [ "NOPASSWD" ];
+        }
+      ];
+    }
+  ];
+
   # Logs the host's root docker client in to GHCR before anything tries to
   # pull the (private) image — the `docker run` this generates relies on the
   # resulting /root/.docker/config.json.


### PR DESCRIPTION
## Problem

The `deploy` job I just added to `TristonYoder/stagePlotiphar`'s [`build-container.yml`](https://github.com/TristonYoder/stagePlotiphar/blob/main/.github/workflows/build-container.yml) runs, on the `stageplotiphar-david` self-hosted runner:

```bash
docker pull ghcr.io/tristonyoder/stageplotiphar:latest
sudo systemctl restart docker-stageplotiphar.service
```

— the same two commands the site owner has been running by hand after every image build. `docker pull` is fine (the runner is already in the `docker` group via `dockerAccess` in `modules/services/development/github-runner.nix`), but nothing in this repo grants the runner sudo, so the restart step fails.

## Fix

Add a `security.sudo.extraRules` entry, co-located in `docker/productivity/stageplotiphar.nix` next to the service it restarts, scoped to exactly:

```
systemctl restart docker-stageplotiphar.service
```

Scoped to the **`docker` group** rather than the runner's actual username: the native `services.github-runners` backend uses `DynamicUser = true`, so its real username is systemd-generated and not something worth hardcoding into a sudoers rule. Group membership is stable and already carries root-equivalent trust (anyone with docker socket access can already get root on the host), so this adds no meaningful new privilege — it just lets a docker-group member (in practice, this CI job) do via sudo what they could already do by hand.

Verified with `nix flake check` and `nix eval .#nixosConfigurations.david.config.security.sudo.extraRules` — the rule evaluates to exactly the one scoped command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)