### PR TITLE
fix(home): pin XDG user dirs declaratively

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -58,6 +58,41 @@ in
   home.sessionPath = [
     "$HOME/.local/bin"
   ];
+
+  # =============================================================================
+  # XDG USER DIRECTORIES
+  # =============================================================================
+
+  # Pin the XDG user dirs declaratively. Without this, xdg-user-dirs-update runs
+  # at session start, rewrites ~/.config/user-dirs.dirs, and collapses to
+  # XDG_<x>_DIR="$HOME/" any directory it cannot stat.
+  #
+  # Under modules.system.users.homeSplit these directories are symlinks into
+  # /data, which on NFS clients is an *automount*. If the automount has not
+  # triggered yet when xdg-user-dirs-update runs at login, every entry collapses
+  # to $HOME -- which shows up as Plasma putting the whole home directory on the
+  # desktop, and file dialogs defaulting to $HOME. (Confirmed on
+  # tristons-workstation; david was unaffected because its /data is a local ZFS
+  # mount that is always present.)
+  #
+  # home-manager writes this file read-only into the store, so
+  # xdg-user-dirs-update cannot rewrite it regardless of mount state.
+  #
+  # createDirectories stays false: these paths are tmpfiles-managed symlinks
+  # onto shared storage, not directories for home-manager to create.
+  xdg.userDirs = lib.mkIf (!isDarwin) {
+    enable = true;
+    createDirectories = false;
+
+    desktop     = "${config.home.homeDirectory}/Desktop";
+    documents   = "${config.home.homeDirectory}/Documents";
+    download    = "${config.home.homeDirectory}/Downloads";
+    music       = "${config.home.homeDirectory}/Music";
+    pictures    = "${config.home.homeDirectory}/Pictures";
+    publicShare = "${config.home.homeDirectory}/Public";
+    templates   = "${config.home.homeDirectory}/Templates";
+    videos      = "${config.home.homeDirectory}/Videos";
+  };
   
   # Let Home Manager install and manage itself
   programs.home-manager.enable = true;


### PR DESCRIPTION
Follow-up to #327.

## Symptom

After migrating to `homeSplit`, Plasma on tristons-workstation put the **whole home directory** on the desktop instead of `~/Desktop`.

## Cause

`xdg-user-dirs-update` runs at session start and rewrites `~/.config/user-dirs.dirs`, collapsing to `$HOME/` any directory it cannot `stat`. It had rewritten every entry:

```
XDG_DESKTOP_DIR="$HOME/"
XDG_DOWNLOAD_DIR="$HOME/"
XDG_DOCUMENTS_DIR="$HOME/"
...
```

Under `homeSplit` these paths are symlinks into `/data`, which on NFS clients is an **automount**. If it has not triggered yet when the updater runs at login, every entry collapses.

Confirmed by mtime — the pre-migration copy and david's live copy both still read `$HOME/Desktop` (mtime Jun 17), while the workstation's was rewritten at the first post-migration login. david was unaffected because its `/data` is a local ZFS mount that is always present, so this only bites NFS clients.

## Fix

`xdg.userDirs.enable` writes `user-dirs.dirs` **read-only into the store**, so `xdg-user-dirs-update` cannot rewrite it regardless of mount state.

`createDirectories = false` deliberately: these paths are tmpfiles-managed symlinks onto shared storage, not directories for home-manager to create.

Applies to all Linux hosts, so nixbook gets the same protection — it NFS-mounts `/data` too and would hit this the moment it adopts the split.

## Verification

```
WORKSTATION EVAL OK
xdg.userDirs.desktop           = /home/tristonyoder/Desktop
xdg.userDirs.enable            = true
xdg.userDirs.createDirectories = false
```