### PR TITLE
fix(stageplotiphar): replace sudo grant with a polkit rule (NoNewPrivileges)

### DIFF
--- a/docker/productivity/stageplotiphar.nix
+++ b/docker/productivity/stageplotiphar.nix
@@ -158,32 +158,41 @@
   # Lets the app repo's own CI deploy job (TristonYoder/stagePlotiphar,
   # .github/workflows/build-container.yml `deploy` job, running on the
   # "stageplotiphar-david" self-hosted runner) restart this one unit after
-  # `docker pull`ing a new `:latest` image, without granting it broader sudo.
-  # Mirrors the manual `sudo docker pull ...; sudo systemctl restart
+  # `docker pull`ing a new `:latest` image. Mirrors the manual
+  # `sudo docker pull ...; sudo systemctl restart
   # docker-stageplotiphar.service` the site owner ran by hand before that
   # deploy job existed.
   #
-  # `docker pull`/`docker tag` themselves need no sudo — dockerAccess in
-  # modules/services/development/github-runner.nix already puts the runner
-  # in the "docker" group, and that alone is already root-equivalent host
-  # access via the docker socket (see that module's comment on
-  # `dockerAccess`). Scoping this rule to the "docker" group rather than to
-  # the runner's actual (DynamicUser-assigned, unpredictable) username is
-  # what makes it robust to that: anyone able to reach root via the socket
-  # gains nothing new from also being able to restart this one systemd
-  # unit, so matching on group membership costs no real security margin
-  # while sidestepping DynamicUser's generated-username fragility.
-  security.sudo.extraRules = [
-    {
-      groups = [ "docker" ];
-      commands = [
-        {
-          command = "${pkgs.systemd}/bin/systemctl restart docker-stageplotiphar.service";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-    }
-  ];
+  # `docker pull`/`docker tag` themselves need no privilege escalation —
+  # dockerAccess in modules/services/development/github-runner.nix already
+  # puts the runner in the "docker" group, and that alone is already
+  # root-equivalent host access via the docker socket (see that module's
+  # comment on `dockerAccess`).
+  #
+  # A polkit rule, not a sudoers entry: the native runner's systemd unit
+  # (services.github-runners, upstream hardening) sets
+  # NoNewPrivileges=true, which blocks setuid `sudo` outright — confirmed
+  # live: `sudo: The "no new privileges" flag is set, which prevents sudo
+  # from running as root.` `systemctl restart` as a non-root user instead
+  # goes over D-Bus to systemd, authorized by polkit — no local privilege
+  # escalation involved, so NoNewPrivileges doesn't block it. Scoped to the
+  # "docker" group rather than the runner's actual (DynamicUser-assigned,
+  # unpredictable) username: anyone able to reach root via the docker
+  # socket gains nothing new from also being able to restart this one
+  # unit, so matching on group membership costs no real security margin.
+  # Same pattern as modules/services/kiosk/cec-bridge.nix's
+  # kiosk-launcher.service rule, just scoped to a group instead of a
+  # single static user.
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (action.id == "org.freedesktop.systemd1.manage-units" &&
+          action.lookup("unit") == "docker-stageplotiphar.service" &&
+          action.lookup("verb") == "restart" &&
+          subject.isInGroup("docker")) {
+        return polkit.Result.YES;
+      }
+    });
+  '';
 
   # Logs the host's root docker client in to GHCR before anything tries to
   # pull the (private) image — the `docker run` this generates relies on the


### PR DESCRIPTION
## Problem

#328 added a NOPASSWD sudoers rule for the `docker` group to restart `docker-stageplotiphar.service`. It evaluated and merged fine, but turned out to be unusable: the native GitHub runner's systemd unit (`services.github-runners`, upstream hardening) sets `NoNewPrivileges=true`, which blocks setuid `sudo` regardless of any sudoers rule. Confirmed live once the app repo's deploy job actually tried it:

```
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
```

(An earlier attempt to fix this by hardcoding `/run/wrappers/bin/sudo` in the workflow — working around a different PATH issue — hit this same NNP wall right after.)

## Fix

Swap the sudoers rule for a **polkit rule**. `systemctl restart <unit>` as a non-root user goes over D-Bus to systemd and is authorized by polkit, not by local privilege escalation — so `NoNewPrivileges` doesn't apply to it at all. Scoped the same way as before (the `docker` group, not the runner's DynamicUser-assigned username). This repo already uses the identical pattern for `kiosk-launcher.service` in `modules/services/kiosk/cec-bridge.nix`, just scoped there to a static user instead of a group.

Verified with `nix flake check` and `nix eval .#nixosConfigurations.david.config.security.polkit.extraConfig` — the rule composes correctly alongside the existing NetworkManager/timedate/fwupd rules.

## Follow-up

The app repo's deploy job needs a matching change to call plain `systemctl restart docker-stageplotiphar.service` (no `sudo` at all) — companion PR coming in TristonYoder/stagePlotiphar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)